### PR TITLE
Fix invalid id fetching

### DIFF
--- a/API/Repositories/Implementations/MatchesRepository.cs
+++ b/API/Repositories/Implementations/MatchesRepository.cs
@@ -43,7 +43,7 @@ public class MatchesRepository(
         await MatchBaseQuery(onlyIncludeFiltered).Where(x => ids.Contains(x.Id)).ToListAsync();
 
     public async Task<IEnumerable<int>> GetAllAsync(bool filterInvalidMatches) =>
-        return await MatchBaseQuery(filterInvalidMatches).Select(x => x.Id).ToListAsync();
+        await MatchBaseQuery(filterInvalidMatches).Select(x => x.Id).ToListAsync();
 
     public async Task<Match?> GetByMatchIdAsync(long matchId) =>
         await _context

--- a/API/Repositories/Implementations/MatchesRepository.cs
+++ b/API/Repositories/Implementations/MatchesRepository.cs
@@ -44,25 +44,8 @@ public class MatchesRepository(
 
     public async Task<IEnumerable<int>> GetAllAsync(bool filterInvalidMatches)
     {
-        IQueryable<Match> query = _context.Matches.OrderBy(m => m.StartTime).AsQueryable();
-
-        if (filterInvalidMatches)
-        {
-            query = _context
-                .Matches.Include(x =>
-                    x.Games.Where(y => y.VerificationStatus == GameVerificationStatus.Verified)
-                )
-                .ThenInclude(x => x.MatchScores.Where(y => y.IsValid == true))
-                .Include(x =>
-                    x.Games.Where(y => y.VerificationStatus == GameVerificationStatus.Verified)
-                )
-                .ThenInclude(x => x.Beatmap)
-                .Where(x => x.Games.Count > 0);
-        }
-
-        List<int> matches = await query.Select(x => x.Id).ToListAsync();
-
-        return matches;
+        IQueryable<Match> query = MatchBaseQuery(filterInvalidMatches);
+        return await query.Select(x => x.Id).ToListAsync();
     }
 
     public async Task<Match?> GetByMatchIdAsync(long matchId) =>

--- a/API/Repositories/Implementations/MatchesRepository.cs
+++ b/API/Repositories/Implementations/MatchesRepository.cs
@@ -42,11 +42,8 @@ public class MatchesRepository(
     public async Task<IEnumerable<Match>> GetAsync(IEnumerable<int> ids, bool onlyIncludeFiltered) =>
         await MatchBaseQuery(onlyIncludeFiltered).Where(x => ids.Contains(x.Id)).ToListAsync();
 
-    public async Task<IEnumerable<int>> GetAllAsync(bool filterInvalidMatches)
-    {
-        IQueryable<Match> query = MatchBaseQuery(filterInvalidMatches);
-        return await query.Select(x => x.Id).ToListAsync();
-    }
+    public async Task<IEnumerable<int>> GetAllAsync(bool filterInvalidMatches) =>
+        return await MatchBaseQuery(filterInvalidMatches).Select(x => x.Id).ToListAsync();
 
     public async Task<Match?> GetByMatchIdAsync(long matchId) =>
         await _context


### PR DESCRIPTION
Fixes a bug where non-verified matches would be returned in the `GetAllAsync` function of `MatchesRepository`.