### PR TITLE
Add `/tournaments/{id}` and `/tournaments/{id}/matches` endpoints

### DIFF
--- a/API/Controllers/TournamentsController.cs
+++ b/API/Controllers/TournamentsController.cs
@@ -31,4 +31,32 @@ public class TournamentsController(ITournamentsService service) : Controller
 
         return Ok(res);
     }
+
+    [HttpGet("{id:int}")]
+    [Authorize(Roles = "admin, system")]
+    public async Task<IActionResult> GetAsync(int id)
+    {
+        TournamentDTO? tournament = await _service.GetAsync(id);
+
+        if (tournament == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(tournament);
+    }
+
+    [HttpGet("{id:int}/matches")]
+    [Authorize(Roles = "admin, system")]
+    public async Task<IActionResult> GetMatchesAsync(int id)
+    {
+        TournamentDTO? tournament = await _service.GetAsync(id);
+
+        if (tournament == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(tournament.Matches);
+    }
 }

--- a/API/DTOs/TournamentDTO.cs
+++ b/API/DTOs/TournamentDTO.cs
@@ -6,13 +6,42 @@ namespace API.DTOs;
 
 public class TournamentDTO
 {
+    /// <summary>
+    /// The name of the tournament
+    /// </summary>
     public string Name { get; set; } = null!;
+    /// <summary>
+    /// The tournament abbreviation (e.g. OWC2023)
+    /// </summary>
     public string Abbreviation { get; set; } = null!;
+    /// <summary>
+    /// The osu! forum post advertising this tournament
+    /// </summary>
     public string ForumUrl { get; set; } = null!;
+    /// <summary>
+    /// The 'higher skill' portion of the rank range. 1 for open rank.
+    /// e.g. a 10,000-50,000 tournament would have 10,000 for this value.
+    /// </summary>
     public int RankRangeLowerBound { get; set; }
+    /// <summary>
+    /// The tournament ruleset
+    /// </summary>
     public int Mode { get; set; }
+    /// <summary>
+    /// The expected in-match team size.
+    /// e.g. a 2v2 team size 4 tournament should have '2'
+    /// for this value.
+    /// </summary>
     public int TeamSize { get; set; }
     // Requested by Cytusine, normally we don't return this info.
+    /// <summary>
+    /// The time this tournament was submitted
+    /// </summary>
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
     public DateTime Created { get; set; }
+    /// <summary>
+    /// All associated match data. Null in bulk GET requests
+    /// (such as get all)
+    /// </summary>
+    public IEnumerable<MatchDTO>? Matches { get; set; }
 }

--- a/API/Services/Implementations/TournamentsService.cs
+++ b/API/Services/Implementations/TournamentsService.cs
@@ -1,4 +1,5 @@
 using API.DTOs;
+using API.Entities;
 using API.Repositories.Interfaces;
 using API.Services.Interfaces;
 using AutoMapper;
@@ -24,7 +25,7 @@ public class TournamentsService(ITournamentsRepository repository, IMapper mappe
 
     public async Task<IEnumerable<TournamentDTO>> GetAllAsync()
     {
-        IEnumerable<Entities.Tournament> items = await _repository.GetAllAsync();
+        IEnumerable<Tournament> items = await _repository.GetAllAsync();
         items = items.OrderBy(x => x.Name);
 
         return _mapper.Map<IEnumerable<TournamentDTO>>(items);
@@ -36,4 +37,16 @@ public class TournamentsService(ITournamentsRepository repository, IMapper mappe
         DateTime? dateMin = null,
         DateTime? dateMax = null
     ) => await _repository.CountPlayedAsync(playerId, mode, dateMin, dateMax);
+
+    public async Task<TournamentDTO?> GetAsync(int id)
+    {
+        Tournament? tournament = await _repository.GetAsync(id);
+
+        if (tournament == null)
+        {
+            return null;
+        }
+
+        return _mapper.Map<TournamentDTO>(tournament);
+    }
 }

--- a/API/Services/Interfaces/ITournamentsService.cs
+++ b/API/Services/Interfaces/ITournamentsService.cs
@@ -24,4 +24,10 @@ public interface ITournamentsService
     /// <param name="playerId"></param>
     /// <returns></returns>
     Task<int> CountPlayedAsync(int playerId, int mode, DateTime? dateMin = null, DateTime? dateMax = null);
+    /// <summary>
+    /// Returns the associated tournament (with match data) if it exists.
+    /// </summary>
+    /// <param name="id">The tournament id</param>
+    /// <returns></returns>
+    Task<TournamentDTO?> GetAsync(int id);
 }


### PR DESCRIPTION
Was needing a way to get a set of tournament data for testing the processor, so figured I'd go ahead and implement these. Docs will be implemented at a later point when we are 100% certain on the direction of API docs.

