### PR TITLE
Add `launchBrowser: true` to `launchSettings.json` for http-only launch

### DIFF
--- a/API/Properties/launchSettings.json
+++ b/API/Properties/launchSettings.json
@@ -12,7 +12,7 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": false,
+      "launchBrowser": true,
       "launchUrl": "swagger",
       "applicationUrl": "http://localhost:5075",
       "environmentVariables": {


### PR DESCRIPTION
Launching the browser opens swagger, useful for debugging.