### PR TITLE
Improve `/api/v1/search` to use a single query parameter for all searches

### DIFF
--- a/API/Controllers/SearchController.cs
+++ b/API/Controllers/SearchController.cs
@@ -2,26 +2,30 @@ using API.DTOs;
 using API.Services.Interfaces;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Cors;
-using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
 namespace API.Controllers;
 
 [ApiController]
 [ApiVersion(1)]
-[EnableCors]
 [Authorize(Roles = "system")] // Internal access only at this time
 [Route("api/v{version:apiVersion}/[controller]")]
 public class SearchController(ISearchService service) : Controller
 {
-    private readonly ISearchService _searchService = service;
-
+    /// <summary>
+    /// Search for tournaments, matches, and users
+    /// </summary>
+    /// <remarks>
+    /// Allows for partial or full searching on the names of tournaments, matches, and usernames
+    /// </remarks>
+    /// <param name="searchKey">The string to match against names of tournaments, matches, and usernames</param>
+    /// <response code="404">If no data matches the given search key</response>
+    /// <response code="200">Returns a list of all possible tournaments, matches, and usernames for the given search key</response>
     [HttpGet]
     [EndpointSummary("Allows for partial or full searching on the names of tournaments, matches and usernames.")]
-    public async Task<Results<NotFound, Ok<List<SearchResponseDTO>>>> SearchByNamesAsync([FromQuery] string? tournamentName, [FromQuery] string? matchName, [FromQuery] string? username)
+    public async Task<IActionResult> SearchByNamesAsync([FromQuery] string searchKey)
     {
-        List<SearchResponseDTO>? response = await _searchService.SearchByNameAsync(tournamentName, matchName, username);
-        return response is null ? TypedResults.NotFound() : TypedResults.Ok(response);
+        List<SearchResponseDTO> response = await service.SearchByNameAsync(searchKey);
+        return response.Count == 0 ? NotFound() : Ok(response);
     }
 }

--- a/API/Controllers/SearchController.cs
+++ b/API/Controllers/SearchController.cs
@@ -8,7 +8,8 @@ namespace API.Controllers;
 
 [ApiController]
 [ApiVersion(1)]
