### PR TITLE
Modify leaderboard tier filter behavior to match new requirements

### DIFF
--- a/API/Controllers/PlayersController.cs
+++ b/API/Controllers/PlayersController.cs
@@ -1,5 +1,4 @@
 using API.DTOs;
-using API.Osu;
 using API.Services.Interfaces;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;

--- a/API/DTOs/LeaderboardTierFilterDTO.cs
+++ b/API/DTOs/LeaderboardTierFilterDTO.cs
@@ -1,21 +1,24 @@
 namespace API.DTOs;
 
 /// <summary>
-/// A collection of booleans represeting which tiers to filter.
+/// A collection of booleans representing which tiers to filter.
 ///
-/// Null = No filter
-/// False = Explictly excluded
+/// False = Default, no behavioral change
 /// True = Explicitly included
+///
+/// If everything is false *and* if everything is true, the leaderboard will return
+/// in its default state. If everything is false except for Bronze and Emerald,
+/// then only Bronze and Emerald players will show up in the leaderboard.
 /// </summary>
 public class LeaderboardTierFilterDTO
 {
-    public bool? FilterBronze { get; set; }
-    public bool? FilterSilver { get; set; }
-    public bool? FilterGold { get; set; }
-    public bool? FilterPlatinum { get; set; }
-    public bool? FilterEmerald { get; set; }
-    public bool? FilterDiamond { get; set; }
-    public bool? FilterMaster { get; set; }
-    public bool? FilterGrandmaster { get; set; }
-    public bool? FilterEliteGrandmaster { get; set; }
+    public bool FilterBronze { get; set; }
+    public bool FilterSilver { get; set; }
+    public bool FilterGold { get; set; }
+    public bool FilterPlatinum { get; set; }
+    public bool FilterEmerald { get; set; }
+    public bool FilterDiamond { get; set; }
+    public bool FilterMaster { get; set; }
+    public bool FilterGrandmaster { get; set; }
+    public bool FilterEliteGrandmaster { get; set; }
 }

--- a/API/DTOs/LeaderboardTierFilterDTO.cs
+++ b/API/DTOs/LeaderboardTierFilterDTO.cs
@@ -4,11 +4,14 @@ namespace API.DTOs;
 /// A collection of booleans representing which tiers to filter.
 ///
 /// False = Default, no behavioral change
-/// True = Explicitly included
+/// True = Explicitly included in leaderboard results
 ///
-/// If everything is false *and* if everything is true, the leaderboard will return
-/// in its default state. If everything is false except for Bronze and Emerald,
-/// then only Bronze and Emerald players will show up in the leaderboard.
+/// If *all* tiers are set to false, or all tiers are set to true, the leaderboard will return
+/// as if no tier filters were applied.
+///
+/// For example, if Bronze and Emerald are true and everything else is false,
+/// then only Bronze and Emerald players will show up in the leaderboard
+/// (specifically, Bronze III-I and Emerald III-I)
 /// </summary>
 public class LeaderboardTierFilterDTO
 {

--- a/API/ModelBinders/LeaderboardFilterModelBinder.cs
+++ b/API/ModelBinders/LeaderboardFilterModelBinder.cs
@@ -1,7 +1,5 @@
-using System;
 using System.ComponentModel;
 using System.Globalization;
-using System.Threading.Tasks;
 using API.DTOs;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
@@ -27,15 +25,15 @@ public class LeaderboardFilterModelBinder : IModelBinder
             MaxWinrate = GetValue<double?>("MaxWinrate"),
             TierFilters = new LeaderboardTierFilterDTO
             {
-                FilterBronze = GetValue<bool?>("Bronze"),
-                FilterSilver = GetValue<bool?>("Silver"),
-                FilterGold = GetValue<bool?>("Gold"),
-                FilterPlatinum = GetValue<bool?>("Platinum"),
-                FilterEmerald = GetValue<bool?>("Emerald"),
-                FilterDiamond = GetValue<bool?>("Diamond"),
-                FilterMaster = GetValue<bool?>("Master"),
-                FilterGrandmaster = GetValue<bool?>("Grandmaster"),
-                FilterEliteGrandmaster = GetValue<bool?>("EliteGrandmaster"),
+                FilterBronze = GetValue<bool>("Bronze"),
+                FilterSilver = GetValue<bool>("Silver"),
+                FilterGold = GetValue<bool>("Gold"),
+                FilterPlatinum = GetValue<bool>("Platinum"),
+                FilterEmerald = GetValue<bool>("Emerald"),
+                FilterDiamond = GetValue<bool>("Diamond"),
+                FilterMaster = GetValue<bool>("Master"),
+                FilterGrandmaster = GetValue<bool>("Grandmaster"),
+                FilterEliteGrandmaster = GetValue<bool>("EliteGrandmaster"),
             }
         };
 

--- a/API/Repositories/Implementations/BaseStatsRepository.cs
+++ b/API/Repositories/Implementations/BaseStatsRepository.cs
@@ -286,7 +286,6 @@ public class BaseStatsRepository(OtrContext context, IPlayerRepository playerRep
             {
                 baseQuery = FilterByTier(baseQuery, filter.TierFilters!);
             }
-            // baseQuery = FilterByWinrate(baseQuery, filter.MinWinrate, filter.MaxWinrate);
         }
 
         return baseQuery;
