### PR TITLE
Move `/api/v1/stats/ratingadjustments DELETE` into `/api/v1/stats DELETE`

### DIFF
--- a/API/Controllers/StatsController.cs
+++ b/API/Controllers/StatsController.cs
@@ -64,14 +64,6 @@ public class StatsController(IPlayerStatsService playerStatsService, IBaseStatsS
         return Ok();
     }
 
-    [HttpDelete("ratingadjustments")]
-    [Authorize(Roles = "system")]
-    public async Task<IActionResult> TruncateAdjustmentsAsync()
-    {
-        await _playerStatsService.TruncateRatingAdjustmentsAsync();
-        return Ok();
-    }
-
     [HttpPost("matchstats")]
     [Authorize(Roles = "system")]
     public async Task<IActionResult> PostAsync([FromBody] IEnumerable<PlayerMatchStatsDTO> postBody)

--- a/API/Services/Implementations/PlayerStatsService.cs
+++ b/API/Services/Implementations/PlayerStatsService.cs
@@ -272,6 +272,7 @@ public class PlayerStatsService(
         await _matchStatsRepository.TruncateAsync();
         await _ratingStatsRepository.TruncateAsync();
         await _matchWinRecordRepository.TruncateAsync();
+        await _ratingAdjustmentsRepository.TruncateAsync();
     }
 
     public async Task TruncateRatingAdjustmentsAsync() => await _ratingAdjustmentsRepository.TruncateAsync();


### PR DESCRIPTION
- Remove `/api/v1/stats/ratingadjustments DELETE`
- Merge this behavior into `/api/v1/stats DELETE`

While this is a breaking change, this was only used by the old processor.