-[Authorize(Roles = "system")] // Internal access only at this time
+[Authorize(Roles = "user")]
+[Authorize(Roles = "whitelist")]
 [Route("api/v{version:apiVersion}/[controller]")]
 public class SearchController(ISearchService service) : Controller
 {
@@ -23,6 +24,8 @@ public class SearchController(ISearchService service) : Controller
     /// <response code="200">Returns a list of all possible tournaments, matches, and usernames for the given search key</response>
     [HttpGet]
     [EndpointSummary("Allows for partial or full searching on the names of tournaments, matches and usernames.")]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<IEnumerable<SearchResponseDTO>>(StatusCodes.Status200OK)]
     public async Task<IActionResult> SearchByNamesAsync([FromQuery] string searchKey)
     {
         List<SearchResponseDTO> response = await service.SearchByNameAsync(searchKey);

--- a/API/Services/Implementations/SearchService.cs
+++ b/API/Services/Implementations/SearchService.cs
@@ -24,7 +24,7 @@ public class SearchService(ITournamentsRepository tournamentsRepository, IMatche
     private async Task<IEnumerable<SearchResponseDTO>> SearchMatchesByNameAsync(string matchName)
     {
         var matches = (await matchesRepository.SearchAsync(matchName)).ToList();
-        return matches.Select(match => new SearchResponseDTO { Type = "Match", Text = match.MatchId.ToString(), Url = $"/matches/{match.Id}" });
+        return matches.Select(match => new SearchResponseDTO { Type = "Match", Text = match.Name ?? match.MatchId.ToString(), Url = $"/matches/{match.Id}" });
     }
 
     private async Task<IEnumerable<SearchResponseDTO>> SearchPlayersByNameAsync(string username)

--- a/API/Services/Implementations/SearchService.cs
+++ b/API/Services/Implementations/SearchService.cs
@@ -6,50 +6,30 @@ namespace API.Services.Implementations;
 
 public class SearchService(ITournamentsRepository tournamentsRepository, IMatchesRepository matchesRepository, IPlayerRepository playerRepository) : ISearchService
 {
-    private readonly ITournamentsRepository _tournamentsRepository = tournamentsRepository;
-    private readonly IMatchesRepository _matchesRepository = matchesRepository;
-    private readonly IPlayerRepository _playerRepository = playerRepository;
-
-    public async Task<List<SearchResponseDTO>> SearchByNameAsync(string? tournamentName, string? matchName, string? username)
+    public async Task<List<SearchResponseDTO>> SearchByNameAsync(string searchKey)
     {
-        var returnList = (await SearchTournamentsByNameAsync(tournamentName)).ToList();
-
-        returnList.AddRange(await SearchMatchesByNameAsync(matchName));
-        returnList.AddRange(await SearchPlayersByNameAsync(username));
+        var returnList = (await SearchTournamentsByNameAsync(searchKey)).ToList();
+        returnList.AddRange(await SearchMatchesByNameAsync(searchKey));
+        returnList.AddRange(await SearchPlayersByNameAsync(searchKey));
 
         return returnList;
     }
 
-    private async Task<IEnumerable<SearchResponseDTO>> SearchTournamentsByNameAsync(string? tournamentName)
+    private async Task<IEnumerable<SearchResponseDTO>> SearchTournamentsByNameAsync(string tournamentName)
     {
-        if (tournamentName is null)
-        {
-            return new List<SearchResponseDTO>();
-        }
-
-        var tournaments = (await _tournamentsRepository.SearchAsync(tournamentName)).ToList();
-        return tournaments.Select(tournament => new SearchResponseDTO() { Type = "Tournament", Text = tournament.Name, Url = $"/tournaments/{tournament.Id}" });
+        var tournaments = (await tournamentsRepository.SearchAsync(tournamentName)).ToList();
+        return tournaments.Select(tournament => new SearchResponseDTO { Type = "Tournament", Text = tournament.Name, Url = $"/tournaments/{tournament.Id}" });
     }
 
-    private async Task<IEnumerable<SearchResponseDTO>> SearchMatchesByNameAsync(string? matchName)
+    private async Task<IEnumerable<SearchResponseDTO>> SearchMatchesByNameAsync(string matchName)
     {
-        if (matchName is null)
-        {
-            return new List<SearchResponseDTO>(); ;
-        }
-
-        var matches = (await _matchesRepository.SearchAsync(matchName)).ToList();
-        return matches.Select(match => new SearchResponseDTO() { Type = "Match", Text = match.MatchId.ToString(), Url = $"/matches/{match.Id}" });
+        var matches = (await matchesRepository.SearchAsync(matchName)).ToList();
+        return matches.Select(match => new SearchResponseDTO { Type = "Match", Text = match.MatchId.ToString(), Url = $"/matches/{match.Id}" });
     }
 
-    private async Task<IEnumerable<SearchResponseDTO>> SearchPlayersByNameAsync(string? username)
+    private async Task<IEnumerable<SearchResponseDTO>> SearchPlayersByNameAsync(string username)
     {
-        if (username is null)
-        {
-            return new List<SearchResponseDTO>(); ;
-        }
-
-        var players = (await _playerRepository.SearchAsync(username)).ToList();
-        return players.Select(player => new SearchResponseDTO() { Type = "Player", Text = player.Username ?? "<Unknown>", Url = $"/users/{player.Id}", Thumbnail = $"a.ppy.sh/{player.OsuId}" });
+        var players = (await playerRepository.SearchAsync(username)).ToList();
+        return players.Select(player => new SearchResponseDTO { Type = "Player", Text = player.Username ?? "<Unknown>", Url = $"/users/{player.Id}", Thumbnail = $"a.ppy.sh/{player.OsuId}" });
     }
 }

--- a/API/Services/Interfaces/ISearchService.cs
+++ b/API/Services/Interfaces/ISearchService.cs
@@ -5,11 +5,9 @@ namespace API.Services.Interfaces;
 public interface ISearchService
 {
     /// <summary>
-    /// Takes in a string query and lookups up matched tournaments, matches, or usernames. This search performs a partial match search.
+    /// Gets possible matching tournaments, matches, or usernames for the given search key
     /// </summary>
-    /// <param name="tournamentName"></param>
-    /// <param name="matchName"></param>
-    /// <param name="username"></param>
-    /// <returns></returns>
-    Task<List<SearchResponseDTO>> SearchByNameAsync(string? tournamentName, string? matchName, string? username);
+    /// <remarks>Searching by name is always case-insensitive and partial match enabled</remarks>
+    /// <returns>A list of all possible matching results</returns>
+    Task<List<SearchResponseDTO>> SearchByNameAsync(string searchKey);
 }


### PR DESCRIPTION
Removes `tournamentName`, `matchName`, and `username` query parameters and adds a single `searchKey` parameter to `/api/v1/search`. The endpoint now searches all three tables at the same time for potential results