### PR TITLE
Correct all controllers' role authorization schemes

### DIFF
--- a/API/Controllers/LeaderboardsController.cs
+++ b/API/Controllers/LeaderboardsController.cs
@@ -25,7 +25,7 @@ public class LeaderboardsController : Controller
     }
 
     [HttpGet]
-    [AllowAnonymous] // TODO: Frontend needs to have a dedicated client for these requests.
+    // [AllowAnonymous] // TODO: Frontend needs to have a dedicated client for these requests.
     public async Task<ActionResult<LeaderboardDTO>> GetAsync(
         [FromQuery] LeaderboardRequestQueryDTO requestQuery
     )

--- a/API/Controllers/MatchesController.cs
+++ b/API/Controllers/MatchesController.cs
@@ -14,8 +14,6 @@ namespace API.Controllers;
 [ApiController]
 [ApiVersion(1)]
 [EnableCors]
-[Authorize(Roles = "user")]
-[Authorize(Roles = "whitelist")]
 [Route("api/v{version:apiVersion}/[controller]")]
 public class MatchesController : Controller
 {
@@ -28,6 +26,7 @@ public class MatchesController : Controller
         _tournamentsService = tournamentsService;
     }
 
+    // TODO: Move to tournaments controller
     [HttpPost("batch")]
     [Authorize(Roles = "submit")]
     public async Task<IActionResult> PostAsync(
@@ -93,6 +92,7 @@ public class MatchesController : Controller
     }
 
     [HttpGet("{id:int}")]
+    [Authorize("user, client")]
     public async Task<ActionResult<MatchDTO>> GetByIdAsync(int id)
     {
         var match = await _matchesService.GetAsync(id);
@@ -118,14 +118,14 @@ public class MatchesController : Controller
         return Ok(matches);
     }
 
-    [Authorize(Roles = "admin")]
     [HttpGet("duplicates")]
+    [Authorize(Roles = "admin")]
     [EndpointSummary("Retrieves all known duplicate groups")]
     public async Task<IActionResult> GetDuplicatesAsync() =>
         Ok(await _matchesService.GetAllDuplicatesAsync());
 
-    [Authorize(Roles = "admin")]
     [HttpPost("duplicate")]
+    [Authorize(Roles = "admin")]
     [EndpointSummary("Mark a match as a confirmed or denied duplicate of the root")]
     public async Task<IActionResult> MarkDuplicatesAsync(
         [FromQuery] int rootId,

--- a/API/Controllers/MeController.cs
+++ b/API/Controllers/MeController.cs
@@ -53,7 +53,6 @@ public class MeController : Controller
     /// </summary>
     /// <returns></returns>
     [HttpGet("validate")]
-    [Authorize(Roles = "whitelist")]
     [EndpointSummary("Validates the currently logged in user has permissions to access the website.")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/API/Controllers/PlayersController.cs
+++ b/API/Controllers/PlayersController.cs
@@ -11,8 +11,6 @@ namespace API.Controllers;
 [ApiController]
 [ApiVersion(1)]
 [EnableCors]
-[Authorize(Roles = "user")]
-[Authorize(Roles = "whitelist")]
 [Route("api/v{version:apiVersion}/[controller]")]
 public class PlayersController(IPlayerService playerService) : Controller
 {
@@ -27,6 +25,7 @@ public class PlayersController(IPlayerService playerService) : Controller
     }
 
     [HttpGet("{key}/info")]
+    [Authorize(Roles = "user, client")]
     [EndpointSummary("Get player info by versatile search")]
     [EndpointDescription("Get player info searching first by id, then osuId, then username")]
     public async Task<ActionResult<PlayerInfoDTO?>> GetAsync(string key)

--- a/API/Controllers/StatsController.cs
+++ b/API/Controllers/StatsController.cs
@@ -10,8 +10,6 @@ namespace API.Controllers;
 [ApiController]
 [ApiVersion(1)]
 [EnableCors]
-[Authorize(Roles = "user")]
-[Authorize(Roles = "whitelist")]
 [Route("api/v{version:apiVersion}/[controller]")]
 public class StatsController : Controller
 {
@@ -25,6 +23,7 @@ public class StatsController : Controller
     }
 
     [HttpGet("{playerId:int}")]
+    [Authorize(Roles = "user, client")]
     public async Task<ActionResult<PlayerStatsDTO>> GetAsync(
         int playerId,
         [FromQuery] int? comparerId,
@@ -41,6 +40,7 @@ public class StatsController : Controller
         );
 
     [HttpGet("{username}")]
+    [Authorize(Roles = "user, client")]
     public async Task<ActionResult<PlayerStatsDTO?>> GetAsync(
         string username,
         [FromQuery] int? comparerId,
@@ -57,6 +57,7 @@ public class StatsController : Controller
         );
 
     [HttpGet("histogram")]
+    [Authorize(Roles = "user, client")]
     public async Task<ActionResult<IDictionary<int, int>>> GetRatingHistogramAsync(
         [FromQuery] int mode = 0
     ) => Ok(await _baseStatsService.GetHistogramAsync(mode));

--- a/API/Controllers/TournamentsController.cs
+++ b/API/Controllers/TournamentsController.cs
@@ -11,8 +11,6 @@ namespace API.Controllers;
 [ApiVersion(1)]
 [EnableCors]
 [Route("api/v{version:apiVersion}/[controller]")]
-[Authorize(Roles = "user")]
-[Authorize(Roles = "whitelist")]
 public class TournamentsController : Controller
 {
     private readonly ITournamentsService _service;
@@ -31,7 +29,7 @@ public class TournamentsController : Controller
     }
 
     [HttpPut]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = "admin, system")]
     public async Task<IActionResult> PutAsync(TournamentWebSubmissionDTO tournament)
     {
         var res = await _service.CreateOrUpdateAsync(tournament, true);


### PR DESCRIPTION
I was mistaken on how cascading role authorization works in ASP.NET. This PR addresses the fact that class-level `Authorize` attributes are NOT overridden by members, but are rather *extended* by members. This means that class-level Authorization should only be applied if *every* endpoint in the class must have a certain permission.