@@ -375,15 +374,15 @@ public class BaseStatsRepository(OtrContext context, IPlayerRepository playerRep
         LeaderboardTierFilterDTO tierFilter
     )
     {
-        bool includeBronze = tierFilter.FilterBronze;
-        bool includeSilver = tierFilter.FilterSilver;
-        bool includeGold = tierFilter.FilterGold;
-        bool includePlatinum = tierFilter.FilterPlatinum;
-        bool includeEmerald = tierFilter.FilterEmerald;
-        bool includeDiamond = tierFilter.FilterDiamond;
-        bool includeMaster = tierFilter.FilterMaster;
-        bool includeGrandmaster = tierFilter.FilterGrandmaster;
-        bool includeEliteGrandmaster = tierFilter.FilterEliteGrandmaster;
+        var includeBronze = tierFilter.FilterBronze;
+        var includeSilver = tierFilter.FilterSilver;
+        var includeGold = tierFilter.FilterGold;
+        var includePlatinum = tierFilter.FilterPlatinum;
+        var includeEmerald = tierFilter.FilterEmerald;
+        var includeDiamond = tierFilter.FilterDiamond;
+        var includeMaster = tierFilter.FilterMaster;
+        var includeGrandmaster = tierFilter.FilterGrandmaster;
+        var includeEliteGrandmaster = tierFilter.FilterEliteGrandmaster;
 
         return query.Where(x =>
             (includeBronze && x.Rating < RatingUtils.RatingSilverIII)

--- a/API/Repositories/Implementations/BaseStatsRepository.cs
+++ b/API/Repositories/Implementations/BaseStatsRepository.cs
@@ -282,9 +282,9 @@ public class BaseStatsRepository(OtrContext context, IPlayerRepository playerRep
             baseQuery = FilterByRating(baseQuery, filter.MinRating, filter.MaxRating);
             baseQuery = FilterByMatchesPlayed(baseQuery, filter.MinMatches, filter.MaxMatches);
 
-            if (filter.TierFilters != null)
+            if (filter.TierFilters.IsEngaged())
             {
-                baseQuery = FilterByTier(baseQuery, filter.TierFilters);
+                baseQuery = FilterByTier(baseQuery, filter.TierFilters!);
             }
             // baseQuery = FilterByWinrate(baseQuery, filter.MinWinrate, filter.MaxWinrate);
         }
@@ -375,123 +375,26 @@ public class BaseStatsRepository(OtrContext context, IPlayerRepository playerRep
         LeaderboardTierFilterDTO tierFilter
     )
     {
-        // Filter for Bronze tier
-        if (tierFilter.FilterBronze == true)
-        {
-            query = query.Where(x => x.Rating < RatingUtils.RatingSilverIII);
-        }
-        else if (tierFilter.FilterBronze == false)
-        {
-            query = query.Where(x => x.Rating >= RatingUtils.RatingSilverIII);
-        }
+        bool includeBronze = tierFilter.FilterBronze;
+        bool includeSilver = tierFilter.FilterSilver;
+        bool includeGold = tierFilter.FilterGold;
+        bool includePlatinum = tierFilter.FilterPlatinum;
+        bool includeEmerald = tierFilter.FilterEmerald;
+        bool includeDiamond = tierFilter.FilterDiamond;
+        bool includeMaster = tierFilter.FilterMaster;
+        bool includeGrandmaster = tierFilter.FilterGrandmaster;
+        bool includeEliteGrandmaster = tierFilter.FilterEliteGrandmaster;
 
-        // Filter for Silver tier
-        if (tierFilter.FilterSilver == true)
-        {
-            query = query.Where(x =>
-                x.Rating >= RatingUtils.RatingSilverIII && x.Rating < RatingUtils.RatingGoldIII
-            );
-        }
-        else if (tierFilter.FilterSilver == false)
-        {
-            query = query.Where(x =>
-                x.Rating < RatingUtils.RatingSilverIII || x.Rating >= RatingUtils.RatingGoldIII
-            );
-        }
-
-        // Filter for Gold tier
-        if (tierFilter.FilterGold == true)
-        {
-            query = query.Where(x =>
-                x.Rating >= RatingUtils.RatingGoldIII && x.Rating < RatingUtils.RatingPlatinumIII
-            );
-        }
-        else if (tierFilter.FilterGold == false)
-        {
-            query = query.Where(x =>
-                x.Rating < RatingUtils.RatingGoldIII || x.Rating >= RatingUtils.RatingPlatinumIII
-            );
-        }
-
-        // Filter for Platinum tier
-        if (tierFilter.FilterPlatinum == true)
-        {
-            query = query.Where(x =>
-                x.Rating >= RatingUtils.RatingPlatinumIII && x.Rating < RatingUtils.RatingDiamondIII
-            );
-        }
-        else if (tierFilter.FilterPlatinum == false)
-        {
-            query = query.Where(x =>
-                x.Rating < RatingUtils.RatingPlatinumIII || x.Rating >= RatingUtils.RatingDiamondIII
-            );
-        }
-
-        if (tierFilter.FilterEmerald == true)
-        {
-            query = query.Where(x =>
-                x.Rating >= RatingUtils.RatingEmeraldIII && x.Rating < RatingUtils.RatingMasterIII
-            );
-        }
-        else if (tierFilter.FilterEmerald == false)
-        {
-            query = query.Where(x =>
-                x.Rating < RatingUtils.RatingEmeraldIII || x.Rating >= RatingUtils.RatingDiamondIII
-            );
-        }
-
-        // Filter for Diamond tier
-        if (tierFilter.FilterDiamond == true)
-        {
-            query = query.Where(x =>
-                x.Rating >= RatingUtils.RatingDiamondIII && x.Rating < RatingUtils.RatingMasterIII
-            );
-        }
-        else if (tierFilter.FilterDiamond == false)
-        {
-            query = query.Where(x =>
-                x.Rating < RatingUtils.RatingDiamondIII || x.Rating >= RatingUtils.RatingMasterIII
-            );
-        }
-
-        // Filter for Master tier
-        if (tierFilter.FilterMaster == true)
-        {
-            query = query.Where(x =>
-                x.Rating >= RatingUtils.RatingMasterIII && x.Rating < RatingUtils.RatingGrandmasterIII
-            );
-        }
-        else if (tierFilter.FilterMaster == false)
-        {
-            query = query.Where(x =>
-                x.Rating < RatingUtils.RatingMasterIII || x.Rating >= RatingUtils.RatingGrandmasterIII
-            );
-        }
-
-        // Filter for Grandmaster tier
-        if (tierFilter.FilterGrandmaster == true)
-        {
-            query = query.Where(x =>
-                x.Rating >= RatingUtils.RatingGrandmasterIII && x.Rating < RatingUtils.RatingEliteGrandmaster
-            );
-        }
-        else if (tierFilter.FilterGrandmaster == false)
-        {
-            query = query.Where(x =>
-                x.Rating < RatingUtils.RatingGrandmasterIII || x.Rating >= RatingUtils.RatingEliteGrandmaster
-            );
-        }
-
-        // Filter for Elite Grandmaster tier
-        if (tierFilter.FilterEliteGrandmaster == true)
-        {
-            query = query.Where(x => x.Rating >= RatingUtils.RatingEliteGrandmaster);
-        }
-        else if (tierFilter.FilterEliteGrandmaster == false)
-        {
-            query = query.Where(x => x.Rating < RatingUtils.RatingEliteGrandmaster);
-        }
-
-        return query;
+        return query.Where(x =>
+            (includeBronze && x.Rating < RatingUtils.RatingSilverIII)
+            || (includeSilver && x.Rating >= RatingUtils.RatingSilverIII && x.Rating < RatingUtils.RatingGoldIII)
+            || (includeGold && x.Rating >= RatingUtils.RatingGoldIII && x.Rating < RatingUtils.RatingPlatinumIII)
+            || (includePlatinum && x.Rating >= RatingUtils.RatingPlatinumIII && x.Rating < RatingUtils.RatingEmeraldIII)
+            || (includeEmerald && x.Rating >= RatingUtils.RatingEmeraldIII && x.Rating < RatingUtils.RatingDiamondIII)
+            || (includeDiamond && x.Rating >= RatingUtils.RatingDiamondIII && x.Rating < RatingUtils.RatingMasterIII)
+            || (includeMaster && x.Rating >= RatingUtils.RatingMasterIII && x.Rating < RatingUtils.RatingGrandmasterIII)
+            || (includeGrandmaster && x.Rating >= RatingUtils.RatingGrandmasterIII && x.Rating < RatingUtils.RatingEliteGrandmaster)
+            || (includeEliteGrandmaster && x.Rating >= RatingUtils.RatingEliteGrandmaster)
+        );
     }
 }

--- a/API/Repositories/Implementations/BeatmapRepository.cs
+++ b/API/Repositories/Implementations/BeatmapRepository.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using API.DTOs;
 using API.Entities;
 using API.Repositories.Interfaces;
 using Microsoft.EntityFrameworkCore;

--- a/API/Services/Implementations/PlayerStatsService.cs
+++ b/API/Services/Implementations/PlayerStatsService.cs
@@ -4,7 +4,6 @@ using API.Enums;
 using API.Repositories.Interfaces;
 using API.Services.Interfaces;
 using API.Utilities;
-using AutoMapper;
 
 namespace API.Services.Implementations;
 

--- a/API/Utilities/LeaderboardExtensions.cs
+++ b/API/Utilities/LeaderboardExtensions.cs
@@ -4,28 +4,21 @@ namespace API.Utilities;
 
 public static class LeaderboardExtensions
 {
-    public static bool IsInvalid(this LeaderboardTierFilterDTO? filter)
+    public static bool IsEngaged(this LeaderboardTierFilterDTO? filter)
     {
         if (filter == null)
         {
             return false;
         }
 
-        if (
-            filter.FilterBronze == false
-            && filter.FilterSilver == false
-            && filter.FilterGold == false
-            && filter.FilterPlatinum == false
-            && filter.FilterEmerald == false
-            && filter.FilterDiamond == false
-            && filter.FilterMaster == false
-            && filter.FilterGrandmaster == false
-            && filter.FilterEliteGrandmaster == false
-        )
-        {
-            return true;
-        }
-
-        return false;
+        return filter.FilterBronze
+               || filter.FilterSilver
+               || filter.FilterGold
+               || filter.FilterPlatinum
+               || filter.FilterEmerald
+               || filter.FilterDiamond
+               || filter.FilterMaster
+               || filter.FilterGrandmaster
+               || filter.FilterEliteGrandmaster;
     }
 }

--- a/API/Utilities/RatingUtils.cs
+++ b/API/Utilities/RatingUtils.cs
@@ -296,4 +296,47 @@ public static class RatingUtils
 
     public static bool IsProvisional(double volatility, int matchesPlayed, int tournamentsPlayed) =>
         volatility >= 200.0 || matchesPlayed <= 8 || tournamentsPlayed <= 2;
+
+    public static bool IsEliteGrandmaster(string tier) =>
+        tier == GetTier(RatingEliteGrandmaster);
+
+    public static bool IsGrandmaster(string tier) =>
+        tier == GetTier(RatingGrandmasterIII) ||
+        tier == GetTier(RatingGrandmasterII) ||
+        tier == GetTier(RatingGrandmasterI);
+
+    public static bool IsMaster(string tier) =>
+        tier == GetTier(RatingMasterIII) ||
+        tier == GetTier(RatingMasterII) ||
+        tier == GetTier(RatingMasterI);
+
+    public static bool IsDiamond(string tier) =>
+        tier == GetTier(RatingDiamondIII) ||
+        tier == GetTier(RatingDiamondII) ||
+        tier == GetTier(RatingDiamondI);
+
+    public static bool IsEmerald(string tier) =>
+        tier == GetTier(RatingEmeraldIII) ||
+        tier == GetTier(RatingEmeraldII) ||
+        tier == GetTier(RatingEmeraldI);
+
+    public static bool IsPlatinum(string tier) =>
+        tier == GetTier(RatingPlatinumIII) ||
+        tier == GetTier(RatingPlatinumII) ||
+        tier == GetTier(RatingPlatinumI);
+
+    public static bool IsGold(string tier) =>
+        tier == GetTier(RatingGoldIII) ||
+        tier == GetTier(RatingGoldII) ||
+        tier == GetTier(RatingGoldI);
+
+    public static bool IsSilver(string tier) =>
+        tier == GetTier(RatingSilverIII) ||
+        tier == GetTier(RatingSilverII) ||
+        tier == GetTier(RatingSilverI);
+
+    public static bool IsBronze(string tier) =>
+        tier == GetTier(RatingBronzeIII) ||
+        tier == GetTier(RatingBronzeII) ||
+        tier == GetTier(RatingBronzeI);
 }

