### PR TITLE
BeatmapsController refactor

### DIFF
--- a/API/Controllers/BeatmapsController.cs
+++ b/API/Controllers/BeatmapsController.cs
@@ -1,9 +1,9 @@
 using API.DTOs;
-using API.Entities;
 using API.Services.Interfaces;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
 namespace API.Controllers;
@@ -11,25 +11,28 @@ namespace API.Controllers;
 [ApiController]
 [ApiVersion(1)]
 [EnableCors]
-[Authorize(Roles = "system")] // Internal access only at this time
+[Authorize(Roles = "system, admin")] // Internal access only at this time
 [Route("api/v{version:apiVersion}/[controller]")]
 public class BeatmapsController(IBeatmapService beatmapService) : Controller
 {
     private readonly IBeatmapService _beatmapService = beatmapService;
 
-    [HttpGet("all")]
-    public async Task<ActionResult<IEnumerable<Beatmap>>> GetAllAsync() =>
-        Ok(await _beatmapService.GetAllAsync());
+    [HttpGet]
+    [EndpointSummary("List beatmaps")]
+    public async Task<Ok<IEnumerable<BeatmapDTO>>> ListAsync() =>
+        TypedResults.Ok(await _beatmapService.ListAsync());
 
-    [HttpGet("{beatmapId:long}")]
-    public async Task<ActionResult<Beatmap>> GetByOsuBeatmapIdAsync(long beatmapId)
+    [HttpGet("{key}")]
+    [EndpointSummary("Get a beatmap by versatile search")]
+    [EndpointDescription("Get a beatmap searching first by id, then by osu! beatmap id")]
+    public async Task<Results<NotFound, Ok<BeatmapDTO>>> GetAsync(string key)
     {
-        BeatmapDTO? beatmap = await _beatmapService.GetAsync(beatmapId);
+        BeatmapDTO? beatmap = await _beatmapService.GetVersatileAsync(key);
         if (beatmap == null)
         {
-            return NotFound("No matching beatmapId in the database.");
+            return TypedResults.NotFound();
         }
 
-        return Ok(beatmap);
+        return TypedResults.Ok(beatmap);
     }
 }

--- a/API/Controllers/BeatmapsController.cs
+++ b/API/Controllers/BeatmapsController.cs
@@ -22,10 +22,10 @@ public class BeatmapsController(IBeatmapService beatmapService) : Controller
     public async Task<Ok<IEnumerable<BeatmapDTO>>> ListAsync() =>
         TypedResults.Ok(await _beatmapService.ListAsync());
 
-    [HttpGet("{key}")]
+    [HttpGet("{key:long}")]
     [EndpointSummary("Get a beatmap by versatile search")]
     [EndpointDescription("Get a beatmap searching first by id, then by osu! beatmap id")]
