### PR TITLE
Improve robustness of `GameAutomationChecks`

### DIFF
--- a/API/Osu/AutomationChecks/GameAutomationChecks.cs
+++ b/API/Osu/AutomationChecks/GameAutomationChecks.cs
@@ -54,8 +54,8 @@ public static class GameAutomationChecks
             return satisfiesOneVersusOne;
         }
 
-        var countRed = game.MatchScores.Count(s => s is { Team: (int)OsuEnums.Team.Red, Score: > AutomationChecksUtils.MINIMUM_SCORE });
-        var countBlue = game.MatchScores.Count(s => s is { Team: (int)OsuEnums.Team.Blue, Score: > AutomationChecksUtils.MINIMUM_SCORE });
+        var countRed = game.MatchScores.Count(s => s is { Team: (int)OsuEnums.Team.Red, Score: > AutomationChecksUtils.MinimumScore });
+        var countBlue = game.MatchScores.Count(s => s is { Team: (int)OsuEnums.Team.Blue, Score: > AutomationChecksUtils.MinimumScore });
 
         if (countRed == 0 && countBlue == 0)
         {
@@ -80,7 +80,7 @@ public static class GameAutomationChecks
              * - Exactly 1 score is below the minimum
              * - The team sizes are off by exactly 1
              */
-            hasReferee = game.MatchScores.Count(s => s.Score <= AutomationChecksUtils.MINIMUM_SCORE) == 1 &&
+            hasReferee = game.MatchScores.Count(s => s.Score <= AutomationChecksUtils.MinimumScore) == 1 &&
                           Math.Abs(countRed - countBlue) == 1;
             if (!hasReferee)
             {

--- a/API/Osu/AutomationChecks/GameAutomationChecks.cs
+++ b/API/Osu/AutomationChecks/GameAutomationChecks.cs
@@ -78,10 +78,13 @@ public static class GameAutomationChecks
              * Requirements for referee to be valid and present:
              *
              * - Exactly 1 score is below the minimum
-             * - The team sizes are off by exactly 1
+             * - The team sizes are uneven by exactly +1
+             * (meaning, if red has 3 players, blue has 2, and vice versa,
+             * NOT a 2v1 after accounting for the ref)
              */
             hasReferee = game.MatchScores.Count(s => s.Score <= AutomationChecksUtils.MinimumScore) == 1 &&
-                          Math.Abs(countRed - countBlue) == 1;
+                          (countRed == teamSize + 1 || countBlue == teamSize + 1);
+
             if (!hasReferee)
             {
                 s_logger.Information(

--- a/API/Utilities/AutomationChecksUtils.cs
+++ b/API/Utilities/AutomationChecksUtils.cs
@@ -1,0 +1,9 @@
+namespace API.Utilities;
+
+public static class AutomationChecksUtils
+{
+    /// <summary>
+    /// Exclude MatchScores that have scores less than or equal to this value
+    /// </summary>
+    public const int MINIMUM_SCORE = 1000;
+}

--- a/API/Utilities/AutomationChecksUtils.cs
+++ b/API/Utilities/AutomationChecksUtils.cs
@@ -5,5 +5,5 @@ public static class AutomationChecksUtils
     /// <summary>
     /// Exclude MatchScores that have scores less than or equal to this value
     /// </summary>
-    public const int MINIMUM_SCORE = 1000;
+    public const int MinimumScore = 1000;
 }

--- a/APITests/AutomationChecks/AutomationChecksTests.cs
+++ b/APITests/AutomationChecks/AutomationChecksTests.cs
@@ -315,6 +315,52 @@ public class AutomationChecksTests
     }
 
     [Fact]
+    public void Game_FailsTeamSizeCheck_WhenOneScoreIsZero()
+    {
+        API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
+        match.Games.First().MatchScores.First().Score = 0;
+
+        Assert.False(GameAutomationChecks.PassesTeamSizeCheck(match.Games.First()));
+    }
+
+    [Fact]
+    public void Game_FailsTeamSizeCheck_WhenFair2v2_And_ThreeScoresAreZero()
+    {
+        API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
+        match.Tournament.TeamSize = 2;
+
+        match.Games.First().MatchScores = new List<MatchScore>
+        {
+            new()
+            {
+                PlayerId = -1,
+                Score = 0,
+                Team = (int)OsuEnums.Team.Red
+            },
+            new()
+            {
+                PlayerId = -1,
+                Score = 0,
+                Team = (int)OsuEnums.Team.Red
+            },
+            new()
+            {
+                PlayerId = -1,
+                Score = 0,
+                Team = (int)OsuEnums.Team.Blue
+            },
+            new()
+            {
+                PlayerId = -1,
+                Score = 250_000,
+                Team = (int)OsuEnums.Team.Blue
+            }
+        };
+
+        Assert.False(GameAutomationChecks.PassesTeamSizeCheck(match.Games.First()));
+    }
+
+    [Fact]
     public void Game_FailsTeamSizeCheck_WhenDiffersFromTournamentSize()
     {
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
@@ -693,38 +739,39 @@ public class AutomationChecksTests
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
         match.Tournament.TeamSize = 2;
 
-        match
-            .Games.First()
-            .MatchScores.Add(
-                new MatchScore
-                {
-                    PlayerId = 0,
-                    Score = 0,
-                    Team = (int)OsuEnums.Team.Red
-                }
-            );
-
-        match
-            .Games.First()
-            .MatchScores.Add(
-                new MatchScore
-                {
-                    PlayerId = 0,
-                    Score = 500_000,
-                    Team = (int)OsuEnums.Team.Red
-                }
-            );
-
-        match
-            .Games.First()
-            .MatchScores.Add(
-                new MatchScore
-                {
-                    PlayerId = 0,
-                    Score = 500_000,
-                    Team = (int)OsuEnums.Team.Blue
-                }
-            );
+        match.Games.First().MatchScores = new List<MatchScore>()
+        {
+            new() // Referee
+            {
+                PlayerId = 0,
+                Score = 0,
+                Team = (int)OsuEnums.Team.Red
+            },
+            new()
+            {
+                PlayerId = 0,
+                Score = 100000,
+                Team = (int)OsuEnums.Team.Red
+            },
+            new()
+            {
+                PlayerId = 0,
+                Score = 100000,
+                Team = (int)OsuEnums.Team.Red
+            },
+            new()
+            {
+                PlayerId = 0,
+                Score = 100000,
+                Team = (int)OsuEnums.Team.Blue
+            },
+            new()
+            {
+                PlayerId = 0,
+                Score = 100000,
+                Team = (int)OsuEnums.Team.Blue
+            }
+        };
 
         Assert.True(GameAutomationChecks.PassesScoreSanityCheck(match.Games.First()));
         Assert.True(GameAutomationChecks.PassesTeamSizeCheck(match.Games.First()));

--- a/APITests/AutomationChecks/AutomationChecksTests.cs
+++ b/APITests/AutomationChecks/AutomationChecksTests.cs
@@ -734,7 +734,7 @@ public class AutomationChecksTests
     }
 
     [Fact]
-    public void Game_PassesSanity_WhenRefereeInLobby_TeamRed_2v2()
+    public void Game_PassesChecks_WhenRefereeInLobby_TeamRed_2v2()
     {
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
         match.Tournament.TeamSize = 2;
@@ -773,53 +773,92 @@ public class AutomationChecksTests
             }
         };
 
-        Assert.True(GameAutomationChecks.PassesScoreSanityCheck(match.Games.First()));
         Assert.True(GameAutomationChecks.PassesTeamSizeCheck(match.Games.First()));
         Assert.True(GameAutomationChecks.PassesAutomationChecks(match.Games.First()));
     }
 
     [Fact]