--- a/APITests/MockRepositories/MockPlayerRepository.cs
+++ b/APITests/MockRepositories/MockPlayerRepository.cs
@@ -1,5 +1,4 @@
 using API.Repositories.Interfaces;
-using APITests.SeedData;
 using Moq;
 
 namespace APITests.MockRepositories;

--- a/APITests/SeedData/SeededBaseStats.cs
+++ b/APITests/SeedData/SeededBaseStats.cs
@@ -38,14 +38,9 @@ public static class SeededBaseStats
         var lb = new List<BaseStats>();
         LeaderboardTierFilterDTO? tiers = filter.TierFilters;
 
-        if (tiers == null)
+        if (tiers == null || !tiers.IsEngaged())
         {
             return GetSimpleLeaderboard();
-        }
-
-        if (tiers.IsInvalid())
-        {
-            throw new ArgumentException("The tier filter is invalid");
         }
 
         // Add all of the tiers that are true

--- a/APITests/Services/LeaderboardServiceTests.cs
+++ b/APITests/Services/LeaderboardServiceTests.cs
@@ -72,43 +72,6 @@ public class LeaderboardServiceTests
         );
     }
 
-    [Fact]
-    public void LeaderboardFilters_Invalid_WhenAllFiltersFalse()
-    {
-        // Arrange
-        var filter = new LeaderboardFilterDTO
-        {
-            TierFilters = new LeaderboardTierFilterDTO
-            {
-                FilterBronze = false,
-                FilterSilver = false,
-                FilterGold = false,
-                FilterPlatinum = false,
-                FilterEmerald = false,
-                FilterDiamond = false,
-                FilterMaster = false,
-                FilterGrandmaster = false,
-                FilterEliteGrandmaster = false
-            }
-        };
-        // Act
-
-        // Assert
-        Assert.True(filter.TierFilters.IsInvalid());
-    }
-
-    [Fact]
-    public void LeaderboardFilters_Valid_WhenNull()
-    {
-        // Arrange
-        var filter = new LeaderboardFilterDTO { TierFilters = null };
-
-        // Act
-
-        // Assert
-        Assert.False(filter.TierFilters.IsInvalid());
-    }
-
     [Theory]
     [InlineData(0)]
     [InlineData(1)]