-    public async Task<Results<NotFound, Ok<BeatmapDTO>>> GetAsync(string key)
+    public async Task<Results<NotFound, Ok<BeatmapDTO>>> GetAsync(long key)
     {
         BeatmapDTO? beatmap = await _beatmapService.GetVersatileAsync(key);
         if (beatmap == null)

--- a/API/DTOs/BeatmapDTO.cs
+++ b/API/DTOs/BeatmapDTO.cs
@@ -2,6 +2,7 @@ namespace API.DTOs;
 
 public class BeatmapDTO
 {
+    public int Id { get; set; }
     public string Artist { get; set; } = null!;
     public long BeatmapId { get; set; }
     public double? Bpm { get; set; }

--- a/API/Repositories/Implementations/ApiMatchRepository.cs
+++ b/API/Repositories/Implementations/ApiMatchRepository.cs
@@ -125,7 +125,7 @@ public class ApiMatchRepository(
 
         foreach (var beatmapId in beatmapIds)
         {
-            Beatmap? existingBeatmap = await _beatmapRepository.GetByOsuIdAsync(beatmapId);
+            Beatmap? existingBeatmap = await _beatmapRepository.GetAsync(beatmapId);
             if (existingBeatmap == null)
             {
                 Beatmap? beatmap = await _osuApiService.GetBeatmapAsync(
@@ -241,7 +241,7 @@ public class ApiMatchRepository(
         var persisted = new List<Game>();
         foreach (OsuApiGame game in osuMatchGames)
         {
-            var beatmapIdResult = await _beatmapRepository.GetIdByBeatmapIdAsync(game.BeatmapId);
+            var beatmapIdResult = await _beatmapRepository.GetIdAsync(game.BeatmapId);
 
             Game? existingGame = await _context.Games.FirstOrDefaultAsync(g => g.GameId == game.GameId);
 

--- a/API/Repositories/Implementations/BeatmapRepository.cs
+++ b/API/Repositories/Implementations/BeatmapRepository.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using API.DTOs;
 using API.Entities;
 using API.Repositories.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -11,45 +12,10 @@ public class BeatmapRepository(OtrContext context) : RepositoryBase<Beatmap>(con
 {
     private readonly OtrContext _context = context;
 
-    public async Task<long> GetBeatmapIdAsync(int id) =>
-        await _context.Beatmaps.Where(b => b.Id == id).Select(b => b.BeatmapId).FirstOrDefaultAsync();
-
-    public async Task<Beatmap?> GetByOsuIdAsync(long osuBeatmapId) =>
-        await _context.Beatmaps.FirstOrDefaultAsync(x => x.BeatmapId == osuBeatmapId);
-
-    public async Task<Beatmap?> GetBeatmapByBeatmapIdAsync(long osuBeatmapId)
-    {
-        return await _context.Beatmaps.Where(x => x.BeatmapId == osuBeatmapId).FirstOrDefaultAsync();
-    }
-
-    public async Task CreateIfNotExistsAsync(IEnumerable<long> beatmapIds)
-    {
-        foreach (var id in beatmapIds)
-        {
-            if (!await _context.Beatmaps.AnyAsync(x => x.BeatmapId == id))
-            {
-                await _context.Beatmaps.AddAsync(new Beatmap { BeatmapId = id });
-            }
-        }
-
-        await _context.SaveChangesAsync();
-    }
-
-    public async Task<int?> GetIdByBeatmapIdAsync(long gameBeatmapId)
-    {
-        if (!await _context.Beatmaps.AnyAsync(x => x.BeatmapId == gameBeatmapId))
-        {
-            return null;
-        }
-
-        return await _context
-            .Beatmaps.Where(x => x.BeatmapId == gameBeatmapId)
-            .Select(x => x.Id)
-            .FirstOrDefaultAsync();
-    }
-
     public override async Task<IEnumerable<Beatmap>> GetAllAsync() => await _context.Beatmaps.ToListAsync();
 
-    public async Task<IEnumerable<Beatmap>> GetAsync(IEnumerable<long> beatmapIds) =>
-        await _context.Beatmaps.Where(b => beatmapIds.Contains(b.BeatmapId)).ToListAsync();
+    public async Task<Beatmap?> GetAsync(long beatmapId) =>
+        await _context.Beatmaps.FirstOrDefaultAsync(x => x.BeatmapId == beatmapId);
+
+    public async Task<int?> GetIdAsync(long beatmapId) => (await GetAsync(beatmapId))?.Id;
 }

--- a/API/Repositories/Interfaces/IBeatmapRepository.cs
+++ b/API/Repositories/Interfaces/IBeatmapRepository.cs
@@ -4,15 +4,17 @@ namespace API.Repositories.Interfaces;
 
 public interface IBeatmapRepository : IRepository<Beatmap>
 {
-    Task<long> GetBeatmapIdAsync(int id);
-    Task<Beatmap?> GetByOsuIdAsync(long osuBeatmapId);
-    Task CreateIfNotExistsAsync(IEnumerable<long> beatmapIds);
-    Task<int?> GetIdByBeatmapIdAsync(long gameBeatmapId);
+    /// <summary>
+    /// Returns a beatmap for the given osu! beatmap id
+    /// </summary>
+    /// <param name="beatmapId">osu! beatmap id</param>
+    /// <returns></returns>
+    Task<Beatmap?> GetAsync(long beatmapId);
 
     /// <summary>
-    /// Returns a collection of beatmap objects for the given beatmap IDs.
+    /// Returns the Id (primary key) of a <see cref="Beatmap"/> for a given osu! beatmap id
     /// </summary>
-    /// <param name="beatmapIds"></param>
+    /// <param name="beatmapId">osu! beatmap id</param>
     /// <returns></returns>
-    Task<IEnumerable<Beatmap>> GetAsync(IEnumerable<long> beatmapIds);
+    Task<int?> GetIdAsync(long beatmapId);
 }

--- a/API/Services/Implementations/BeatmapService.cs
+++ b/API/Services/Implementations/BeatmapService.cs
@@ -19,26 +19,15 @@ public class BeatmapService(IBeatmapRepository beatmapRepository, IMapper mapper
     public async Task<BeatmapDTO?> GetAsync(long beatmapId) =>
         _mapper.Map<BeatmapDTO?>(await _beatmapRepository.GetAsync(beatmapId: beatmapId));
 
-    public async Task<BeatmapDTO?> GetVersatileAsync(string key)
+    public async Task<BeatmapDTO?> GetVersatileAsync(long key)
     {
-        if (!int.TryParse(key, out var intValue))
-        {
-            return null;
-        }
-
         // Check for primary key
-        BeatmapDTO? result = await GetAsync(intValue);
+        BeatmapDTO? result = await GetAsync((int)key);
         if (result is not null)
         {
             return result;
         }
-
-        // Check for beatmapId
-        if (long.TryParse(key, out var longValue))
-        {
-            return await GetAsync(longValue);
-        }
-
-        return null;
+        // Check for beatmap id
+        return await GetAsync(key);
     }
 }

--- a/API/Services/Implementations/BeatmapService.cs
+++ b/API/Services/Implementations/BeatmapService.cs
@@ -10,12 +10,35 @@ public class BeatmapService(IBeatmapRepository beatmapRepository, IMapper mapper
     private readonly IBeatmapRepository _beatmapRepository = beatmapRepository;
     private readonly IMapper _mapper = mapper;
 
-    public async Task<IEnumerable<BeatmapDTO>> GetAllAsync() =>
+    public async Task<IEnumerable<BeatmapDTO>> ListAsync() =>
         _mapper.Map<IEnumerable<BeatmapDTO>>(await _beatmapRepository.GetAllAsync());
 
-    public async Task<IEnumerable<BeatmapDTO>> GetByBeatmapIdsAsync(IEnumerable<long> beatmapIds) =>
-        _mapper.Map<IEnumerable<BeatmapDTO>>(await _beatmapRepository.GetAsync(beatmapIds));
+    public async Task<BeatmapDTO?> GetAsync(int id) =>
+        _mapper.Map<BeatmapDTO?>(await _beatmapRepository.GetAsync(id: id));
 
-    public async Task<BeatmapDTO?> GetAsync(long osuBeatmapId) =>
-        _mapper.Map<BeatmapDTO?>(await _beatmapRepository.GetByOsuIdAsync(osuBeatmapId));
+    public async Task<BeatmapDTO?> GetAsync(long beatmapId) =>
+        _mapper.Map<BeatmapDTO?>(await _beatmapRepository.GetAsync(beatmapId: beatmapId));
+
+    public async Task<BeatmapDTO?> GetVersatileAsync(string key)
+    {
+        if (!int.TryParse(key, out var intValue))
+        {
+            return null;
+        }
+
+        // Check for primary key
+        BeatmapDTO? result = await GetAsync(intValue);
+        if (result is not null)
+        {
+            return result;
+        }
+
+        // Check for beatmapId
+        if (long.TryParse(key, out var longValue))
+        {
+            return await GetAsync(longValue);
+        }
+
+        return null;
+    }
 }

--- a/API/Services/Interfaces/IBeatmapService.cs
+++ b/API/Services/Interfaces/IBeatmapService.cs
@@ -35,5 +35,5 @@ public interface IBeatmapService
     /// </summary>
     /// <param name="key">The dynamic key of the beatmap to look for</param>
     /// <returns></returns>
-    Task<BeatmapDTO?> GetVersatileAsync(string key);
+    Task<BeatmapDTO?> GetVersatileAsync(long key);
 }

--- a/API/Services/Interfaces/IBeatmapService.cs
+++ b/API/Services/Interfaces/IBeatmapService.cs
@@ -4,7 +4,36 @@ namespace API.Services.Interfaces;
 
 public interface IBeatmapService
 {
-    Task<IEnumerable<BeatmapDTO>> GetAllAsync();
-    Task<IEnumerable<BeatmapDTO>> GetByBeatmapIdsAsync(IEnumerable<long> beatmapIds);
-    Task<BeatmapDTO?> GetAsync(long osuBeatmapId);
+    /// <summary>
+    /// List all beatmaps
+    /// </summary>
+    /// <returns></returns>
+    Task<IEnumerable<BeatmapDTO>> ListAsync();
+
+    /// <summary>
+    /// Get a beatmap by primary key
+    /// </summary>
+    /// <param name="id">primary key</param>
+    /// <returns></returns>
+    Task<BeatmapDTO?> GetAsync(int id);
+
+    /// <summary>
+    /// Get a beatmap by osu! beatmapId
+    /// </summary>
+    /// <param name="beatmapId">osu! beatmapId</param>
+    /// <returns></returns>
+    Task<BeatmapDTO?> GetAsync(long beatmapId);
+
+    /// <summary>
+    /// Dynamically searches for a beatmap via the following, in order of priority:
+    ///
+    /// If the key can be parsed as an integer:
+    /// - The beatmap id (primary key)
+    ///
+    /// If the key can be parsed as a long:
+    /// - The beatmap id (osu! id)
+    /// </summary>
+    /// <param name="key">The dynamic key of the beatmap to look for</param>
+    /// <returns></returns>
+    Task<BeatmapDTO?> GetVersatileAsync(string key);
 }

--- a/otrAPI.sln.DotSettings
+++ b/otrAPI.sln.DotSettings
@@ -2,4 +2,6 @@
 	<s:Boolean x:Key="/Default/CodeEditing/SuppressNullableWarningFix/Enabled/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/Filtering/ExcludeCoverageFilters/=APITests_003B_002A_003B_002A_003B_002A/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/Filtering/ExcludeCoverageFilters/=API_003B_002A_003BAPI_002EMigrations_002E_002A_003B_002A/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/Filtering/ExcludeCoverageFilters/=API_003B_002A_003BProgram_003B_002A/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/Environment/Filtering/ExcludeCoverageFilters/=API_003B_002A_003BProgram_003B_002A/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=beatmap/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Beatmaps/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Refactor of the beatmaps controller and related services pursuant to #207 

Breaking changes:
- Remove `GET` `/api/v1/beatmaps/all`
- Remove `GET` `/api/v1/beatmaps/{id}
- Add `GET` `/api/v1/beatmaps`
  - [List](https://cloud.google.com/apis/design/standard_methods#list) endpoint
- Add `GET` `/api/v1/beamtaps/{key}`
  - Versatile search endpoint that returns one beatmap searching first by id (primary key), then by osu! beatmap id

