### PR TITLE
Add the ability to enable / disable the whitelist globally

### DIFF
--- a/API/Configurations/AuthConfiguration.cs
+++ b/API/Configurations/AuthConfiguration.cs
@@ -8,4 +8,6 @@ public class AuthConfiguration
 
     [Required(ErrorMessage = "ClientCallbackUrl is required!")]
     public string ClientCallbackUrl { get; set; } = string.Empty;
+
+    public bool EnforceWhitelist { get; set; }
 }

--- a/API/Controllers/BeatmapsController.cs
+++ b/API/Controllers/BeatmapsController.cs
@@ -1,5 +1,6 @@
 using API.DTOs;
 using API.Services.Interfaces;
+using API.Utilities;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -8,7 +9,7 @@ namespace API.Controllers;
 
 [ApiController]
 [ApiVersion(1)]
-[Authorize(Roles = "system, admin")] // Internal access only at this time
+[Authorize(Roles = $"{OtrClaims.System}, {OtrClaims.Admin}")] // Internal access only at this time
 [Route("api/v{version:apiVersion}/[controller]")]
 public class BeatmapsController(IBeatmapService beatmapService) : Controller
 {

--- a/API/Controllers/ClientsController.cs
+++ b/API/Controllers/ClientsController.cs
@@ -1,9 +1,9 @@
 using API.DTOs;
 using API.Entities;
 using API.Services.Interfaces;
+using API.Utilities;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
@@ -12,12 +12,11 @@ namespace API.Controllers;
 
 [ApiController]
 [ApiVersion(1)]
-[EnableCors]
 [Route("api/v{version:apiVersion}/[controller]")]
 public class ClientsController(IOAuthClientService clientService) : Controller
 {
     [HttpPatch("{id:int}/ratelimit")]
-    [Authorize(Roles = "admin")]
+    [Authorize(Roles = OtrClaims.Admin)]
     [EndpointSummary("Patches the ratelimit for a given client")]
     public async Task<Results<BadRequest, NotFound, Ok<OAuthClientDTO>>> PatchRatelimitAsync(int id, [FromBody] JsonPatchDocument<RateLimitOverrides> patchedOverrides)
     {

--- a/API/Controllers/LeaderboardsController.cs
+++ b/API/Controllers/LeaderboardsController.cs
@@ -12,8 +12,7 @@ namespace API.Controllers;
 [ApiController]
 [ApiVersion(1)]
 [EnableCors]
-[Authorize(Roles = "user")]
-[Authorize(Roles = "whitelist")]
+[Authorize(Roles = OtrClaims.User)]
 [Route("api/v{version:apiVersion}/[controller]")]
 public class LeaderboardsController(ILeaderboardService leaderboardService) : Controller
 {

--- a/API/Controllers/MatchesController.cs
+++ b/API/Controllers/MatchesController.cs
@@ -18,7 +18,7 @@ public class MatchesController(IMatchesService matchesService) : Controller
     private readonly IMatchesService _matchesService = matchesService;
 
     [HttpPost("checks/refresh")]
-    [Authorize(Roles = "admin, system")]
+    [Authorize(Roles = $"{OtrClaims.Admin}, {OtrClaims.System}")]
     [EndpointSummary(
         "Sets all matches as requiring automation checks. Should be run if " + "automation checks are altered."
     )]
@@ -30,7 +30,7 @@ public class MatchesController(IMatchesService matchesService) : Controller
     }
 
     [HttpGet("ids")]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = OtrClaims.System)]
     [EndpointSummary("Returns all verified match ids")]
     public async Task<ActionResult<IEnumerable<int>>> GetAllAsync()
     {
@@ -39,7 +39,7 @@ public class MatchesController(IMatchesService matchesService) : Controller
     }
 
     [HttpGet("{id:int}")]
-    [Authorize(Roles = "user, client")]
+    [Authorize(Roles = $"{OtrClaims.User}, {OtrClaims.Client}")]
     public async Task<ActionResult<MatchDTO>> GetByIdAsync(int id)
     {
         MatchDTO? match = await _matchesService.GetAsync(id);
@@ -53,7 +53,7 @@ public class MatchesController(IMatchesService matchesService) : Controller
     }
 
     [HttpPost("convert")]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = OtrClaims.System)]
     [EndpointSummary("Converts a list of match ids to MatchDTO objects")]
     [EndpointDescription(
         "This is a useful way to fetch a list of matches without starving the " + "program of memory. This is used by the rating processor to fetch matches"
@@ -65,12 +65,12 @@ public class MatchesController(IMatchesService matchesService) : Controller
     }
 
     [HttpGet("duplicates")]
-    [Authorize(Roles = "admin")]
+    [Authorize(Roles = OtrClaims.Admin)]
     [EndpointSummary("Retrieves all known duplicate groups")]
     public async Task<IActionResult> GetDuplicatesAsync() => Ok(await _matchesService.GetAllDuplicatesAsync());
 
     [HttpPost("duplicate")]
-    [Authorize(Roles = "admin")]
+    [Authorize(Roles = OtrClaims.Admin)]
     [EndpointSummary("Mark a match as a confirmed or denied duplicate of the root")]
     public async Task<IActionResult> MarkDuplicatesAsync([FromQuery] int rootId,
         [FromQuery]
@@ -93,12 +93,12 @@ public class MatchesController(IMatchesService matchesService) : Controller
 
     // TODO: Should be /player/{osuId}/matches instead.
     [HttpGet("player/{osuId:long}")]
-    [Authorize(Roles = "admin, system")]
+    [Authorize(Roles = $"{OtrClaims.Admin}, {OtrClaims.System}")]
     public async Task<ActionResult<IEnumerable<MatchDTO>>> GetMatchesAsync(long osuId, int mode) =>
         Ok(await _matchesService.GetAllForPlayerAsync(osuId, mode, DateTime.MinValue, DateTime.MaxValue));
 
     [HttpGet("{id:int}/osuid")]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = OtrClaims.System)]
     public async Task<ActionResult<long>> GetOsuMatchIdByIdAsync(int id)
     {
         MatchDTO? match = await _matchesService.GetByOsuIdAsync(id);
@@ -117,7 +117,7 @@ public class MatchesController(IMatchesService matchesService) : Controller
     }
 
     [HttpGet("id-mapping")]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = OtrClaims.System)]
     public async Task<IActionResult> GetIdMappingAsync()
     {
         IEnumerable<MatchIdMappingDTO> mapping = await _matchesService.GetIdMappingAsync();
@@ -133,7 +133,7 @@ public class MatchesController(IMatchesService matchesService) : Controller
     /// <response code="400">If JsonPatch data is malformed</response>
     /// <response code="200">Returns the updated match</response>
     [HttpPatch("{id:int}/verification-status")]
-    [Authorize(Roles = "admin")]
+    [Authorize(Roles = OtrClaims.Admin)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType<ModelStateDictionary>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<MatchDTO>(StatusCodes.Status200OK)]

--- a/API/Controllers/MeController.cs
+++ b/API/Controllers/MeController.cs
@@ -10,8 +10,7 @@ namespace API.Controllers;
 [ApiController]
 [ApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]")]
-[Authorize(Roles = "user")]
-[Authorize(Roles = "whitelist")]
+[Authorize(Roles = OtrClaims.User)]
 public class MeController(IUserService userService, IPlayerStatsService playerStatsService) : Controller
 {
     private readonly IUserService _userService = userService;

--- a/API/Controllers/OAuthController.cs
+++ b/API/Controllers/OAuthController.cs
@@ -45,7 +45,7 @@ public class OAuthController(IOAuthHandler oAuthHandler) : Controller
     }
 
     [HttpPost("client")]
-    [Authorize(Roles = "user")]
+    [Authorize(Roles = OtrClaims.User)]
     [EndpointDescription("Create a new OAuth client")]
     public async Task<Results<UnauthorizedHttpResult, Ok<OAuthClientDTO>>> CreateClientAsync()
     {

--- a/API/Controllers/PlayersController.cs
+++ b/API/Controllers/PlayersController.cs
@@ -1,5 +1,6 @@
 using API.DTOs;
 using API.Services.Interfaces;
+using API.Utilities;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
@@ -16,7 +17,7 @@ public class PlayersController(IPlayerService playerService) : Controller
     private readonly IPlayerService _playerService = playerService;
 
     [HttpGet("all")]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = OtrClaims.System)]
     public async Task<IActionResult> GetAllAsync()
     {
         IEnumerable<PlayerDTO> players = await _playerService.GetAllAsync();
@@ -24,7 +25,7 @@ public class PlayersController(IPlayerService playerService) : Controller
     }
 
     [HttpGet("{key}/info")]