@@ -139,15 +102,7 @@ public class LeaderboardServiceTests
             {
                 TierFilters = new LeaderboardTierFilterDTO
                 {
-                    FilterEliteGrandmaster = true,
-                    FilterGrandmaster = false,
-                    FilterMaster = false,
-                    FilterEmerald = false,
-                    FilterDiamond = false,
-                    FilterPlatinum = false,
-                    FilterGold = false,
-                    FilterSilver = false,
-                    FilterBronze = false
+                    FilterEliteGrandmaster = true
                 }
             }
         };
@@ -156,7 +111,7 @@ public class LeaderboardServiceTests
         LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
 
         // Assert
-        Assert.All(lb.Leaderboard, x => Assert.Equal("Elite Grandmaster", x.Tier));
+        Assert.All(lb.Leaderboard, x => Assert.True(RatingUtils.IsEliteGrandmaster(x.Tier)));
     }
 
     [Fact]
@@ -171,15 +126,7 @@ public class LeaderboardServiceTests
             {
                 TierFilters = new LeaderboardTierFilterDTO
                 {
-                    FilterEliteGrandmaster = false,
-                    FilterGrandmaster = true,
-                    FilterMaster = false,
-                    FilterEmerald = false,
-                    FilterDiamond = false,
-                    FilterPlatinum = false,
-                    FilterGold = false,
-                    FilterSilver = false,
-                    FilterBronze = false
+                    FilterGrandmaster = true
                 }
             }
         };
@@ -188,7 +135,7 @@ public class LeaderboardServiceTests
         LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
 
         // Assert
-        Assert.All(lb.Leaderboard, x => Assert.Contains("Grandmaster", x.Tier));
+        Assert.All(lb.Leaderboard, x => Assert.True(RatingUtils.IsGrandmaster(x.Tier)));
     }
 
     [Fact]
@@ -203,15 +150,7 @@ public class LeaderboardServiceTests
             {
                 TierFilters = new LeaderboardTierFilterDTO
                 {
-                    FilterEliteGrandmaster = false,
-                    FilterGrandmaster = false,
-                    FilterMaster = true,
-                    FilterEmerald = false,
-                    FilterDiamond = false,
-                    FilterPlatinum = false,
-                    FilterGold = false,
-                    FilterSilver = false,
-                    FilterBronze = false
+                    FilterMaster = true
                 }
             }
         };
@@ -220,7 +159,7 @@ public class LeaderboardServiceTests
         LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
 
         // Assert
-        Assert.All(lb.Leaderboard, x => Assert.Contains("Master", x.Tier));
+        Assert.All(lb.Leaderboard, x => Assert.True(RatingUtils.IsMaster(x.Tier)));
     }
 
     [Fact]
@@ -235,15 +174,7 @@ public class LeaderboardServiceTests
             {
                 TierFilters = new LeaderboardTierFilterDTO
                 {
-                    FilterEliteGrandmaster = false,
-                    FilterGrandmaster = false,
-                    FilterMaster = false,
-                    FilterEmerald = false,
-                    FilterDiamond = true,
-                    FilterPlatinum = false,
-                    FilterGold = false,
-                    FilterSilver = false,
-                    FilterBronze = false
+                    FilterDiamond = true
                 }
             }
         };
@@ -252,7 +183,7 @@ public class LeaderboardServiceTests
         LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
 
         // Assert
-        Assert.All(lb.Leaderboard, x => Assert.Contains("Diamond", x.Tier));
+        Assert.All(lb.Leaderboard, x => Assert.True(RatingUtils.IsDiamond(x.Tier)));
     }
 
     [Fact]
@@ -267,15 +198,7 @@ public class LeaderboardServiceTests
             {
                 TierFilters = new LeaderboardTierFilterDTO
                 {
-                    FilterEliteGrandmaster = false,
-                    FilterGrandmaster = false,
-                    FilterMaster = false,
-                    FilterEmerald = true,
-                    FilterDiamond = false,
-                    FilterPlatinum = false,
-                    FilterGold = false,
-                    FilterSilver = false,
-                    FilterBronze = false
+                    FilterEmerald = true
                 }
             }
         };
@@ -284,7 +207,7 @@ public class LeaderboardServiceTests
         LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
 
         // Assert
-        Assert.All(lb.Leaderboard, x => Assert.Contains("Emerald", x.Tier));
+        Assert.All(lb.Leaderboard, x => Assert.True(RatingUtils.IsEmerald(x.Tier)));
     }
 
     [Fact]
@@ -299,15 +222,7 @@ public class LeaderboardServiceTests
             {
                 TierFilters = new LeaderboardTierFilterDTO
                 {
-                    FilterEliteGrandmaster = false,
-                    FilterGrandmaster = false,
-                    FilterMaster = false,
-                    FilterEmerald = false,
-                    FilterDiamond = false,
-                    FilterPlatinum = true,
-                    FilterGold = false,
-                    FilterSilver = false,
-                    FilterBronze = false
+                    FilterPlatinum = true
                 }
             }
         };
