### PR TITLE
feature/edit match validation

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -16,6 +16,8 @@
         <PackageReference Include="AutoMapper" Version="12.0.1" />
         <PackageReference Include="Community.Microsoft.Extensions.Caching.PostgreSql" Version="4.0.4"/>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1"/>
+        <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1"/>
         <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.1"/>

--- a/API/Controllers/MatchesController.cs
+++ b/API/Controllers/MatchesController.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.JsonPatch;
-using Microsoft.AspNetCore.JsonPatch.Operations;
 
 // ReSharper disable PossibleMultipleEnumeration
 namespace API.Controllers;
@@ -29,7 +28,7 @@ public class MatchesController : Controller
 	[HttpPost("batch")]
 	public async Task<IActionResult> PostAsync([FromBody] TournamentWebSubmissionDTO wrapper, [FromQuery] bool verified = false)
 	{
-		/**
+		/*
 		 * FLOW:
 		 *
 		 * The user submits a batch of links to the front-end. They are looking to add new data
@@ -127,7 +126,7 @@ public class MatchesController : Controller
 
 	[Authorize(Roles = "Admin")]
 	[HttpGet("duplicates")]
-	[EndpointSummary("Retreives all known duplicate groups")]
+	[EndpointSummary("Retrieves all known duplicate groups")]
 	public async Task<IActionResult> GetDuplicatesAsync() => Ok(await _matchesService.GetAllDuplicatesAsync());
 
 	[Authorize(Roles = "Admin")]

--- a/API/Controllers/MatchesController.cs
+++ b/API/Controllers/MatchesController.cs
@@ -194,12 +194,13 @@ public class MatchesController : Controller
 		return Ok(mapping);
 	}
 
-	[HttpPatch("verification-status/{id:int}")]
-	public async Task<IActionResult> EditVerificationStatusById(int matchId, [FromBody] JsonPatchDocument<MatchDTO> patch)
+	[HttpPatch("{id:int}/patch")]
+	[EndpointSummary("Takes in json patch for match properties, and returns the patched object. The object being patched is a MatchDTO.")]
+	[ProducesResponseType<MatchDTO>(StatusCodes.Status200OK)]
+	[ProducesResponseType(StatusCodes.Status400BadRequest)]
+	public async Task<IActionResult> PatchMatchById(int matchId, [FromBody] JsonPatchDocument<MatchDTO> patch)
 	{
 		var match = await _matchesService.GetAsync(matchId);
-
-		var original = match;
 
 		if (match is null)
 		{
@@ -213,12 +214,8 @@ public class MatchesController : Controller
 			return BadRequest(ModelState);
 		}
 		
-		//_matchesService.Update(match);
+		var updatedMatch = await _matchesService.UpdateAsync(match);
 
-		return Ok(new
-		{
-			original,
-			patched = match
-		});
+		return Ok(updatedMatch);
 	}
 }

--- a/API/Controllers/MatchesController.cs
+++ b/API/Controllers/MatchesController.cs
@@ -5,6 +5,7 @@ using API.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.JsonPatch;
 
 // ReSharper disable PossibleMultipleEnumeration
 namespace API.Controllers;
@@ -191,5 +192,33 @@ public class MatchesController : Controller
 	{
 		var mapping = await _matchesService.GetIdMappingAsync();
 		return Ok(mapping);
+	}
+
+	[HttpPatch("verification-status/{id:int}")]
+	public async Task<IActionResult> EditVerificationStatusById(int matchId, [FromBody] JsonPatchDocument<MatchDTO> patch)
+	{
+		var match = await _matchesService.GetAsync(matchId);
+
+		var original = match;
+
+		if (match is null)
+		{
+			return NotFound($"Match with id {matchId} does not exist");
+		}
+		
+		patch.ApplyTo(match, ModelState);
+
+		if (!TryValidateModel(match))
+		{
+			return BadRequest(ModelState);
+		}
+		
+		//_matchesService.Update(match);
+
+		return Ok(new
+		{
+			original,
+			patched = match
+		});
 	}
 }

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -18,6 +18,7 @@ using Serilog;
 using Serilog.Events;
 using System.Text;
 using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc.NewtonsoftJson;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -28,7 +29,8 @@ builder.Services.AddControllers(options => { options.ModelBinderProviders.Insert
        {
 	       o.JsonSerializerOptions.NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals;
 	       o.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
-       });
+       })
+       .AddNewtonsoftJson();
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();

--- a/API/Repositories/Implementations/MatchesRepository.cs
+++ b/API/Repositories/Implementations/MatchesRepository.cs
@@ -40,6 +40,24 @@ public class MatchesRepository : RepositoryBase<Match>, IMatchesRepository
 		return await _context.SaveChangesAsync();
 	}
 
+	public async Task<Match> UpdateExisting(MatchDTO matchDto)
+	{
+		var existing = await GetAsync(matchDto.Id);
+
+		if (existing == null)
+		{
+			throw new Exception("Match does not exist, this method assumes the match exists.");
+		}
+
+		existing.Name = matchDto.Name;
+		existing.StartTime = matchDto.StartTime;
+		existing.EndTime = matchDto.EndTime;
+		existing.VerificationStatus = matchDto.VerificationStatus;
+
+		await UpdateAsync(existing);
+		return existing;
+	}
+
 	public async Task RefreshAutomationChecks(bool invalidOnly = true)
 	{
 		var query = _context.Matches

--- a/API/Repositories/Implementations/MatchesRepository.cs
+++ b/API/Repositories/Implementations/MatchesRepository.cs
@@ -1,7 +1,6 @@
 using API.DTOs;
 using API.Entities;
 using API.Enums;
-using API.Osu;
 using API.Repositories.Interfaces;
 using API.Utilities;
 using AutoMapper;
@@ -40,19 +39,16 @@ public class MatchesRepository : RepositoryBase<Match>, IMatchesRepository
 		return await _context.SaveChangesAsync();
 	}
 
-	public async Task<Match> UpdateExisting(MatchDTO matchDto)
+	public async Task<Match> UpdateVerificationStatus(int id, int? verificationStatus)
 	{
-		var existing = await GetAsync(matchDto.Id);
+		var existing = await GetAsync(id, false);
 
 		if (existing == null)
 		{
 			throw new Exception("Match does not exist, this method assumes the match exists.");
 		}
-
-		existing.Name = matchDto.Name;
-		existing.StartTime = matchDto.StartTime;
-		existing.EndTime = matchDto.EndTime;
-		existing.VerificationStatus = matchDto.VerificationStatus;
+		
+		existing.VerificationStatus = verificationStatus;
 
 		await UpdateAsync(existing);
 		return existing;

--- a/API/Repositories/Interfaces/IMatchesRepository.cs
+++ b/API/Repositories/Interfaces/IMatchesRepository.cs
@@ -15,7 +15,7 @@ public interface IMatchesRepository : IRepository<Match>
 	Task<Match?> GetFirstMatchNeedingAutoCheckAsync();
 	Task<IList<Match>> GetNeedApiProcessingAsync();
 	Task<IEnumerable<Match>> GetByMatchIdsAsync(IEnumerable<long> matchIds);
-	Task<Match> UpdateExisting(MatchDTO matchDto);
+	Task<Match> UpdateVerificationStatus(int id, int? verificationStatus);
 
 	/// <summary>
 	///  Used to queue up matches for verification.

--- a/API/Repositories/Interfaces/IMatchesRepository.cs
+++ b/API/Repositories/Interfaces/IMatchesRepository.cs
@@ -15,6 +15,7 @@ public interface IMatchesRepository : IRepository<Match>
 	Task<Match?> GetFirstMatchNeedingAutoCheckAsync();
 	Task<IList<Match>> GetNeedApiProcessingAsync();
 	Task<IEnumerable<Match>> GetByMatchIdsAsync(IEnumerable<long> matchIds);
+	Task<Match> UpdateExisting(MatchDTO matchDto);
 
 	/// <summary>
 	///  Used to queue up matches for verification.

--- a/API/Services/Implementations/MatchesService.cs
+++ b/API/Services/Implementations/MatchesService.cs
@@ -151,4 +151,10 @@ public class MatchesService : IMatchesService
 		var match = await _matchesRepository.GetByMatchIdAsync(osuMatchId);
 		return _mapper.Map<MatchDTO?>(match);
 	}
+
+	public async Task<MatchDTO> UpdateAsync(MatchDTO matchDto)
+	{
+		var match = await _matchesRepository.UpdateExisting(matchDto);
+		return _mapper.Map<MatchDTO>(match);
+	}
 }

--- a/API/Services/Implementations/MatchesService.cs
+++ b/API/Services/Implementations/MatchesService.cs
@@ -152,9 +152,9 @@ public class MatchesService : IMatchesService
 		return _mapper.Map<MatchDTO?>(match);
 	}
 
-	public async Task<MatchDTO> UpdateAsync(MatchDTO matchDto)
+	public async Task<MatchDTO> UpdateVerificationStatus(int id, int? verificationStatus)
 	{
-		var match = await _matchesRepository.UpdateExisting(matchDto);
+		var match = await _matchesRepository.UpdateVerificationStatus(id, verificationStatus);
 		return _mapper.Map<MatchDTO>(match);
 	}
 }

--- a/API/Services/Interfaces/IMatchesService.cs
+++ b/API/Services/Interfaces/IMatchesService.cs
@@ -14,6 +14,7 @@ public interface IMatchesService
 	Task<IEnumerable<int>> GetAllIdsAsync(bool onlyIncludeFiltered);
 	Task<MatchDTO?> GetByOsuIdAsync(long osuMatchId);
 	Task<MatchDTO?> GetAsync(int id, bool filterInvalid = true);
+	Task<MatchDTO> UpdateAsync(MatchDTO matchDto);
 	Task<IEnumerable<MatchDTO>> GetAllForPlayerAsync(long osuPlayerId, int mode, DateTime start, DateTime end);
 
 	/// <summary>

--- a/API/Services/Interfaces/IMatchesService.cs
+++ b/API/Services/Interfaces/IMatchesService.cs
@@ -14,7 +14,7 @@ public interface IMatchesService
 	Task<IEnumerable<int>> GetAllIdsAsync(bool onlyIncludeFiltered);
 	Task<MatchDTO?> GetByOsuIdAsync(long osuMatchId);
 	Task<MatchDTO?> GetAsync(int id, bool filterInvalid = true);
-	Task<MatchDTO> UpdateAsync(MatchDTO matchDto);
+	Task<MatchDTO> UpdateVerificationStatus(int id, int? verificationStatus);
 	Task<IEnumerable<MatchDTO>> GetAllForPlayerAsync(long osuPlayerId, int mode, DateTime start, DateTime end);
 
 	/// <summary>


### PR DESCRIPTION
Closes #91

Adds a new PATCH endpoint for editing the match verification status of a match.


## Other Changes
- A few miscellaneous code warning cleanups.
- Added helper methods from MatchService -> MatchRepository to edit just the match verification status value.