-    [Authorize(Roles = "user, client")]
+    [Authorize(Roles = $"{OtrClaims.User}, {OtrClaims.Client}")]
     [EndpointSummary("Get player info by versatile search")]
     [EndpointDescription("Get player info searching first by id, then osuId, then username")]
     public async Task<ActionResult<PlayerInfoDTO?>> GetAsync(string key)
@@ -40,7 +41,7 @@ public class PlayersController(IPlayerService playerService) : Controller
     }
 
     [HttpGet("ranks/all")]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = OtrClaims.System)]
     public async Task<ActionResult<IEnumerable<PlayerRanksDTO>>> GetAllRanksAsync()
     {
         IEnumerable<PlayerRanksDTO> ranks = await _playerService.GetAllRanksAsync();
@@ -48,7 +49,7 @@ public class PlayersController(IPlayerService playerService) : Controller
     }
 
     [HttpGet("id-mapping")]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = OtrClaims.System)]
     public async Task<ActionResult<IEnumerable<PlayerIdMappingDTO>>> GetIdMappingAsync()
     {
         IEnumerable<PlayerIdMappingDTO> mapping = await _playerService.GetIdMappingAsync();
@@ -56,7 +57,7 @@ public class PlayersController(IPlayerService playerService) : Controller
     }
 
     [HttpGet("country-mapping")]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = OtrClaims.System)]
     [ProducesResponseType<IEnumerable<PlayerCountryMappingDTO>>(StatusCodes.Status200OK)]
     [EndpointSummary(
         "Returns a list of PlayerCountryMappingDTOs that have a player's id and their country tag."

--- a/API/Controllers/ScreeningController.cs
+++ b/API/Controllers/ScreeningController.cs
@@ -1,5 +1,6 @@
 using API.DTOs;
 using API.Services.Interfaces;
+using API.Utilities;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -20,7 +21,7 @@ public class ScreeningController(IScreeningService screeningService) : Controlle
     /// <response code="400">Errors encountered during validation</response>
     /// <response code="200">The screening result</response>
     [HttpPost]
-    [Authorize(Roles = "user, client")]
+    [Authorize(Roles = $"{OtrClaims.User}, {OtrClaims.Client}")]
     [ProducesResponseType<ModelStateDictionary>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<ScreeningResultDTO>(StatusCodes.Status200OK)]
     public async Task<IActionResult> ScreenAsync([FromBody] ScreeningRequestDTO screeningRequest)

--- a/API/Controllers/SearchController.cs
+++ b/API/Controllers/SearchController.cs
@@ -1,5 +1,6 @@
 using API.DTOs;
 using API.Services.Interfaces;
+using API.Utilities;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -8,8 +9,7 @@ namespace API.Controllers;
 
 [ApiController]
 [ApiVersion(1)]
-[Authorize(Roles = "user")]
-[Authorize(Roles = "whitelist")]
+[Authorize(Roles = OtrClaims.User)]
 [Route("api/v{version:apiVersion}/[controller]")]
 public class SearchController(ISearchService service) : Controller
 {

--- a/API/Controllers/StatsController.cs
+++ b/API/Controllers/StatsController.cs
@@ -1,15 +1,14 @@
 using API.DTOs;
 using API.Services.Interfaces;
+using API.Utilities;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 
 namespace API.Controllers;
 
 [ApiController]
 [ApiVersion(1)]
-[EnableCors]
 [Route("api/v{version:apiVersion}/[controller]")]
 public class StatsController(IPlayerStatsService playerStatsService, IBaseStatsService baseStatsService) : Controller
 {
@@ -17,7 +16,7 @@ public class StatsController(IPlayerStatsService playerStatsService, IBaseStatsS
     private readonly IPlayerStatsService _playerStatsService = playerStatsService;
 
     [HttpGet("{playerId:int}")]
-    [Authorize(Roles = "user, client")]
+    [Authorize(Roles = $"{OtrClaims.User}, {OtrClaims.Client}")]
     public async Task<ActionResult<PlayerStatsDTO>> GetAsync(
         int playerId,
         [FromQuery] int? comparerId,
@@ -34,7 +33,7 @@ public class StatsController(IPlayerStatsService playerStatsService, IBaseStatsS
         );
 
     [HttpGet("{username}")]
-    [Authorize(Roles = "user, client")]
+    [Authorize(Roles = $"{OtrClaims.User}, {OtrClaims.Client}")]
     public async Task<ActionResult<PlayerStatsDTO?>> GetAsync(
         string username,
         [FromQuery] int? comparerId,
@@ -51,13 +50,13 @@ public class StatsController(IPlayerStatsService playerStatsService, IBaseStatsS
         );
 
     [HttpGet("histogram")]
-    [Authorize(Roles = "user, client")]
+    [Authorize(Roles = $"{OtrClaims.User}, {OtrClaims.Client}")]
     public async Task<ActionResult<IDictionary<int, int>>> GetRatingHistogramAsync(
         [FromQuery] int mode = 0
     ) => Ok(await _baseStatsService.GetHistogramAsync(mode));
 
     [HttpPost("ratingadjustments")]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = OtrClaims.System)]
     public async Task<IActionResult> PostAsync([FromBody] IEnumerable<RatingAdjustmentDTO> postBody)
     {
         await _playerStatsService.BatchInsertAsync(postBody);
@@ -65,7 +64,7 @@ public class StatsController(IPlayerStatsService playerStatsService, IBaseStatsS
     }
 
     [HttpDelete("ratingadjustments")]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = OtrClaims.System)]
     public async Task<IActionResult> TruncateAdjustmentsAsync()
     {
         await _playerStatsService.TruncateRatingAdjustmentsAsync();
@@ -73,7 +72,7 @@ public class StatsController(IPlayerStatsService playerStatsService, IBaseStatsS
     }
 
     [HttpPost("matchstats")]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = OtrClaims.System)]
     public async Task<IActionResult> PostAsync([FromBody] IEnumerable<PlayerMatchStatsDTO> postBody)
     {
         await _playerStatsService.BatchInsertAsync(postBody);
@@ -81,7 +80,7 @@ public class StatsController(IPlayerStatsService playerStatsService, IBaseStatsS
     }
 
     [HttpPost("ratingstats")]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = OtrClaims.System)]
     public async Task<IActionResult> PostAsync([FromBody] IEnumerable<MatchRatingStatsDTO> postBody)
     {
         await _playerStatsService.BatchInsertAsync(postBody);
@@ -89,7 +88,7 @@ public class StatsController(IPlayerStatsService playerStatsService, IBaseStatsS
     }
 
     [HttpPost("basestats")]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = OtrClaims.System)]
     public async Task<IActionResult> PostAsync([FromBody] IEnumerable<BaseStatsPostDTO> postBody)
     {
         await _playerStatsService.BatchInsertAsync(postBody);
@@ -97,7 +96,7 @@ public class StatsController(IPlayerStatsService playerStatsService, IBaseStatsS
     }
 
     [HttpPost("gamewinrecords")]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = OtrClaims.System)]
     public async Task<IActionResult> PostAsync([FromBody] IEnumerable<GameWinRecordDTO> postBody)
     {
         await _playerStatsService.BatchInsertAsync(postBody);
@@ -105,7 +104,7 @@ public class StatsController(IPlayerStatsService playerStatsService, IBaseStatsS
     }
 
     [HttpPost("matchwinrecords")]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = OtrClaims.System)]
     public async Task<IActionResult> PostAsync([FromBody] IEnumerable<MatchWinRecordDTO> postBody)
     {
         await _playerStatsService.BatchInsertAsync(postBody);
@@ -113,7 +112,7 @@ public class StatsController(IPlayerStatsService playerStatsService, IBaseStatsS
     }
 
     [HttpDelete]
-    [Authorize(Roles = "system")]
+    [Authorize(Roles = OtrClaims.System)]
     public async Task<IActionResult> TruncateAsync()
     {
         await _playerStatsService.TruncateAsync();

--- a/API/Controllers/TournamentsController.cs
+++ b/API/Controllers/TournamentsController.cs
@@ -12,8 +12,7 @@ namespace API.Controllers;
 [ApiController]
 [ApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]")]
-[Authorize(Roles = "user")]
-[Authorize(Roles = "whitelist")]
+[Authorize(Roles = OtrClaims.User)]
 public class TournamentsController(ITournamentsService tournamentsService, IMatchesService matchesService) : Controller
 {
     /// <summary>
@@ -22,7 +21,7 @@ public class TournamentsController(ITournamentsService tournamentsService, IMatc
     /// <remarks>Will not include match data</remarks>
     /// <response code="200">Returns all tournaments</response>
     [HttpGet]
-    [Authorize(Roles = "admin, system")]
+    [Authorize(Roles = OtrClaims.System)]
     [ProducesResponseType<IEnumerable<TournamentDTO>>(StatusCodes.Status200OK)]
     public async Task<IActionResult> ListAsync()
     {
@@ -121,7 +120,7 @@ public class TournamentsController(ITournamentsService tournamentsService, IMatc
     /// <response code="400">If JsonPatch data is malformed</response>
     /// <response code="200">Returns the patched tournament</response>
     [HttpPatch("{id:int}")]
-    [Authorize(Roles = "admin")]
+    [Authorize(Roles = OtrClaims.Admin)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<ModelStateDictionary>(StatusCodes.Status400BadRequest)]
@@ -167,7 +166,7 @@ public class TournamentsController(ITournamentsService tournamentsService, IMatc
     /// <response code="400">If the creation of matches was unsuccessful</response>
     /// <response code="201">Returns location information of the created matches</response>
     [HttpPost("{id:int}/matches")]
-    [Authorize(Roles = "admin")]
+    [Authorize(Roles = OtrClaims.Admin)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType<ModelStateDictionary>(StatusCodes.Status400BadRequest)]

--- a/API/Controllers/UsersController.cs
+++ b/API/Controllers/UsersController.cs
@@ -12,7 +12,6 @@ namespace API.Controllers;
 [ApiController]
 [ApiVersion(1)]
 [Authorize(Roles = OtrClaims.User)]
-[Authorize(Roles = OtrClaims.Whitelist)]
 [Route("api/v{version:apiVersion}/[controller]")]
 [SuppressMessage("ReSharper", "RouteTemplates.ActionRoutePrefixCanBeExtractedToControllerRoute")]
 public class UsersController(IUserService userService, IOAuthClientService clientService) : Controller

--- a/API/Handlers/Implementations/OAuthHandler.cs
+++ b/API/Handlers/Implementations/OAuthHandler.cs
@@ -56,7 +56,7 @@ public class OAuthHandler(
         // Because this user is logging in with osu!, we can
         // issue a new refresh token.
         var accessToken = GenerateAccessToken(user);
-        var refreshToken = GenerateRefreshToken(user.Id.ToString(), _jwtConfiguration.Value.Audience, "user");
+        var refreshToken = GenerateRefreshToken(user.Id.ToString(), _jwtConfiguration.Value.Audience, OtrClaims.User);
 
         _logger.LogDebug(
             "Authorized user with id {Id}, access expires in {seconds}",
@@ -181,7 +181,7 @@ public class OAuthHandler(
     /// <returns></returns>
     private string GenerateAccessToken(OAuthClient client)
     {
-        client.Scopes = [.. client.Scopes, "client"];
+        client.Scopes = [.. client.Scopes, OtrClaims.Client];
         IEnumerable<Claim> claims = client.Scopes.Select(role => new Claim(ClaimTypes.Role, role));
         var serializedOverrides = RateLimitOverridesSerializer.Serialize(client.RateLimitOverrides);
         if (!string.IsNullOrEmpty(serializedOverrides))
@@ -209,7 +209,7 @@ public class OAuthHandler(
     /// <returns></returns>
     private string GenerateAccessToken(User user)
     {
-        user.Scopes = [.. user.Scopes, "user"];
+        user.Scopes = [.. user.Scopes, OtrClaims.User];
         IEnumerable<Claim> claims = user.Scopes.Select(role => new Claim(ClaimTypes.Role, role));
         var serializedOverrides = RateLimitOverridesSerializer.Serialize(user.RateLimitOverrides);
         if (!string.IsNullOrEmpty(serializedOverrides))
@@ -285,7 +285,7 @@ public class OAuthHandler(
         var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtConfiguration.Value.Key));
         var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
 
-        if (role != "user" && role != "client")
+        if (role != OtrClaims.User && role != OtrClaims.Client)
         {
             throw new ArgumentException("Role must be either 'user' or 'client'");
         }

--- a/API/Middlewares/RequestLoggingMiddleware.cs
+++ b/API/Middlewares/RequestLoggingMiddleware.cs
@@ -1,7 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Text;
 
-namespace API;
+namespace API.Middlewares;
 
 public class RequestLoggingMiddleware(RequestDelegate next, ILogger<RequestLoggingMiddleware> logger)
 {

--- a/API/Middlewares/WhitelistEnforcementMiddleware.cs
+++ b/API/Middlewares/WhitelistEnforcementMiddleware.cs
@@ -1,0 +1,29 @@
+using API.Utilities;
+using Microsoft.AspNetCore.Authorization;
+
+namespace API.Middlewares;
+
+/// <summary>
+/// Middleware that enforces all requesting ClaimsPrinciples contain the whitelist claim
+/// </summary>
+public class WhitelistEnforcementMiddleware(RequestDelegate next)
+{
+    public async Task Invoke(HttpContext context)
+    {
+        // Check for [AllowAnonymous]
+        if (context.GetEndpoint()?.Metadata.GetMetadata<IAllowAnonymous>() is not null)
+        {
+            await next(context);
+            return;
+        }
+
+        if (!context.User.IsWhitelisted())
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+        }
+        else
+        {
+            await next(context);
+        }
+    }
+}

--- a/API/Middlewares/WhitelistEnforcementMiddleware.cs
+++ b/API/Middlewares/WhitelistEnforcementMiddleware.cs
@@ -17,7 +17,8 @@ public class WhitelistEnforcementMiddleware(RequestDelegate next)
             return;
         }
 
-        if (!context.User.IsWhitelisted() || !context.User.IsAdmin() || !context.User.IsSystem())
+        // Allow whitelisted and privileged requests
+        if (!context.User.IsWhitelisted() && !context.User.IsAdmin() && !context.User.IsSystem())
         {
             context.Response.StatusCode = StatusCodes.Status401Unauthorized;
         }

--- a/API/Middlewares/WhitelistEnforcementMiddleware.cs
+++ b/API/Middlewares/WhitelistEnforcementMiddleware.cs
@@ -17,7 +17,7 @@ public class WhitelistEnforcementMiddleware(RequestDelegate next)
             return;
         }
 
-        if (!context.User.IsWhitelisted())
+        if (!context.User.IsWhitelisted() || !context.User.IsAdmin() || !context.User.IsSystem())
         {
             context.Response.StatusCode = StatusCodes.Status401Unauthorized;
         }

--- a/API/Utilities/ClaimsPrincipalExtensions.cs
+++ b/API/Utilities/ClaimsPrincipalExtensions.cs
@@ -10,28 +10,28 @@ public static class ClaimsPrincipalExtensions
     /// Denotes the principal as having the admin role.
     /// </summary>
     public static bool IsAdmin(this ClaimsPrincipal claimsPrincipal) =>
-        IsInRole(claimsPrincipal, "admin");
+        IsInRole(claimsPrincipal, OtrClaims.Admin);
 
     /// <summary>
     /// Denotes the principal as having the system role.
     /// </summary>
-    public static bool IsSystem(this ClaimsPrincipal claimsPrincipal) => IsInRole(claimsPrincipal, "system");
+    public static bool IsSystem(this ClaimsPrincipal claimsPrincipal) => IsInRole(claimsPrincipal, OtrClaims.System);
 
     /// <summary>
     /// Denotes the principal as having the user role.
     /// </summary>
-    public static bool IsUser(this ClaimsPrincipal claimsPrincipal) => IsInRole(claimsPrincipal, "user");
+    public static bool IsUser(this ClaimsPrincipal claimsPrincipal) => IsInRole(claimsPrincipal, OtrClaims.User);
 
     /// <summary>
     /// Denotes the principal as having the client role.
     /// </summary>
-    public static bool IsClient(this ClaimsPrincipal claimsPrincipal) => IsInRole(claimsPrincipal, "client");
+    public static bool IsClient(this ClaimsPrincipal claimsPrincipal) => IsInRole(claimsPrincipal, OtrClaims.Client);
 
     /// <summary>
     /// Denotes the principal as having the verifier role.
     /// </summary>
     public static bool IsMatchVerifier(this ClaimsPrincipal claimsPrincipal) =>
-        IsInRole(claimsPrincipal, "verifier");
+        IsInRole(claimsPrincipal, OtrClaims.Verifier);
 
     /// <summary>
     /// Denotes the principle as having the whitelist role

--- a/API/Utilities/ClaimsPrincipalExtensions.cs
+++ b/API/Utilities/ClaimsPrincipalExtensions.cs
@@ -34,6 +34,12 @@ public static class ClaimsPrincipalExtensions
         IsInRole(claimsPrincipal, "verifier");
 
     /// <summary>
+    /// Denotes the principle as having the whitelist role
+    /// </summary>
+    public static bool IsWhitelisted(this ClaimsPrincipal claimsPrincipal) =>
+        IsInRole(claimsPrincipal, OtrClaims.Whitelist);
+
+    /// <summary>
     /// Returns the appropriate <see cref="MatchVerificationSource"/> enum for the principle
     /// </summary>
     public static MatchVerificationSource? VerificationSource(this ClaimsPrincipal claimsPrincipal) =>

--- a/API/Utilities/OtrClaims.cs
+++ b/API/Utilities/OtrClaims.cs
@@ -46,7 +46,7 @@ public static class OtrClaims
     public const string Submitter = "submit";
 
     /// <summary>
-    /// Claim granted to users and clients to restrict access during
+    /// Claim granted to users and clients to restrict api access
     /// </summary>
     public const string Whitelist = "whitelist";
 

--- a/API/Utilities/OtrClaims.cs
+++ b/API/Utilities/OtrClaims.cs
@@ -1,14 +1,8 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace API.Utilities;
-
-// TODO: Refactor all uses of the below strings to use OtrClaims
-// Suppression can be removed once this is done
 
 /// <summary>
 /// String values that represent valid claims for authorized users
 /// </summary>
-[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
 public static class OtrClaims
 {
     /// <summary>

--- a/API/example.appsettings.json
+++ b/API/example.appsettings.json
@@ -21,7 +21,8 @@
     "Audience": ""
   },
   "Auth": {
-    "ClientCallbackUrl": ""
+    "ClientCallbackUrl": "",
+    "EnforceWhitelist": false
   },
   "RateLimit": {
     "PermitLimit": 30,

--- a/APITests/Utilities/ClaimsPrincipalExtensionsTests.cs
+++ b/APITests/Utilities/ClaimsPrincipalExtensionsTests.cs
@@ -12,13 +12,14 @@ public class ClaimsPrincipalExtensionsTests
         Assert.False(claims.IsAdmin());
         Assert.False(claims.IsSystem());
         Assert.False(claims.IsMatchVerifier());
+        Assert.False(claims.IsWhitelisted());
     }
 
     [Fact]
     public void ClaimsPrincipal_IsAdmin()
     {
         var claims = new ClaimsPrincipal();
-        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new(ClaimTypes.Role, "admin") }));
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new(ClaimTypes.Role, OtrClaims.Admin) }));
 
         Assert.True(claims.IsAdmin());
     }
@@ -27,7 +28,7 @@ public class ClaimsPrincipalExtensionsTests
     public void ClaimsPrincipal_IsMatchVerifier()
     {
         var claims = new ClaimsPrincipal();
-        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new(ClaimTypes.Role, "verifier") }));
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new(ClaimTypes.Role, OtrClaims.Verifier) }));
 
         Assert.True(claims.IsMatchVerifier());
     }