@@ -316,7 +231,7 @@ public class LeaderboardServiceTests
         LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
 
         // Assert
-        Assert.All(lb.Leaderboard, x => Assert.Contains("Platinum", x.Tier));
+        Assert.All(lb.Leaderboard, x => Assert.True(RatingUtils.IsPlatinum(x.Tier)));
     }
 
     [Fact]
@@ -331,15 +246,7 @@ public class LeaderboardServiceTests
             {
                 TierFilters = new LeaderboardTierFilterDTO
                 {
-                    FilterEliteGrandmaster = false,
-                    FilterGrandmaster = false,
-                    FilterMaster = false,
-                    FilterEmerald = false,
-                    FilterDiamond = false,
-                    FilterPlatinum = false,
-                    FilterGold = true,
-                    FilterSilver = false,
-                    FilterBronze = false
+                    FilterGold = true
                 }
             }
         };
@@ -348,7 +255,7 @@ public class LeaderboardServiceTests
         LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
 
         // Assert
-        Assert.All(lb.Leaderboard, x => Assert.Contains("Gold", x.Tier));
+        Assert.All(lb.Leaderboard, x => Assert.True(RatingUtils.IsGold(x.Tier)));
     }
 
     [Fact]
@@ -363,15 +270,7 @@ public class LeaderboardServiceTests
             {
                 TierFilters = new LeaderboardTierFilterDTO
                 {
-                    FilterEliteGrandmaster = false,
-                    FilterGrandmaster = false,
-                    FilterMaster = false,
-                    FilterEmerald = false,
-                    FilterDiamond = false,
-                    FilterPlatinum = false,
-                    FilterGold = false,
-                    FilterSilver = true,
-                    FilterBronze = false
+                    FilterSilver = true
                 }
             }
         };
@@ -380,7 +279,7 @@ public class LeaderboardServiceTests
         LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
 
         // Assert
-        Assert.All(lb.Leaderboard, x => Assert.Contains("Silver", x.Tier));
+        Assert.All(lb.Leaderboard, x => Assert.True(RatingUtils.IsSilver(x.Tier)));
     }
 
     [Fact]
@@ -395,14 +294,6 @@ public class LeaderboardServiceTests
             {
                 TierFilters = new LeaderboardTierFilterDTO
                 {
-                    FilterEliteGrandmaster = false,
-                    FilterGrandmaster = false,
-                    FilterMaster = false,
-                    FilterEmerald = false,
-                    FilterDiamond = false,
-                    FilterPlatinum = false,
-                    FilterGold = false,
-                    FilterSilver = false,
                     FilterBronze = true
                 }
             }
@@ -412,7 +303,7 @@ public class LeaderboardServiceTests
         LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
 
         // Assert
-        Assert.All(lb.Leaderboard, x => Assert.Contains("Bronze", x.Tier));
+        Assert.All(lb.Leaderboard, x => Assert.True(RatingUtils.IsBronze(x.Tier)));
     }
 
     [Fact]
@@ -444,19 +335,19 @@ public class LeaderboardServiceTests
 
         // Assert
         Assert.All(lb.Leaderboard, x => Assert.NotNull(x.Tier));
-        Assert.Contains(lb.Leaderboard, x => x.Tier == "Elite Grandmaster");
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Grandmaster"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Master"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Emerald"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Diamond"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Platinum"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Gold"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Silver"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Bronze"));
+        Assert.Contains(lb.Leaderboard, x => RatingUtils.IsEliteGrandmaster(x.Tier));
+        Assert.Contains(lb.Leaderboard, x => RatingUtils.IsGrandmaster(x.Tier));
+        Assert.Contains(lb.Leaderboard, x => RatingUtils.IsMaster(x.Tier));
+        Assert.Contains(lb.Leaderboard, x => RatingUtils.IsDiamond(x.Tier));
+        Assert.Contains(lb.Leaderboard, x => RatingUtils.IsEmerald(x.Tier));
+        Assert.Contains(lb.Leaderboard, x => RatingUtils.IsPlatinum(x.Tier));
+        Assert.Contains(lb.Leaderboard, x => RatingUtils.IsGold(x.Tier));
+        Assert.Contains(lb.Leaderboard, x => RatingUtils.IsSilver(x.Tier));
+        Assert.Contains(lb.Leaderboard, x => RatingUtils.IsBronze(x.Tier));
     }
 
     [Fact]
-    public async Task GetLeaderboardAsync_ExcludesEliteGrandmaster_WhenRequested()
+    public async Task GetLeaderboardAsync_SpecificallyIncludes_Bronze_Grandmaster_WhenRequested()
     {
         // Arrange
         var filter = new LeaderboardRequestQueryDTO
@@ -466,14 +357,7 @@ public class LeaderboardServiceTests
             {
                 TierFilters = new LeaderboardTierFilterDTO
                 {
-                    FilterEliteGrandmaster = false,
                     FilterGrandmaster = true,
-                    FilterMaster = true,
-                    FilterEmerald = true,
-                    FilterDiamond = true,
-                    FilterPlatinum = true,
-                    FilterGold = true,
-                    FilterSilver = true,
                     FilterBronze = true
                 }
             }
@@ -483,19 +367,19 @@ public class LeaderboardServiceTests
         LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
 
         // Assert
-        Assert.DoesNotContain(lb.Leaderboard, x => x.Tier == "Elite Grandmaster");
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Grandmaster"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Master"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Emerald"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Diamond"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Platinum"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Gold"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Silver"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Bronze"));
+        Assert.DoesNotContain(lb.Leaderboard, x => RatingUtils.IsEliteGrandmaster(x.Tier));
+        Assert.Contains(lb.Leaderboard, x => RatingUtils.IsGrandmaster(x.Tier));
+        Assert.DoesNotContain(lb.Leaderboard, x => RatingUtils.IsMaster(x.Tier));
+        Assert.DoesNotContain(lb.Leaderboard, x => RatingUtils.IsDiamond(x.Tier));
+        Assert.DoesNotContain(lb.Leaderboard, x => RatingUtils.IsEmerald(x.Tier));
+        Assert.DoesNotContain(lb.Leaderboard, x => RatingUtils.IsPlatinum(x.Tier));
+        Assert.DoesNotContain(lb.Leaderboard, x => RatingUtils.IsGold(x.Tier));
+        Assert.DoesNotContain(lb.Leaderboard, x => RatingUtils.IsSilver(x.Tier));
+        Assert.Contains(lb.Leaderboard, x => RatingUtils.IsBronze(x.Tier));
     }
 
     [Fact]
