### PR TITLE
Sort leaderboard by global rank

### DIFF
--- a/API/Services/Implementations/LeaderboardService.cs
+++ b/API/Services/Implementations/LeaderboardService.cs
@@ -96,7 +96,7 @@ public class LeaderboardService(
             );
         }
 
-        leaderboard.Leaderboard = leaderboardPlayerInfo;
+        leaderboard.Leaderboard = leaderboardPlayerInfo.OrderBy(x => x.GlobalRank);
         return leaderboard;
     }
 


### PR DESCRIPTION
There's currently a small cosmetic issue where the leaderboard is sorted by rating, rather than global rank. When many players have the same rating, the leaderboard's global ranks can get jumbled up as seen here.
![image](https://github.com/osu-tournament-rating/otr-api/assets/38370573/1add7594-0169-4997-add2-bae51f45b338)