-    public void Game_PassesSanity_WhenRefereeInLobby_TeamBlue_2v2()
+    public void Game_PassesChecks_WhenRefereeInLobby_TeamBlue_2v2()
     {
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
         match.Tournament.TeamSize = 2;
 
-        match
-            .Games.First()
-            .MatchScores.Add(
-                new MatchScore
-                {
-                    PlayerId = 0,
-                    Score = 0,
-                    Team = (int)OsuEnums.Team.Blue
-                }
-            );
+        match.Games.First().MatchScores = new List<MatchScore>
+        {
+            new() // Referee
+            {
+                PlayerId = 0,
+                Score = 0,
+                Team = (int)OsuEnums.Team.Blue
+            },
+            new()
+            {
+                PlayerId = 0,
+                Score = 100000,
+                Team = (int)OsuEnums.Team.Red
+            },
+            new()
+            {
+                PlayerId = 0,
+                Score = 100000,
+                Team = (int)OsuEnums.Team.Red
+            },
+            new()
+            {
+                PlayerId = 0,
+                Score = 100000,
+                Team = (int)OsuEnums.Team.Blue
+            },
+            new()
+            {
+                PlayerId = 0,
+                Score = 100000,
+                Team = (int)OsuEnums.Team.Blue
+            }
+        };
 
-        match
-            .Games.First()
-            .MatchScores.Add(
-                new MatchScore
-                {
-                    PlayerId = 0,
-                    Score = 500_000,
-                    Team = (int)OsuEnums.Team.Red
-                }
-            );
-
-        match
-            .Games.First()
-            .MatchScores.Add(
-                new MatchScore
-                {
-                    PlayerId = 0,
-                    Score = 500_000,
-                    Team = (int)OsuEnums.Team.Blue
-                }
-            );
-
-        Assert.True(GameAutomationChecks.PassesScoreSanityCheck(match.Games.First()));
         Assert.True(GameAutomationChecks.PassesTeamSizeCheck(match.Games.First()));
         Assert.True(GameAutomationChecks.PassesAutomationChecks(match.Games.First()));
+    }
+
+    [Fact]
+    public void Game_FailsTeamSizeCheck_WhenOneZeroScore_CausesInvalid2v2()
+    {
+        // This test ensures that a player who earns 0 score is not
+        // accidentally flagged as a referee despite meeting a lot of the
+        // criteria
+        API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
+        match.Tournament.TeamSize = 2;
+
+        match.Games.First().MatchScores = new List<MatchScore>
+        {
+            new() // Player on team red gets 0 score, NOT a referee
+            {
+                PlayerId = 0,
+                Score = 0,
+                Team = (int)OsuEnums.Team.Red
+            },
+            new()
+            {
+                PlayerId = 0,
+                Score = 100000,
+                Team = (int)OsuEnums.Team.Red
+            },
+            new()
+            {
+                PlayerId = 0,
+                Score = 100000,
+                Team = (int)OsuEnums.Team.Blue
+            },
+            new()
+            {
+                PlayerId = 0,
+                Score = 100000,
+                Team = (int)OsuEnums.Team.Blue
+            }
+        };
+
+        Assert.False(GameAutomationChecks.PassesTeamSizeCheck(match.Games.First()));
     }
 
     // Scores