@@ -36,16 +37,25 @@ public class ClaimsPrincipalExtensionsTests
     public void ClaimsPrincipal_IsUser()
     {
         var claims = new ClaimsPrincipal();
-        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new(ClaimTypes.Role, "user") }));
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new(ClaimTypes.Role, OtrClaims.User) }));
 
         Assert.True(claims.IsUser());
+    }
+
+    [Fact]
+    public void ClaimsPrinciple_IsWhitelisted()
+    {
+        var claims = new ClaimsPrincipal();
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new(ClaimTypes.Role, OtrClaims.Whitelist) }));
+
+        Assert.True(claims.IsWhitelisted());
     }
 
     [Fact]
     public void ClaimsPrincipal_IsAdmin_WhenClaimTypeMapped()
     {
         var claims = new ClaimsPrincipal();
-        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("role", "admin") }));
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("role", OtrClaims.Admin) }));
 
         Assert.True(claims.IsAdmin());
     }
@@ -54,7 +64,7 @@ public class ClaimsPrincipalExtensionsTests
     public void ClaimsPrincipal_IsMatchVerifier_WhenClaimTypeMapped()
     {
         var claims = new ClaimsPrincipal();
-        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("role", "verifier") }));
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("role", OtrClaims.Verifier) }));
 
         Assert.True(claims.IsMatchVerifier());
         Assert.False(claims.IsAdmin());