-    public async Task GetLeaderboardAsync_ExcludesGrandmaster_WhenRequested()
+    public async Task GetLeaderboardAsync_SpecificallyIncludes_Silver_Diamond_EliteGrandmaster_WhenRequested()
     {
         // Arrange
         var filter = new LeaderboardRequestQueryDTO
@@ -506,14 +390,8 @@ public class LeaderboardServiceTests
                 TierFilters = new LeaderboardTierFilterDTO
                 {
                     FilterEliteGrandmaster = true,
-                    FilterGrandmaster = false,
-                    FilterMaster = true,
-                    FilterEmerald = true,
                     FilterDiamond = true,
-                    FilterPlatinum = true,
-                    FilterGold = true,
                     FilterSilver = true,
-                    FilterBronze = true
                 }
             }
         };
@@ -522,291 +400,14 @@ public class LeaderboardServiceTests
         LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
 
         // Assert
-
-        Assert.Contains(lb.Leaderboard, x => x.Tier == "Elite Grandmaster");
-        Assert.DoesNotContain(
-            lb.Leaderboard,
-            x => x.Tier.Contains("Grandmaster") && x.Tier != "Elite Grandmaster"
-        );
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Master"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Emerald"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Diamond"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Platinum"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Gold"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Silver"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Bronze"));
-    }
-
-    [Fact]
-    public async Task GetLeaderboardAsync_ExcludesMaster_WhenRequested()
-    {
-        // Arrange
-        var filter = new LeaderboardRequestQueryDTO
-        {
-            Mode = 0,
-            Filter = new LeaderboardFilterDTO
-            {
-                TierFilters = new LeaderboardTierFilterDTO
-                {
-                    FilterEliteGrandmaster = true,
-                    FilterGrandmaster = true,
-                    FilterMaster = false,
-                    FilterEmerald = true,
-                    FilterDiamond = true,
-                    FilterPlatinum = true,
-                    FilterGold = true,
-                    FilterSilver = true,
-                    FilterBronze = true
-                }
-            }
-        };
-
-        // Act
-        LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
-
-        // Assert
-
-        Assert.Contains(lb.Leaderboard, x => x.Tier == "Elite Grandmaster");
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Grandmaster"));
-        Assert.DoesNotContain(lb.Leaderboard, x => x.Tier.Contains("Master"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Emerald"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Diamond"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Platinum"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Gold"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Silver"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Bronze"));
-    }
-
-    [Fact]
-    public async Task GetLeaderboardAsync_ExcludesEmerald_WhenRequested()
-    {
-        // Arrange
-        var filter = new LeaderboardRequestQueryDTO
-        {
-            Mode = 0,
-            Filter = new LeaderboardFilterDTO
-            {
-                TierFilters = new LeaderboardTierFilterDTO
-                {
-                    FilterEliteGrandmaster = true,
-                    FilterGrandmaster = true,
-                    FilterMaster = true,
-                    FilterEmerald = false,
-                    FilterDiamond = true,
-                    FilterPlatinum = true,
-                    FilterGold = true,
-                    FilterSilver = true,
-                    FilterBronze = true
-                }
-            }
-        };
-
-        // Act
-        LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
-
-        Assert.Contains(lb.Leaderboard, x => x.Tier == "Elite Grandmaster");
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Grandmaster"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Master"));
-        Assert.DoesNotContain(lb.Leaderboard, x => x.Tier.Contains("Emerald"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Diamond"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Platinum"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Gold"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Silver"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Bronze"));
-    }
-
-    [Fact]
-    public async Task GetLeaderboardAsync_ExcludesDiamond_WhenRequested()
-    {
-        // Arrange
-        var filter = new LeaderboardRequestQueryDTO
-        {
-            Mode = 0,
-            Filter = new LeaderboardFilterDTO
-            {
-                TierFilters = new LeaderboardTierFilterDTO
-                {
-                    FilterEliteGrandmaster = true,
-                    FilterGrandmaster = true,
-                    FilterMaster = true,
-                    FilterEmerald = true,
-                    FilterDiamond = false,
-                    FilterPlatinum = true,
-                    FilterGold = true,
-                    FilterSilver = true,
-                    FilterBronze = true
-                }
-            }
-        };
-
-        // Act
-        LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
-
-        // Assert
-        Assert.Contains(lb.Leaderboard, x => x.Tier == "Elite Grandmaster");
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Grandmaster"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Master"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Emerald"));
-        Assert.DoesNotContain(lb.Leaderboard, x => x.Tier.Contains("Diamond"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Platinum"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Gold"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Silver"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Bronze"));
-    }
-
-    [Fact]
-    public async Task GetLeaderboardAsync_ExcludesPlatinum_WhenRequested()
-    {
-        // Arrange
-        var filter = new LeaderboardRequestQueryDTO
-        {
-            Mode = 0,
-            Filter = new LeaderboardFilterDTO
-            {
-                TierFilters = new LeaderboardTierFilterDTO
-                {
-                    FilterEliteGrandmaster = true,
-                    FilterGrandmaster = true,
-                    FilterMaster = true,
-                    FilterEmerald = true,
-                    FilterDiamond = true,
-                    FilterPlatinum = false,
-                    FilterGold = true,
-                    FilterSilver = true,
-                    FilterBronze = true
-                }
-            }
-        };
-
-        // Act
-        LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
-
-        // Assert
-        Assert.Contains(lb.Leaderboard, x => x.Tier == "Elite Grandmaster");
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Grandmaster"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Master"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Emerald"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Diamond"));
-        Assert.DoesNotContain(lb.Leaderboard, x => x.Tier.Contains("Platinum"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Gold"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Silver"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Bronze"));
-    }
-
-    [Fact]
-    public async Task GetLeaderboardAsync_ExcludesGold_WhenRequested()
-    {
-        // Arrange
-        var filter = new LeaderboardRequestQueryDTO
-        {
-            Mode = 0,
-            Filter = new LeaderboardFilterDTO
-            {
-                TierFilters = new LeaderboardTierFilterDTO
-                {
-                    FilterEliteGrandmaster = true,
-                    FilterGrandmaster = true,
-                    FilterMaster = true,
-                    FilterEmerald = true,
-                    FilterDiamond = true,
-                    FilterPlatinum = true,
-                    FilterGold = false,
-                    FilterSilver = true,
-                    FilterBronze = true
-                }
-            }
-        };
-
-        // Act
-        LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
-
-        // Assert
-        Assert.Contains(lb.Leaderboard, x => x.Tier == "Elite Grandmaster");
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Grandmaster"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Master"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Emerald"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Diamond"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Platinum"));
-        Assert.DoesNotContain(lb.Leaderboard, x => x.Tier.Contains("Gold"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Silver"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Bronze"));
-    }
-
-    [Fact]
-    public async Task GetLeaderboardAsync_ExcludesSilver_WhenRequested()
-    {
-        // Arrange
-        var filter = new LeaderboardRequestQueryDTO
-        {
-            Mode = 0,
-            Filter = new LeaderboardFilterDTO
-            {
-                TierFilters = new LeaderboardTierFilterDTO
-                {
-                    FilterEliteGrandmaster = true,
-                    FilterGrandmaster = true,
-                    FilterMaster = true,
-                    FilterEmerald = true,
-                    FilterDiamond = true,
-                    FilterPlatinum = true,
-                    FilterGold = true,
-                    FilterSilver = false,
-                    FilterBronze = true
-                }
-            }
-        };
-
-        // Act
-        LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
-
-        // Assert
-        Assert.Contains(lb.Leaderboard, x => x.Tier == "Elite Grandmaster");
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Grandmaster"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Master"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Emerald"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Diamond"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Platinum"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Gold"));
-        Assert.DoesNotContain(lb.Leaderboard, x => x.Tier.Contains("Silver"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Bronze"));
-    }
-
-    [Fact]
-    public async Task GetLeaderboardAsync_ExcludesBronze_WhenRequested()
-    {
-        // Arrange
-        var filter = new LeaderboardRequestQueryDTO
-        {
-            Mode = 0,
-            Filter = new LeaderboardFilterDTO
-            {
-                TierFilters = new LeaderboardTierFilterDTO
-                {
-                    FilterEliteGrandmaster = true,
-                    FilterGrandmaster = true,
-                    FilterMaster = true,
-                    FilterEmerald = true,
-                    FilterDiamond = true,
-                    FilterPlatinum = true,
-                    FilterGold = true,
-                    FilterSilver = true,
-                    FilterBronze = false
-                }
-            }
-        };
-
-        // Act
-        LeaderboardDTO lb = await _leaderboardService.GetLeaderboardAsync(filter);
-
-        // Assert
-        Assert.Contains(lb.Leaderboard, x => x.Tier == "Elite Grandmaster");
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Grandmaster"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Master"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Emerald"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Diamond"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Platinum"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Gold"));
-        Assert.Contains(lb.Leaderboard, x => x.Tier.Contains("Silver"));
-        Assert.DoesNotContain(lb.Leaderboard, x => x.Tier.Contains("Bronze"));
+        Assert.Contains(lb.Leaderboard, x => RatingUtils.IsEliteGrandmaster(x.Tier));
+        Assert.DoesNotContain(lb.Leaderboard, x => RatingUtils.IsGrandmaster(x.Tier));
+        Assert.DoesNotContain(lb.Leaderboard, x => RatingUtils.IsMaster(x.Tier));
+        Assert.Contains(lb.Leaderboard, x => RatingUtils.IsDiamond(x.Tier));
+        Assert.DoesNotContain(lb.Leaderboard, x => RatingUtils.IsEmerald(x.Tier));
+        Assert.DoesNotContain(lb.Leaderboard, x => RatingUtils.IsPlatinum(x.Tier));
+        Assert.DoesNotContain(lb.Leaderboard, x => RatingUtils.IsGold(x.Tier));
+        Assert.Contains(lb.Leaderboard, x => RatingUtils.IsSilver(x.Tier));
+        Assert.DoesNotContain(lb.Leaderboard, x => RatingUtils.IsBronze(x.Tier));
     }
 }

