### PR TITLE
Fix refreshed access tokens not receiving `user` or `client` claims

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.0.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.0.0" />
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="Community.Microsoft.Extensions.Caching.PostgreSql" Version="4.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />

--- a/API/Controllers/MeController.cs
+++ b/API/Controllers/MeController.cs
@@ -42,21 +42,6 @@ public class MeController(IUserService userService, IPlayerStatsService playerSt
         return Ok(user);
     }
 
-    /// <summary>
-    ///  Validates the currently logged in user's OTR-Access-Token cookie
-    /// </summary>
-    /// <returns></returns>
-    [HttpGet("validate")]
-    [EndpointSummary("Validates the currently logged in user has permissions to access the website.")]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public IActionResult ValidateJwt()
-    {
-        // Middleware will return 403 if the user does not
-        // have the correct roles
-        return NoContent();
-    }
-
     [HttpGet("stats")]
     public async Task<ActionResult<PlayerStatsDTO>> GetStatsAsync(
         [FromQuery] int mode = 0,

--- a/API/Controllers/MeController.cs
+++ b/API/Controllers/MeController.cs
@@ -53,7 +53,7 @@ public class MeController(IUserService userService, IPlayerStatsService playerSt
 
         if (!userId.HasValue)
         {
-            return BadRequest("User is not logged in or id could not be retreived from logged in user.");
+            return BadRequest("User is not logged in or id could not be retrieved from logged in user.");
         }
 
         var playerId = (await _userService.GetAsync(userId.Value))?.Id;

--- a/API/Handlers/Implementations/OAuthHandler.cs
+++ b/API/Handlers/Implementations/OAuthHandler.cs
@@ -172,7 +172,7 @@ public class OAuthHandler : IOAuthHandler
             accessToken = GenerateAccessToken(
                 user.Id.ToString(),
                 _jwtAudience,
-                user.Scopes,
+                [.. user.Scopes, "user"],
                 ACCESS_DURATION_SECONDS
             );
         }
@@ -187,7 +187,7 @@ public class OAuthHandler : IOAuthHandler
             accessToken = GenerateAccessToken(
                 client.ClientId.ToString(),
                 _jwtAudience,
-                client.Scopes,
+                [.. client.Scopes, "client"],
                 ACCESS_DURATION_SECONDS
             );
         }

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -13,7 +13,6 @@ using API.Services.Implementations;
 using API.Services.Interfaces;
 using API.Utilities;
 using Asp.Versioning;
-using Asp.Versioning.Conventions;
 using AutoMapper;
 using Dapper;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -57,9 +56,16 @@ builder
 builder
     .Services.AddApiVersioning(options =>
     {
+        options.ReportApiVersions = true;
+        options.DefaultApiVersion = new ApiVersion(1);
         options.ApiVersionReader = new UrlSegmentApiVersionReader();
     })
-    .AddMvc();
+    .AddMvc()
+    .AddApiExplorer(options =>
+    {
+        options.GroupNameFormat = "'v'VVV";
+        options.SubstituteApiVersionInUrl = true;
+    });
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
@@ -195,7 +201,7 @@ builder.Services.AddCors(options =>
 builder.Services.AddRouting(options => options.LowercaseUrls = true);
 
 builder.Host.ConfigureOsuSharp(
-    (ctx, options) =>
+    (_, options) =>
     {
         OsuConfiguration osuConfiguration = builder.Configuration.BindAndValidate<OsuConfiguration>(
             OsuConfiguration.Position


### PR DESCRIPTION
Since these claims are manually applied on creation, they need to be manually applied on refresh as well. This pull also addresses two smaller issues, populating the api version in swagger and removing the `/me/validate` endpoint (hence the breaking change tag).

Closes #179, #152 