@@ -65,16 +75,25 @@ public class ClaimsPrincipalExtensionsTests
     public void ClaimsPrincipal_IsUser_WhenClaimTypeMapped()
     {
         var claims = new ClaimsPrincipal();
-        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("role", "user") }));
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("role", OtrClaims.User) }));
 
         Assert.True(claims.IsUser());
+    }
+
+    [Fact]
+    public void ClaimsPrinciple_IsWhitelisted_WhenClaimTypeMapped()
+    {
+        var claims = new ClaimsPrincipal();
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("role", OtrClaims.Whitelist) }));
+
+        Assert.True(claims.IsWhitelisted());
     }
 
     [Fact]
     public void ClaimsPrincipal_IsNotAdmin_WhenClaimTypeInvalid()
     {
         var claims = new ClaimsPrincipal();
-        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("123", "admin") }));
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("123", OtrClaims.Admin) }));
 
         Assert.False(claims.IsAdmin());
     }
@@ -83,7 +102,7 @@ public class ClaimsPrincipalExtensionsTests
     public void ClaimsPrincipal_IsNotMatchVerifier_WhenClaimTypeInvalid()
     {
         var claims = new ClaimsPrincipal();
-        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("123", "verifier") }));
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("123", OtrClaims.Verifier) }));
 
         Assert.False(claims.IsMatchVerifier());
     }