--- a/APITests/Utilities/LeaderboardExtensionsTests.cs
+++ b/APITests/Utilities/LeaderboardExtensionsTests.cs
@@ -164,9 +164,9 @@ public class LeaderboardExtensionsTests
 
         Assert.Multiple(() =>
         {
-             Assert.True(RatingUtils.IsDiamond(lbInfo.Tier));
-             Assert.True(RatingUtils.IsDiamond(lbInfo2.Tier));
-             Assert.True(RatingUtils.IsDiamond(lbInfo3.Tier));
+            Assert.True(RatingUtils.IsDiamond(lbInfo.Tier));
+            Assert.True(RatingUtils.IsDiamond(lbInfo2.Tier));
+            Assert.True(RatingUtils.IsDiamond(lbInfo3.Tier));
         });
     }
 

--- a/APITests/Utilities/LeaderboardExtensionsTests.cs
+++ b/APITests/Utilities/LeaderboardExtensionsTests.cs
@@ -1,0 +1,302 @@
+using API.DTOs;
+using API.Utilities;
+
+namespace APITests.Utilities;
+
+public class LeaderboardExtensionsTests
+{
+    [Fact]
+    public void IsEngaged_NullFilter_ReturnsFalse()
+    {
+        LeaderboardTierFilterDTO? filter = null;
+        Assert.False(filter.IsEngaged());
+    }
+
+    [Fact]
+    public void IsEngaged_EmptyFilter_ReturnsFalse()
+    {
+        var filter = new LeaderboardTierFilterDTO();
+        Assert.False(filter.IsEngaged());
+    }
+
+    [Fact]
+    public void IsEngaged_FilterWithAnyTrue_ReturnsTrue()
+    {
+        var filter = new LeaderboardTierFilterDTO
+        {
+            FilterBronze = true
+        };
+
+        var filter2 = new LeaderboardTierFilterDTO
+        {
+            FilterSilver = true
+        };
+
+        var filter3 = new LeaderboardTierFilterDTO
+        {
+            FilterGold = true
+        };
+
+        var filter4 = new LeaderboardTierFilterDTO
+        {
+            FilterPlatinum = true
+        };
+
+        var filter5 = new LeaderboardTierFilterDTO
+        {
+            FilterEmerald = true
+        };
+
+        var filter6 = new LeaderboardTierFilterDTO
+        {
+            FilterDiamond = true
+        };
+
+        var filter7 = new LeaderboardTierFilterDTO
+        {
+            FilterMaster = true
+        };
+
+        var filter8 = new LeaderboardTierFilterDTO
+        {
+            FilterGrandmaster = true
+        };
+
+        var filter9 = new LeaderboardTierFilterDTO
+        {
+            FilterEliteGrandmaster = true
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.True(filter.IsEngaged());
+            Assert.True(filter2.IsEngaged());
+            Assert.True(filter3.IsEngaged());
+            Assert.True(filter4.IsEngaged());
+            Assert.True(filter5.IsEngaged());
+            Assert.True(filter6.IsEngaged());
+            Assert.True(filter7.IsEngaged());
+            Assert.True(filter8.IsEngaged());
+            Assert.True(filter9.IsEngaged());
+        });
+    }
+
+    [Fact]
+    public void IsEliteGrandmasterTier_TierIsEliteGrandmaster_ReturnsTrue()
+    {
+        var lbInfo = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Elite Grandmaster"
+        };
+
+        Assert.True(RatingUtils.IsEliteGrandmaster(lbInfo.Tier));
+    }
+
+    [Fact]
+    public void IsGrandmasterTier_TierIsGrandmaster_ReturnsTrue()
+    {
+        var lbInfo = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Grandmaster I"
+        };
+
+        var lbInfo2 = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Grandmaster II"
+        };
+
+        var lbInfo3 = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Grandmaster III"
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.True(RatingUtils.IsGrandmaster(lbInfo.Tier));
+            Assert.True(RatingUtils.IsGrandmaster(lbInfo2.Tier));
+            Assert.True(RatingUtils.IsGrandmaster(lbInfo3.Tier));
+        });
+    }
+
+    [Fact]
+    public void IsMasterTier_TierIsMaster_ReturnsTrue()
+    {
+        var lbInfo = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Master I"
+        };
+
+        var lbInfo2 = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Master II"
+        };
+
+        var lbInfo3 = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Master III"
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.True(RatingUtils.IsMaster(lbInfo.Tier));
+            Assert.True(RatingUtils.IsMaster(lbInfo2.Tier));
+            Assert.True(RatingUtils.IsMaster(lbInfo3.Tier));
+        });
+    }
+
+    [Fact]
+    public void IsDiamondTier_TierIsDiamond_ReturnsTrue()
+    {
+        var lbInfo = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Diamond I"
+        };
+
+        var lbInfo2 = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Diamond II"
+        };
+
+        var lbInfo3 = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Diamond III"
+        };
+
+        Assert.Multiple(() =>
+        {
+             Assert.True(RatingUtils.IsDiamond(lbInfo.Tier));
+             Assert.True(RatingUtils.IsDiamond(lbInfo2.Tier));
+             Assert.True(RatingUtils.IsDiamond(lbInfo3.Tier));
+        });
+    }
+
+    [Fact]
+    public void IsEmeraldTier_TierIsEmerald_ReturnsTrue()
+    {
+        var lbInfo = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Emerald I"
+        };
+
+        var lbInfo2 = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Emerald II"
+        };
+
+        var lbInfo3 = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Emerald III"
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.True(RatingUtils.IsEmerald(lbInfo.Tier));
+            Assert.True(RatingUtils.IsEmerald(lbInfo2.Tier));
+            Assert.True(RatingUtils.IsEmerald(lbInfo3.Tier));
+        });
+    }
+
+    [Fact]
+    public void IsPlatinumTier_TierIsPlatinum_ReturnsTrue()
+    {
+        var lbInfo = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Platinum I"
+        };
+
+        var lbInfo2 = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Platinum II"
+        };
+
+        var lbInfo3 = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Platinum III"
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.True(RatingUtils.IsPlatinum(lbInfo.Tier));
+            Assert.True(RatingUtils.IsPlatinum(lbInfo2.Tier));
+            Assert.True(RatingUtils.IsPlatinum(lbInfo3.Tier));
+        });
+    }
+
+    [Fact]
+    public void IsGoldTier_TierIsGold_ReturnsTrue()
+    {
+        var lbInfo = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Gold I"
+        };
+
+        var lbInfo2 = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Gold II"
+        };
+
+        var lbInfo3 = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Gold III"
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.True(RatingUtils.IsGold(lbInfo.Tier));
+            Assert.True(RatingUtils.IsGold(lbInfo2.Tier));
+            Assert.True(RatingUtils.IsGold(lbInfo3.Tier));
+        });
+    }
+
+    [Fact]
+    public void IsSilverTier_TierIsSilver_ReturnsTrue()
+    {
+        var lbInfo = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Silver I"
+        };
+
+        var lbInfo2 = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Silver II"
+        };
+
+        var lbInfo3 = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Silver III"
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.True(RatingUtils.IsSilver(lbInfo.Tier));
+            Assert.True(RatingUtils.IsSilver(lbInfo2.Tier));
+            Assert.True(RatingUtils.IsSilver(lbInfo3.Tier));
+        });
+    }
+
+    [Fact]
+    public void IsBronzeTier_TierIsBronze_ReturnsTrue()
+    {
+        var lbInfo = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Bronze I"
+        };
+
+        var lbInfo2 = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Bronze II"
+        };
+
+        var lbInfo3 = new LeaderboardPlayerInfoDTO
+        {
+            Tier = "Bronze III"
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.True(RatingUtils.IsBronze(lbInfo.Tier));
+            Assert.True(RatingUtils.IsBronze(lbInfo2.Tier));
+            Assert.True(RatingUtils.IsBronze(lbInfo3.Tier));
+        });
+    }
+}


### PR DESCRIPTION
## Dependencies

- [x] https://github.com/osu-tournament-rating/otr-web/issues/138

## Overview

Closes #216 

This PR modifies the behavior of the leaderboard filter significantly, specifically targeting how tier filters are managed.

* Leaderboard tier filters no longer have the ability to be `null`. Now, `false` is the default designation and applies no logic.
* Removes "explicit exclude" functionality. Now, a leaderboard tier filter is 'engaged' if any of the tier filters are `true`. While engaged, the leaderboard only returns tiers that are passed as `true`. For example, if a user requests `bronze=true&grandmaster=true`, all players that have `Bronze III - I` and `Grandmaster III - I` will be returned.
* Fixed broken behavior of explicit include in prior implementation. It simply didn't work before to include multiple tiers of differing rank ranges. For example, the request `I want players within TR ranges 300-500 and 1000-1200` failed to work at all.