### PR TITLE
Update role parsing in `ClaimsPrincipalExtensions`

### DIFF
--- a/API/Handlers/Implementations/OAuthHandler.cs
+++ b/API/Handlers/Implementations/OAuthHandler.cs
@@ -147,6 +147,7 @@ public class OAuthHandler : IOAuthHandler
         if (!claimsPrincipal.IsUser() && !claimsPrincipal.IsClient())
         {
             _logger.LogWarning("Refresh token does not have the user or client role.");
+            return null;
         }
 
         if (claimsPrincipal.IsUser() && claimsPrincipal.IsClient())

--- a/API/Handlers/Implementations/OAuthHandler.cs
+++ b/API/Handlers/Implementations/OAuthHandler.cs
@@ -273,7 +273,7 @@ public class OAuthHandler : IOAuthHandler
 
         var tokenDescriptor = new SecurityTokenDescriptor
         {
-            Subject = new ClaimsIdentity(new[] { new Claim("role", role) }),
+            Subject = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, role) }),
             IssuedAt = DateTime.UtcNow,
             Expires = DateTime.UtcNow.AddSeconds(expirationSeconds),
             Issuer = issuer,

--- a/API/Utilities/ClaimsPrincipalExtensions.cs
+++ b/API/Utilities/ClaimsPrincipalExtensions.cs
@@ -10,31 +10,41 @@ public static class ClaimsPrincipalExtensions
     /// <param name="claimsPrincipal"></param>
     /// <returns></returns>
     public static bool IsAdmin(this ClaimsPrincipal claimsPrincipal) =>
-        claimsPrincipal.IsInRole("admin");
+        IsInRole(claimsPrincipal, "admin");
 
     /// <summary>
     /// Denotes the principal as having the system role.
     /// </summary>
     /// <param name="claimsPrincipal"></param>
     /// <returns></returns>
-    public static bool IsSystem(this ClaimsPrincipal claimsPrincipal) => claimsPrincipal.IsInRole("system");
+    public static bool IsSystem(this ClaimsPrincipal claimsPrincipal) => IsInRole(claimsPrincipal, "system");
     /// <summary>
     /// Denotes the principal as having the user role.
     /// </summary>
     /// <param name="claimsPrincipal"></param>
     /// <returns></returns>
-    public static bool IsUser(this ClaimsPrincipal claimsPrincipal) => claimsPrincipal.IsInRole("user");
+    public static bool IsUser(this ClaimsPrincipal claimsPrincipal)
+    {
+        return IsInRole(claimsPrincipal, "user");
+    }
+
     /// <summary>
     /// Denotes the principal as having the client role.
     /// </summary>
     /// <param name="claimsPrincipal"></param>
     /// <returns></returns>
-    public static bool IsClient(this ClaimsPrincipal claimsPrincipal) => claimsPrincipal.IsInRole("client");
+    public static bool IsClient(this ClaimsPrincipal claimsPrincipal) => IsInRole(claimsPrincipal, "client");
+
     /// <summary>
     /// Denotes the principal as having the verifier role.
     /// </summary>
     /// <param name="claimsPrincipal"></param>
     /// <returns></returns>
     public static bool IsMatchVerifier(this ClaimsPrincipal claimsPrincipal) =>
-        claimsPrincipal.IsInRole("verifier");
+        IsInRole(claimsPrincipal, "verifier");
+
+    private static bool IsInRole(ClaimsPrincipal claimsPrincipal, string role)
+    {
+        return claimsPrincipal.IsInRole(role) || claimsPrincipal.HasClaim("role", role);
+    }
 }

--- a/APITests/Utilities/ClaimsPrincipalExtensionsTests.cs
+++ b/APITests/Utilities/ClaimsPrincipalExtensionsTests.cs
@@ -30,17 +30,6 @@ public class ClaimsPrincipalExtensionsTests
         claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new(ClaimTypes.Role, "verifier") }));
 
         Assert.True(claims.IsMatchVerifier());
-        Assert.False(claims.IsAdmin());
-        Assert.False(claims.IsSystem());
-    }
-
-    [Fact]
-    public void ClaimsPrincipal_Admin_IsMatchVerifier()
-    {
-        var claims = new ClaimsPrincipal();
-        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new(ClaimTypes.Role, "admin") }));
-
-        Assert.True(claims.IsAdmin());
     }
 
     [Fact]
@@ -50,5 +39,61 @@ public class ClaimsPrincipalExtensionsTests
         claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new(ClaimTypes.Role, "user") }));
 
         Assert.True(claims.IsUser());
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_IsAdmin_WhenClaimTypeMapped()
+    {
+        var claims = new ClaimsPrincipal();
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("role", "admin") }));
+
+        Assert.True(claims.IsAdmin());
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_IsMatchVerifier_WhenClaimTypeMapped()
+    {
+        var claims = new ClaimsPrincipal();
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("role", "verifier") }));
+
+        Assert.True(claims.IsMatchVerifier());
+        Assert.False(claims.IsAdmin());
+        Assert.False(claims.IsSystem());
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_IsUser_WhenClaimTypeMapped()
+    {
+        var claims = new ClaimsPrincipal();
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("role", "user") }));
+
+        Assert.True(claims.IsUser());
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_IsNotAdmin_WhenClaimTypeInvalid()
+    {
+        var claims = new ClaimsPrincipal();
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("123", "admin") }));
+
+        Assert.False(claims.IsAdmin());
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_IsNotMatchVerifier_WhenClaimTypeInvalid()
+    {
+        var claims = new ClaimsPrincipal();
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("123", "verifier") }));
+
+        Assert.False(claims.IsMatchVerifier());
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_IsNotUser_WhenClaimTypeInvalid()
+    {
+        var claims = new ClaimsPrincipal();
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("123", "user") }));
+
+        Assert.False(claims.IsUser());
     }
 }


### PR DESCRIPTION
* Fixes bug where the refresh token could not identify whether the token belonged to a user or a client.
* Adds more tests for the role parsing behavior.