### PR TITLE
Use error checking in pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,3 @@ redis.env
 *Backup.csproj
 *.csproj.user
 .vscode/
-
-.husky/pre-commit

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ redis.env
 *.csproj.user
 .vscode/
 
-pre-commit
+.husky/pre-commit

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ redis.env
 *Backup.csproj
 *.csproj.user
 .vscode/
+
+pre-commit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,24 +1,16 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-## husky task runner examples -------------------
-## Note : for local installation use 'dotnet' prefix. e.g. 'dotnet husky'
+echo "Running pre-commit tasks..."
 
-## run all tasks
-#husky run
+FORMAT_OUTPUT=$(dotnet husky run --group pre-commit 2>&1)
 
-### run all tasks with group: 'group-name'
-#husky run --group group-name
+echo "$FORMAT_OUTPUT"
 
-## run task with name: 'task-name'
-#husky run --name task-name
+if echo "$FORMAT_OUTPUT" | grep -q "Unable to fix"; then
+    echo "Found unfixable violations. Please fix the violations and commit again."
+    echo "Generating detailed violation description"
+    dotnet husky run --name dotnet-verify-staged
+fi
 
-## pass hook arguments to task
-#husky run --args "$1" "$2"
-
-## or put your custom commands -------------------
-#echo 'Husky.Net is awesome!'
-
-dotnet husky run --group pre-commit
-
-echo 'Completed pre-commit changes'
+echo "Completed pre-commit tasks"

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,11 +1,36 @@
 {
-   "tasks": [
-      {
-         "name": "dotnet-format-staged",
-         "group": "pre-commit",
-         "command": "dotnet",
-         "args": [ "format", "--include", "${staged}", "--severity", "info" ],
-         "include": ["**/*.cs"]
-      }
-   ]
+    "tasks": [
+        {
+            "name": "dotnet-format-staged",
+            "group": "pre-commit",
+            "command": "dotnet",
+            "args": [
+                "format",
+                "--include",
+                "${staged}",
+                "--severity",
+                "info"
+            ],
+            "include": [
+                "**/*.cs"
+            ]
+        },
+        {
+            "name": "dotnet-verify-staged",
+            "command": "dotnet",
+            "args": [
+                "format",
+                "--verify-no-changes",
+                "--include",
+                "${staged}",
+                "--severity",
+                "info",
+                "--verbosity",
+                "normal"
+            ],
+            "include": [
+                "**/*.cs"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
This change should put to bed the rest of the issues we're having with husky. If the pre-commit task for dotnet format finds errors, it will run a new task that gives error detail with line numbers.

Devs: make sure your `.husky/pre-commit` file has execute permission `chmod +x .husky/pre-commit`. I was running into issues where it was not executing any hooks because of this.