### PR TITLE
Fix `/players/{id}/info` regression

### DIFF
--- a/API/Controllers/MeController.cs
+++ b/API/Controllers/MeController.cs
@@ -24,30 +24,6 @@ public class MeController : Controller
         _playerStatsService = playerStatsService;
     }
 
-    // Will remove once all users are whitelisted in the database
-    // private bool IsWhitelisted(long osuId)
-    // {
-    // 	var whitelist = new long[]
-    // 	{
-    // 		11482346,
-    // 		8191845,
-    // 		11557554,
-    // 		4001304,
-    // 		6892711,
-    // 		7153533,
-    // 		3958619,
-    // 		6701656,
-    // 		1797189,
-    // 		7802400,
-    // 		11255340,
-    // 		13175102,
-    // 		11955929,
-    // 		11292327
-    // 	};
-    //
-    // 	return whitelist.Contains(osuId);
-    // }
-
     [HttpGet]
     [EndpointSummary("Gets the logged in user's information, if they exist")]
     [ProducesResponseType<UserInfoDTO>(StatusCodes.Status200OK)]

--- a/API/Controllers/PlayersController.cs
+++ b/API/Controllers/PlayersController.cs
@@ -30,16 +30,17 @@ public class PlayersController : Controller
         return Ok(players);
     }
 
-    [HttpGet("{userId:int}/info")]
-    public async Task<ActionResult<PlayerInfoDTO?>> GetByUserIdAsync(int userId)
+    [HttpGet("{osuId:long}/info")]
+    public async Task<ActionResult<PlayerInfoDTO?>> GetByUserIdAsync(long osuId)
     {
-        var player = await _playerService.GetAsync(userId);
-        if (player != null)
+        var info = await _playerService.GetAsync(osuId);
+
+        if (info == null)
         {
-            return Ok(player);
+            return NotFound($"User with osuid {osuId} does not exist");
         }
 
-        return NotFound($"User with id {userId} does not exist");
+        return info;
     }
 
     [HttpGet("{username}/info")]

--- a/API/Services/Implementations/PlayerService.cs
+++ b/API/Services/Implementations/PlayerService.cs
@@ -59,6 +59,13 @@ public class PlayerService : IPlayerService
     public async Task<PlayerInfoDTO?> GetAsync(int userId) =>
         _mapper.Map<PlayerInfoDTO?>(await _playerRepository.GetAsync(userId));
 
+    public async Task<PlayerInfoDTO?> GetAsync(long osuId)
+    {
+        int? id = await GetIdAsync(osuId);
+
+        return id == null ? null : _mapper.Map<PlayerInfoDTO?>(await _playerRepository.GetAsync(id.Value));
+    }
+
     public async Task<PlayerInfoDTO?> GetAsync(string username) =>
         _mapper.Map<PlayerInfoDTO?>(await _playerRepository.GetAsync(username));
 }

--- a/API/Services/Interfaces/IPlayerService.cs
+++ b/API/Services/Interfaces/IPlayerService.cs
@@ -21,5 +21,6 @@ public interface IPlayerService
 
     Task<IEnumerable<PlayerCountryMappingDTO>> GetCountryMappingAsync();
     Task<PlayerInfoDTO?> GetAsync(int userId);
+    Task<PlayerInfoDTO?> GetAsync(long osuId);
     Task<PlayerInfoDTO?> GetAsync(string username);
 }


### PR DESCRIPTION
We didn't consider the consequences of changing this endpoint's behavior. The frontend doesn't have a way of translating the osu id to player id etc. otherwise.