### PR TITLE
Refactor `Entities.Game` to use enums where possible

### DIFF
--- a/API/BackgroundWorkers/OsuMatchDataWorker.cs
+++ b/API/BackgroundWorkers/OsuMatchDataWorker.cs
@@ -159,7 +159,7 @@ public class OsuMatchDataWorker(
             if (!GameAutomationChecks.PassesAutomationChecks(game))
             {
                 game.VerificationStatus = GameVerificationStatus.Rejected;
-                game.RejectionReason = (int)GameRejectionReason.FailedAutomationChecks;
+                game.RejectionReason = GameRejectionReason.FailedAutomationChecks;
                 _logger.LogInformation("Game {Game} failed automation checks", game.GameId);
 
                 await gamesRepository.UpdateAsync(game);

--- a/API/BackgroundWorkers/OsuMatchDataWorker.cs
+++ b/API/BackgroundWorkers/OsuMatchDataWorker.cs
@@ -158,7 +158,7 @@ public class OsuMatchDataWorker(
 
             if (!GameAutomationChecks.PassesAutomationChecks(game))
             {
-                game.VerificationStatus = (int)GameVerificationStatus.Rejected;
+                game.VerificationStatus = GameVerificationStatus.Rejected;
                 game.RejectionReason = (int)GameRejectionReason.FailedAutomationChecks;
                 _logger.LogInformation("Game {Game} failed automation checks", game.GameId);
 
@@ -167,16 +167,16 @@ public class OsuMatchDataWorker(
             else
             {
                 // Game has passed automation checks
-                game.VerificationStatus = (int)GameVerificationStatus.PreVerified;
+                game.VerificationStatus = GameVerificationStatus.PreVerified;
                 if (match.VerificationStatus == (int)MatchVerificationStatus.Verified)
                 {
-                    game.VerificationStatus = (int)GameVerificationStatus.Verified;
+                    game.VerificationStatus = GameVerificationStatus.Verified;
                 }
 
                 _logger.LogDebug(
                     "Game {Game} passed automation checks and is marked as {Status}",
                     game.GameId,
-                    (GameVerificationStatus)game.VerificationStatus
+                    game.VerificationStatus.ToString()
                 );
             }
         }

--- a/API/Entities/Game.cs
+++ b/API/Entities/Game.cs
@@ -55,7 +55,7 @@ public class Game : IUpdateableEntity
     /// The team type used for the game
     /// </summary>
     [Column("team_type")]
-    public int TeamType { get; set; }
+    public OsuEnums.TeamType TeamType { get; set; }
 
     /// <summary>
     /// The mods enabled for the game
@@ -136,7 +136,4 @@ public class Game : IUpdateableEntity
     /// </summary>
     [InverseProperty("Game")]
     public virtual GameWinRecord WinRecord { get; set; } = null!;
-
-    [NotMapped]
-    public OsuEnums.TeamType TeamTypeEnum => (OsuEnums.TeamType)TeamType;
 }

--- a/API/Entities/Game.cs
+++ b/API/Entities/Game.cs
@@ -1,72 +1,138 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics.CodeAnalysis;
+using API.Entities.Interfaces;
 using API.Enums;
 using API.Osu;
 using Microsoft.EntityFrameworkCore;
+// ReSharper disable StringLiteralTypo
 
 namespace API.Entities;
 
+/// <summary>
+/// Represents a single game (osu! map) played in a tournament match
+/// </summary>
 [Table("games")]
 [Index("GameId", Name = "osugames_gameid", IsUnique = true)]
-public class Game
+[SuppressMessage("ReSharper", "ClassWithVirtualMembersNeverInherited.Global")]
+[SuppressMessage("ReSharper", "EntityFramework.ModelValidation.CircularDependency")]
+[SuppressMessage("ReSharper", "PropertyCanBeMadeInitOnly.Global")]
+public class Game : IUpdateableEntity
 {
+    /// <summary>
+    /// Primary key
+    /// </summary>
     [Key]
     [Column("id")]
     public int Id { get; set; }
 
+    /// <summary>
+    /// The id of the match the game was played in
+    /// </summary>
     [Column("match_id")]
     public int MatchId { get; set; }
 
+    /// <summary>
+    /// The id of the beatmap the game was played on
+    /// </summary>
     [Column("beatmap_id")]
     public int? BeatmapId { get; set; }
 
+    /// <summary>
+    /// The ruleset for the game
+    /// </summary>
     [Column("play_mode")]
     public int PlayMode { get; set; }
 
+    /// <summary>
+    /// The scoring type used for the game
+    /// </summary>
     [Column("scoring_type")]
     public int ScoringType { get; set; }
 
+    /// <summary>
+    /// The team type used for the game
+    /// </summary>
     [Column("team_type")]
     public int TeamType { get; set; }
 
+    /// <summary>
+    /// The mods enabled for the game
+    /// </summary>
     [Column("mods")]
     public int Mods { get; set; }
 
+    /// <summary>
+    /// Star rating of the played beatmap after applying mods
+    /// </summary>
     [Column("post_mod_sr")]
     public double PostModSr { get; set; }
 
+    /// <summary>
+    /// The osu! id for the game
+    /// </summary>
     [Column("game_id")]
     public long GameId { get; set; }
 
+    /// <summary>
+    /// The verification status of the game
+    /// </summary>
     [Column("verification_status")]
     public int? VerificationStatus { get; set; }
 
+    /// <summary>
+    /// The reason the game was rejected from verification
+    /// </summary>
     [Column("rejection_reason")]
     public int? RejectionReason { get; set; }
 
+    /// <summary>
+    /// Date the entity was created
+    /// </summary>
     [Column("created", TypeName = "timestamp with time zone")]
     public DateTime Created { get; set; }
 
+    /// <summary>
+    /// Timestamp of the beginning of the game
+    /// </summary>
     [Column("start_time", TypeName = "timestamp with time zone")]
     public DateTime StartTime { get; set; }
 
+    /// <summary>
+    /// Timestamp of the end of the game
+    /// </summary>
     [Column("end_time", TypeName = "timestamp with time zone")]
     public DateTime? EndTime { get; set; }
 
+    /// <summary>
+    /// Date of the last update to the entity
+    /// </summary>
     [Column("updated", TypeName = "timestamp with time zone")]
     public DateTime? Updated { get; set; }
 
+    /// <summary>
+    /// The match the game was played in
+    /// </summary>
     [ForeignKey("MatchId")]
     [InverseProperty("Games")]
     public virtual Match Match { get; set; } = null!;
 
+    /// <summary>
+    /// The beatmap the game was played on
+    /// </summary>
     [ForeignKey("BeatmapId")]
     [InverseProperty("Games")]
     public virtual Beatmap? Beatmap { get; set; }
 
+    /// <summary>
+    /// All match scores for the game
+    /// </summary>
     [InverseProperty("Game")]
     public virtual ICollection<MatchScore> MatchScores { get; set; } = new List<MatchScore>();
 
+    /// <summary>
+    /// The win record for the game
+    /// </summary>
     [InverseProperty("Game")]
     public virtual GameWinRecord WinRecord { get; set; } = null!;
 

--- a/API/Entities/Game.cs
+++ b/API/Entities/Game.cs
@@ -41,8 +41,9 @@ public class Game : IUpdateableEntity
     /// <summary>
     /// The ruleset for the game
     /// </summary>
+    // TODO: Refactor to "Ruleset"
     [Column("play_mode")]
-    public int PlayMode { get; set; }
+    public OsuEnums.Ruleset PlayMode { get; set; }
 
     /// <summary>
     /// The scoring type used for the game

--- a/API/Entities/Game.cs
+++ b/API/Entities/Game.cs
@@ -78,7 +78,7 @@ public class Game : IUpdateableEntity
     /// The verification status of the game
     /// </summary>
     [Column("verification_status")]
-    public int? VerificationStatus { get; set; }
+    public GameVerificationStatus? VerificationStatus { get; set; }
 
     /// <summary>
     /// The reason the game was rejected from verification
@@ -144,10 +144,6 @@ public class Game : IUpdateableEntity
 
     [NotMapped]
     public OsuEnums.TeamType TeamTypeEnum => (OsuEnums.TeamType)TeamType;
-
-    [NotMapped]
-    public GameVerificationStatus? VerificationStatusEnum =>
-        VerificationStatus.HasValue ? (GameVerificationStatus)VerificationStatus : null;
 
     [NotMapped]
     public GameRejectionReason? RejectionReasonEnum =>

--- a/API/Entities/Game.cs
+++ b/API/Entities/Game.cs
@@ -84,7 +84,7 @@ public class Game : IUpdateableEntity
     /// The reason the game was rejected from verification
     /// </summary>
     [Column("rejection_reason")]
-    public int? RejectionReason { get; set; }
+    public GameRejectionReason? RejectionReason { get; set; }
 
     /// <summary>
     /// Date the entity was created
@@ -144,8 +144,4 @@ public class Game : IUpdateableEntity
 
     [NotMapped]
     public OsuEnums.TeamType TeamTypeEnum => (OsuEnums.TeamType)TeamType;
-
-    [NotMapped]
-    public GameRejectionReason? RejectionReasonEnum =>
-        RejectionReason.HasValue ? (GameRejectionReason)RejectionReason : null;
 }

--- a/API/Entities/Game.cs
+++ b/API/Entities/Game.cs
@@ -60,7 +60,7 @@ public class Game : IUpdateableEntity
     /// The mods enabled for the game
     /// </summary>
     [Column("mods")]
-    public int Mods { get; set; }
+    public OsuEnums.Mods Mods { get; set; }
 
     /// <summary>
     /// Star rating of the played beatmap after applying mods
@@ -135,9 +135,6 @@ public class Game : IUpdateableEntity
     /// </summary>
     [InverseProperty("Game")]
     public virtual GameWinRecord WinRecord { get; set; } = null!;
-
-    [NotMapped]
-    public OsuEnums.Mods ModsEnum => (OsuEnums.Mods)Mods;
 
     [NotMapped]
     public OsuEnums.Ruleset RulesetEnum => (OsuEnums.Ruleset)PlayMode;

--- a/API/Entities/Game.cs
+++ b/API/Entities/Game.cs
@@ -49,7 +49,7 @@ public class Game : IUpdateableEntity
     /// The scoring type used for the game
     /// </summary>
     [Column("scoring_type")]
-    public int ScoringType { get; set; }
+    public OsuEnums.ScoringType ScoringType { get; set; }
 
     /// <summary>
     /// The team type used for the game
@@ -136,12 +136,6 @@ public class Game : IUpdateableEntity
     /// </summary>
     [InverseProperty("Game")]
     public virtual GameWinRecord WinRecord { get; set; } = null!;
-
-    [NotMapped]
-    public OsuEnums.Ruleset RulesetEnum => (OsuEnums.Ruleset)PlayMode;
-
-    [NotMapped]
-    public OsuEnums.ScoringType ScoringTypeEnum => (OsuEnums.ScoringType)ScoringType;
 
     [NotMapped]
     public OsuEnums.TeamType TeamTypeEnum => (OsuEnums.TeamType)TeamType;

--- a/API/Osu/AutomationChecks/GameAutomationChecks.cs
+++ b/API/Osu/AutomationChecks/GameAutomationChecks.cs
@@ -135,15 +135,16 @@ public static class GameAutomationChecks
         return redUnexpected || blueUnexpected;
     }
 
+    // TODO: Refactor to "PassesRulesetCheck"
     public static bool PassesModeCheck(Game game)
     {
         Tournament tournament = game.Match.Tournament;
-        var gameMode = tournament.Mode;
+        var gameMode = (OsuEnums.Ruleset)tournament.Mode;
 
-        if (gameMode is < 0 or > 3)
+        if (Enum.GetValues<OsuEnums.Ruleset>().Contains(gameMode))
         {
             s_logger.Information(
-                "{Prefix} Tournament {TournamentId} has an invalid game mode: {Mode}, can't verify game {GameId}",
+                "{Prefix} Tournament {TournamentId} has an invalid ruleset: {Mode}, can't verify game {GameId}",
                 LogPrefix,
                 tournament.Id,
                 tournament.Mode,
@@ -156,7 +157,7 @@ public static class GameAutomationChecks
         if (gameMode != game.PlayMode)
         {
             s_logger.Information(
-                "{Prefix} Tournament {TournamentId} has a game mode that differs from game, can't verify game {GameId} [Tournament: Mode={TMode} | Game: Mode={GMode}",
+                "{Prefix} Tournament {TournamentId} has a ruleset that differs from game, can't verify game {GameId} [Tournament: Ruleset={TMode} | Game: Ruleset={GMode}",
                 LogPrefix,
                 tournament.Id,
                 game.GameId,

--- a/API/Osu/AutomationChecks/GameAutomationChecks.cs
+++ b/API/Osu/AutomationChecks/GameAutomationChecks.cs
@@ -192,8 +192,7 @@ public static class GameAutomationChecks
 
     public static bool PassesTeamTypeCheck(Game game)
     {
-        OsuEnums.TeamType teamType = game.TeamTypeEnum;
-        if (teamType is OsuEnums.TeamType.TagTeamVs or OsuEnums.TeamType.TagCoop)
+        if (game.TeamType is OsuEnums.TeamType.TagTeamVs or OsuEnums.TeamType.TagCoop)
         {
             s_logger.Information(
                 "{Prefix} Match {MatchId} has a tag team type, can't verify game {GameId}",
@@ -205,7 +204,7 @@ public static class GameAutomationChecks
         }
 
         // Ensure team size is valid
-        if (teamType == OsuEnums.TeamType.HeadToHead)
+        if (game.TeamType == OsuEnums.TeamType.HeadToHead)
         {
             if (game.Match.Tournament.TeamSize != 1)
             {

--- a/API/Osu/AutomationChecks/GameAutomationChecks.cs
+++ b/API/Osu/AutomationChecks/GameAutomationChecks.cs
@@ -173,7 +173,7 @@ public static class GameAutomationChecks
 
     public static bool PassesScoringTypeCheck(Game game)
     {
-        if (game.ScoringType != (int)OsuEnums.ScoringType.ScoreV2)
+        if (game.ScoringType != OsuEnums.ScoringType.ScoreV2)
         {
             s_logger.Information(
                 "{Prefix} Match {MatchId} does not have a ScoreV2 scoring type, can't verify game {GameId}",

--- a/API/Osu/AutomationChecks/GameAutomationChecks.cs
+++ b/API/Osu/AutomationChecks/GameAutomationChecks.cs
@@ -187,7 +187,7 @@ public static class GameAutomationChecks
     }
 
     public static bool PassesModsCheck(Game game) =>
-        !AutomationConstants.UnallowedMods.Any(unallowedMod => game.ModsEnum.HasFlag(unallowedMod));
+        !AutomationConstants.UnallowedMods.Any(unallowedMod => game.Mods.HasFlag(unallowedMod));
 
     public static bool PassesTeamTypeCheck(Game game)
     {

--- a/API/Repositories/Implementations/ApiMatchRepository.cs
+++ b/API/Repositories/Implementations/ApiMatchRepository.cs
@@ -283,7 +283,7 @@ public class ApiMatchRepository(
             EndTime = osuApiGame.EndTime,
             BeatmapId = beatmapIdResult,
             PlayMode = osuApiGame.Ruleset,
-            ScoringType = (int)osuApiGame.ScoringType,
+            ScoringType = osuApiGame.ScoringType,
             TeamType = (int)osuApiGame.TeamType,
             Mods = osuApiGame.Mods
         };

--- a/API/Repositories/Implementations/ApiMatchRepository.cs
+++ b/API/Repositories/Implementations/ApiMatchRepository.cs
@@ -285,7 +285,7 @@ public class ApiMatchRepository(
             PlayMode = (int)osuApiGame.Ruleset,
             ScoringType = (int)osuApiGame.ScoringType,
             TeamType = (int)osuApiGame.TeamType,
-            Mods = (int)osuApiGame.Mods
+            Mods = osuApiGame.Mods
         };
 
         Game persisted = await _gamesRepository.CreateAsync(dbGame);

--- a/API/Repositories/Implementations/ApiMatchRepository.cs
+++ b/API/Repositories/Implementations/ApiMatchRepository.cs
@@ -282,7 +282,7 @@ public class ApiMatchRepository(
             StartTime = osuApiGame.StartTime,
             EndTime = osuApiGame.EndTime,
             BeatmapId = beatmapIdResult,
-            PlayMode = (int)osuApiGame.Ruleset,
+            PlayMode = osuApiGame.Ruleset,
             ScoringType = (int)osuApiGame.ScoringType,
             TeamType = (int)osuApiGame.TeamType,
             Mods = osuApiGame.Mods

--- a/API/Repositories/Implementations/ApiMatchRepository.cs
+++ b/API/Repositories/Implementations/ApiMatchRepository.cs
@@ -284,7 +284,7 @@ public class ApiMatchRepository(
             BeatmapId = beatmapIdResult,
             PlayMode = osuApiGame.Ruleset,
             ScoringType = osuApiGame.ScoringType,
-            TeamType = (int)osuApiGame.TeamType,
+            TeamType = osuApiGame.TeamType,
             Mods = osuApiGame.Mods
         };
 

--- a/API/Repositories/Implementations/MatchesRepository.cs
+++ b/API/Repositories/Implementations/MatchesRepository.cs
@@ -59,11 +59,11 @@ public class MatchesRepository(
         {
             query = _context
                 .Matches.Include(x =>
-                    x.Games.Where(y => y.VerificationStatus == (int)GameVerificationStatus.Verified)
+                    x.Games.Where(y => y.VerificationStatus == GameVerificationStatus.Verified)
                 )
                 .ThenInclude(x => x.MatchScores.Where(y => y.IsValid == true))
                 .Include(x =>
-                    x.Games.Where(y => y.VerificationStatus == (int)GameVerificationStatus.Verified)
+                    x.Games.Where(y => y.VerificationStatus == GameVerificationStatus.Verified)
                 )
                 .ThenInclude(x => x.Beatmap)
                 .Where(x => x.Games.Count > 0);
@@ -354,9 +354,9 @@ public class MatchesRepository(
 
         return _context
             .Matches.WhereVerified()
-            .Include(x => x.Games.Where(y => y.VerificationStatus == (int)GameVerificationStatus.Verified))
+            .Include(x => x.Games.Where(y => y.VerificationStatus == GameVerificationStatus.Verified))
             .ThenInclude(x => x.MatchScores.Where(y => y.IsValid == true))
-            .Include(x => x.Games.Where(y => y.VerificationStatus == (int)GameVerificationStatus.Verified))
+            .Include(x => x.Games.Where(y => y.VerificationStatus == GameVerificationStatus.Verified))
             .ThenInclude(x => x.Beatmap)
             .Where(x => x.Games.Count > 0)
             .OrderBy(x => x.StartTime);

--- a/API/Repositories/Implementations/PlayerMatchStatsRepository.cs
+++ b/API/Repositories/Implementations/PlayerMatchStatsRepository.cs
@@ -87,7 +87,7 @@ public class PlayerMatchStatsRepository(OtrContext context) : IPlayerMatchStatsR
             .Select(ms => new
             {
                 // Match score mods populated for free mod, else game (lobby) mods
-                ModType = (OsuEnums.Mods?)ms.EnabledMods ?? (OsuEnums.Mods)ms.Game.Mods,
+                ModType = (OsuEnums.Mods?)ms.EnabledMods ?? ms.Game.Mods,
                 ms.Score,
                 PlayerWon = ms.Game.WinRecord.Winners.Contains(playerId)
             })

--- a/API/Repositories/Implementations/PlayerRepository.cs
+++ b/API/Repositories/Implementations/PlayerRepository.cs
@@ -84,6 +84,7 @@ public class PlayerRepository(OtrContext context, IMapper mapper) : RepositoryBa
         return await CreateAsync(new Player { OsuId = osuId });
     }
 
+    // TODO: Refactor param "mode" to use OsuEnums.Ruleset
     public async Task<Player?> GetAsync(long osuId, bool eagerLoad, int mode = 0, int offsetDays = -1)
     {
         if (!eagerLoad)
@@ -95,7 +96,7 @@ public class PlayerRepository(OtrContext context, IMapper mapper) : RepositoryBa
 
         Player? p = await _context
             .Players.Include(x =>
-                x.MatchScores.Where(y => y.Game.StartTime > time && y.Game.PlayMode == mode)
+                x.MatchScores.Where(y => y.Game.StartTime > time && y.Game.PlayMode == (OsuEnums.Ruleset)mode)
             )
             .ThenInclude(x => x.Game)
             .ThenInclude(x => x.Match)

--- a/API/Utilities/QueryExtensions.cs
+++ b/API/Utilities/QueryExtensions.cs
@@ -52,10 +52,10 @@ public static class QueryExtensions
             );
 
     public static IQueryable<Game> WhereTeamVs(this IQueryable<Game> query) =>
-        query.AsQueryable().Where(x => x.TeamType == (int)OsuEnums.TeamType.TeamVs);
+        query.AsQueryable().Where(x => x.TeamType == OsuEnums.TeamType.TeamVs);
 
     public static IQueryable<Game> WhereHeadToHead(this IQueryable<Game> query) =>
-        query.AsQueryable().Where(x => x.TeamType == (int)OsuEnums.TeamType.HeadToHead);
+        query.AsQueryable().Where(x => x.TeamType == OsuEnums.TeamType.HeadToHead);
 
     public static IQueryable<Game> After(this IQueryable<Game> query, DateTime after) =>
         query.AsQueryable().Where(x => x.StartTime > after);
@@ -104,10 +104,10 @@ public static class QueryExtensions
     /// <param name="query"></param>
     /// <returns></returns>
     public static IQueryable<MatchScore> WhereHeadToHead(this IQueryable<MatchScore> query) =>
-        query.AsQueryable().Where(x => x.Game.TeamType == (int)OsuEnums.TeamType.HeadToHead);
+        query.AsQueryable().Where(x => x.Game.TeamType == OsuEnums.TeamType.HeadToHead);
 
     public static IQueryable<MatchScore> WhereNotHeadToHead(this IQueryable<MatchScore> query) =>
-        query.AsQueryable().Where(x => x.Game.TeamType != (int)OsuEnums.TeamType.HeadToHead);
+        query.AsQueryable().Where(x => x.Game.TeamType != OsuEnums.TeamType.HeadToHead);
 
     /// <summary>
     ///  Selects all TeamVs match scores
@@ -115,7 +115,7 @@ public static class QueryExtensions
     /// <param name="query"></param>
     /// <returns></returns>
     public static IQueryable<MatchScore> WhereTeamVs(this IQueryable<MatchScore> query) =>
-        query.AsQueryable().Where(x => x.Game.TeamType == (int)OsuEnums.TeamType.TeamVs);
+        query.AsQueryable().Where(x => x.Game.TeamType == OsuEnums.TeamType.TeamVs);
 
     /// <summary>
     ///  Selects all match scores, other than the provided player's, that are on the opposite team as the provided player.
@@ -146,7 +146,7 @@ public static class QueryExtensions
             .Where(x =>
                 x.Game.MatchScores.Any(y => y.Player.OsuId == osuPlayerId)
                 && x.Player.OsuId != osuPlayerId
-                && x.Game.TeamType != (int)OsuEnums.TeamType.HeadToHead
+                && x.Game.TeamType != OsuEnums.TeamType.HeadToHead
                 && x.Team == x.Game.MatchScores.First(y => y.Player.OsuId == osuPlayerId).Team
             );
 

--- a/API/Utilities/QueryExtensions.cs
+++ b/API/Utilities/QueryExtensions.cs
@@ -74,10 +74,10 @@ public static class QueryExtensions
         return query
             .AsQueryable()
             .Where(x =>
-                (x.Game.Mods != 0 && x.Game.Mods == (int)enabledMods)
+                (x.Game.Mods != OsuEnums.Mods.None && x.Game.Mods == enabledMods)
                 || // Not using NF
                 (x.EnabledMods != null && x.EnabledMods.Value == (int)enabledMods)
-                || (x.Game.Mods != 0 && x.Game.Mods == (int)(enabledMods | OsuEnums.Mods.NoFail))
+                || (x.Game.Mods != OsuEnums.Mods.None && x.Game.Mods == (enabledMods | OsuEnums.Mods.NoFail))
                 || // Using NF
                 (x.EnabledMods != null && x.EnabledMods.Value == (int)(enabledMods | OsuEnums.Mods.NoFail))
             );

--- a/API/Utilities/QueryExtensions.cs
+++ b/API/Utilities/QueryExtensions.cs
@@ -162,8 +162,10 @@ public static class QueryExtensions
     /// <param name="query"></param>
     /// <param name="mode"></param>
     /// <returns></returns>
+    // TODO: Refactor param "mode" to use OsuEnums.Ruleset
+    // TODO: Refactor to "WhereRuleset"
     public static IQueryable<MatchScore> WhereMode(this IQueryable<MatchScore> query, int mode) =>
-        query.AsQueryable().Where(x => x.Game.PlayMode == mode);
+        query.AsQueryable().Where(x => x.Game.PlayMode == (OsuEnums.Ruleset)mode);
 
     public static IQueryable<MatchScore> WhereOsuPlayerId(
         this IQueryable<MatchScore> query,

--- a/APITests/AutomationChecks/AutomationChecksTests.cs
+++ b/APITests/AutomationChecks/AutomationChecksTests.cs
@@ -50,7 +50,7 @@ public class AutomationChecksTests
                 EndTime = new DateTime(2023, 1, 1, 0, 1, 0),
                 GameId = 1,
                 MatchId = 1,
-                ScoringType = (int)OsuEnums.ScoringType.ScoreV2,
+                ScoringType = OsuEnums.ScoringType.ScoreV2,
                 TeamType = (int)OsuEnums.TeamType.TeamVs,
                 Mods = OsuEnums.Mods.NoFail | OsuEnums.Mods.DoubleTime,
                 Match = match
@@ -405,7 +405,7 @@ public class AutomationChecksTests
     public void Game_FailsScoringCheck_WhenComboScoring()
     {
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
-        match.Games.First().ScoringType = (int)OsuEnums.ScoringType.Combo;
+        match.Games.First().ScoringType = OsuEnums.ScoringType.Combo;
 
         Assert.False(GameAutomationChecks.PassesScoringTypeCheck(match.Games.First()));
     }
@@ -551,7 +551,7 @@ public class AutomationChecksTests
         {
             foreach (OsuEnums.ScoringType scoringType in badScoringTypes)
             {
-                match.Games.First().ScoringType = (int)scoringType;
+                match.Games.First().ScoringType = scoringType;
                 Assert.False(GameAutomationChecks.PassesScoringTypeCheck(match.Games.First()));
             }
         });
@@ -634,7 +634,7 @@ public class AutomationChecksTests
     public void Game_FailsScoringTypeCheck()
     {
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
-        match.Games.First().ScoringType = (int)OsuEnums.ScoringType.Combo;
+        match.Games.First().ScoringType = OsuEnums.ScoringType.Combo;
 
         Assert.False(GameAutomationChecks.PassesScoringTypeCheck(match.Games.First()));
     }

--- a/APITests/AutomationChecks/AutomationChecksTests.cs
+++ b/APITests/AutomationChecks/AutomationChecksTests.cs
@@ -51,7 +51,7 @@ public class AutomationChecksTests
                 GameId = 1,
                 MatchId = 1,
                 ScoringType = OsuEnums.ScoringType.ScoreV2,
-                TeamType = (int)OsuEnums.TeamType.TeamVs,
+                TeamType = OsuEnums.TeamType.TeamVs,
                 Mods = OsuEnums.Mods.NoFail | OsuEnums.Mods.DoubleTime,
                 Match = match
             }
@@ -414,11 +414,11 @@ public class AutomationChecksTests
     public void Game_FailsTeamTypeCheck_WhenTagTeamMode()
     {
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
-        match.Games.First().TeamType = (int)OsuEnums.TeamType.TagTeamVs;
+        match.Games.First().TeamType = OsuEnums.TeamType.TagTeamVs;
 
         Assert.False(GameAutomationChecks.PassesTeamTypeCheck(match.Games.First()));
 
-        match.Games.First().TeamType = (int)OsuEnums.TeamType.TagCoop;
+        match.Games.First().TeamType = OsuEnums.TeamType.TagCoop;
         Assert.False(GameAutomationChecks.PassesTeamTypeCheck(match.Games.First()));
     }
 
@@ -426,7 +426,7 @@ public class AutomationChecksTests
     public void Game_FailsTeamTypeCheck_WhenHeadToHead_And_TournamentSizeNotOne()
     {
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
-        match.Games.First().TeamType = (int)OsuEnums.TeamType.HeadToHead;
+        match.Games.First().TeamType = OsuEnums.TeamType.HeadToHead;
         match.Tournament.TeamSize = 4;
 
         Assert.False(GameAutomationChecks.PassesTeamTypeCheck(match.Games.First()));
@@ -436,7 +436,7 @@ public class AutomationChecksTests
     public void Game_PassesTeamTypeCheck_WhenHeadToHead_And_TournamentSizeIsOne()
     {
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
-        match.Games.First().TeamType = (int)OsuEnums.TeamType.HeadToHead;
+        match.Games.First().TeamType = OsuEnums.TeamType.HeadToHead;
         match.Tournament.TeamSize = 1;
 
         Assert.True(GameAutomationChecks.PassesTeamTypeCheck(match.Games.First()));
@@ -643,11 +643,11 @@ public class AutomationChecksTests
     public void Game_FailsTeamTypeCheck()
     {
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
-        match.Games.First().TeamType = (int)OsuEnums.TeamType.TagCoop;
+        match.Games.First().TeamType = OsuEnums.TeamType.TagCoop;
 
         Assert.False(GameAutomationChecks.PassesTeamTypeCheck(match.Games.First()));
 
-        match.Games.First().TeamType = (int)OsuEnums.TeamType.TagTeamVs;
+        match.Games.First().TeamType = OsuEnums.TeamType.TagTeamVs;
         Assert.False(GameAutomationChecks.PassesTeamTypeCheck(match.Games.First()));
     }
 
@@ -656,7 +656,7 @@ public class AutomationChecksTests
     {
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
         Game game = match.Games.First();
-        game.TeamType = (int)OsuEnums.TeamType.HeadToHead;
+        game.TeamType = OsuEnums.TeamType.HeadToHead;
 
         game.Match.Tournament.TeamSize = 4;
         Assert.False(GameAutomationChecks.PassesTeamTypeCheck(game));
@@ -669,7 +669,7 @@ public class AutomationChecksTests
     public void Game_FailsTeamTypeCheck_HeadToHead_When_TeamSize_Is_2()
     {
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
-        match.Games.First().TeamType = (int)OsuEnums.TeamType.HeadToHead;
+        match.Games.First().TeamType = OsuEnums.TeamType.HeadToHead;
         match.Tournament.TeamSize = 2;
 
         Assert.False(GameAutomationChecks.PassesTeamTypeCheck(match.Games.First()));

--- a/APITests/AutomationChecks/AutomationChecksTests.cs
+++ b/APITests/AutomationChecks/AutomationChecksTests.cs
@@ -45,14 +45,14 @@ public class AutomationChecksTests
             new()
             {
                 BeatmapId = 1,
-                PlayMode = 0,
+                PlayMode = OsuEnums.Ruleset.Standard,
                 StartTime = new DateTime(2023, 1, 1, 0, 0, 0),
                 EndTime = new DateTime(2023, 1, 1, 0, 1, 0),
                 GameId = 1,
                 MatchId = 1,
                 ScoringType = (int)OsuEnums.ScoringType.ScoreV2,
                 TeamType = (int)OsuEnums.TeamType.TeamVs,
-                Mods = (int)(OsuEnums.Mods.NoFail | OsuEnums.Mods.DoubleTime),
+                Mods = OsuEnums.Mods.NoFail | OsuEnums.Mods.DoubleTime,
                 Match = match
             }
         };
@@ -103,7 +103,7 @@ public class AutomationChecksTests
 
         Game firstGame = match.Games.First();
         Assert.NotNull(firstGame);
-        Assert.Equal((int)(OsuEnums.Mods.NoFail | OsuEnums.Mods.DoubleTime), firstGame.Mods);
+        Assert.Equal(OsuEnums.Mods.NoFail | OsuEnums.Mods.DoubleTime, firstGame.Mods);
 
         MatchScore firstMatchScore = firstGame.MatchScores.First();
         Assert.NotNull(firstMatchScore);
@@ -616,7 +616,7 @@ public class AutomationChecksTests
     public void Game_FailsModsCheck()
     {
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
-        match.Games.First().Mods = (int)OsuEnums.Mods.Relax;
+        match.Games.First().Mods = OsuEnums.Mods.Relax;
 
         Assert.False(GameAutomationChecks.PassesModsCheck(match.Games.First()));
     }
@@ -625,7 +625,7 @@ public class AutomationChecksTests
     public void Game_FailsModeCheck()
     {
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
-        match.Games.First().PlayMode = (int)OsuEnums.Ruleset.Catch;
+        match.Games.First().PlayMode = OsuEnums.Ruleset.Catch;
 
         Assert.False(GameAutomationChecks.PassesModeCheck(match.Games.First()));
     }

--- a/APITests/SeedData/SeededGame.cs
+++ b/APITests/SeedData/SeededGame.cs
@@ -1,4 +1,6 @@
 using API.Entities;
+using API.Enums;
+using API.Osu;
 
 namespace APITests.SeedData;
 
@@ -25,14 +27,14 @@ public static class SeededGame
             Id = s_rand.Next(),
             MatchId = matchId,
             BeatmapId = 24245,
-            PlayMode = 0,
+            PlayMode = OsuEnums.Ruleset.Standard,
             ScoringType = 3,
             TeamType = 0,
-            Mods = 0,
+            Mods = OsuEnums.Mods.None,
             PostModSr = 6.36389,
             GameId = 502333236,
-            VerificationStatus = 2,
-            RejectionReason = 0,
+            VerificationStatus = GameVerificationStatus.Rejected,
+            RejectionReason = GameRejectionReason.FailedAutomationChecks,
             Created = new DateTime(2023, 09, 14),
             StartTime = new DateTime(2023, 03, 10),
             EndTime = new DateTime(2023, 03, 10),

--- a/APITests/SeedData/SeededGame.cs
+++ b/APITests/SeedData/SeededGame.cs
@@ -29,7 +29,7 @@ public static class SeededGame
             BeatmapId = 24245,
             PlayMode = OsuEnums.Ruleset.Standard,
             ScoringType = OsuEnums.ScoringType.ScoreV2,
-            TeamType = 0,
+            TeamType = OsuEnums.TeamType.HeadToHead,
             Mods = OsuEnums.Mods.None,
             PostModSr = 6.36389,
             GameId = 502333236,

--- a/APITests/SeedData/SeededGame.cs
+++ b/APITests/SeedData/SeededGame.cs
@@ -28,7 +28,7 @@ public static class SeededGame
             MatchId = matchId,
             BeatmapId = 24245,
             PlayMode = OsuEnums.Ruleset.Standard,
-            ScoringType = 3,
+            ScoringType = OsuEnums.ScoringType.ScoreV2,
             TeamType = 0,
             Mods = OsuEnums.Mods.None,
             PostModSr = 6.36389,


### PR DESCRIPTION
- Change the types of properties `PlayMode`, `ScoringType`, `TeamType`, `Mods`, `VerificationStatus`, and `RejectionReason` to be of their respective enums
- All instances of access / use / comparison of the properties have been updated to use their respective enums instead of casting to `int`.
- Added XML docs to `Entities.Game`