@@ -92,8 +111,17 @@ public class ClaimsPrincipalExtensionsTests
     public void ClaimsPrincipal_IsNotUser_WhenClaimTypeInvalid()
     {
         var claims = new ClaimsPrincipal();
-        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("123", "user") }));
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("123", OtrClaims.User) }));
 
         Assert.False(claims.IsUser());
+    }
+
+    [Fact]
+    public void ClaimsPrinciple_IsNotWhitelisted_WhenClaimTypeInvalid()
+    {
+        var claims = new ClaimsPrincipal();
+        claims.AddIdentity(new ClaimsIdentity(new List<Claim> { new("123", OtrClaims.Whitelist) }));
+
+        Assert.False(claims.IsWhitelisted());
     }
 }


### PR DESCRIPTION
As we move towards a beta release, it makes sense to want to have a way to enable and disable the whitelist we have activated instead of granting all users the `whitelist` claim or remove the attributes from the controllers completely. Using the new `WhitelistEnforcementMiddleware`, the behavior can be preserved for when we need to restrict access, but also disabled when we need to do so. The middleware asserts that all requests have either the `whitelist`, `admin`, or `system` claim when active. Activation of this middleware is determined through a new config value `Auth.EnforceWhitelist`.

Since this pull edits all of the controllers anyway, I decided to include the relevant changes for 232 as well.

Closes #232