--- a/APITests/AutomationChecks/AutomationChecksTests.cs
+++ b/APITests/AutomationChecks/AutomationChecksTests.cs
@@ -6,7 +6,7 @@ using API.Osu.AutomationChecks;
 using API.Repositories.Interfaces;
 using Moq;
 
-namespace APITests.Osu;
+namespace APITests.AutomationChecks;
 
 [SuppressMessage("Usage", "xUnit1031:Do not use blocking task operations in test method")]
 public class AutomationChecksTests

--- a/APITests/AutomationChecks/MatchAutomationChecks_Warmups.cs
+++ b/APITests/AutomationChecks/MatchAutomationChecks_Warmups.cs
@@ -4,7 +4,7 @@ using API.Osu.AutomationChecks;
 using API.Osu.Multiplayer;
 using Newtonsoft.Json;
 
-namespace APITests.Osu;
+namespace APITests.AutomationChecks;
 
 public class MatchAutomationChecks_Warmups
 {


### PR DESCRIPTION
* Addresses issues related to checking for referees in lobby. Now, in a hypothetical 2v2 situation, referees will only be identified specifically when the team size is off by exactly 1, and only one player has a score below the minimum (currently 1000).
* In non-1v1 situations, scores less than the minimum will no longer count towards the counter for that team. For example, in a legal 2v2 (4 players in lobby), if one player on red gets <= 1000 score, that score will be removed. The check will see that there is a 1v2 for legal scores and will fail automated checks.

New tests have been added to cover the more complex scenarios for earning <=1000 score and to actually make sure we flag referees accurately. For example, new tests cover the fact that a referee should only be considered when there are *too many* players for an expected tournament team size. Previously, a 1v2 where a player earns 0 score would be flagged as a game that has a referee and would pass checks.