### PR TITLE
Disable lazy loading and use `AsNoTracking` for all table fetches

### DIFF
--- a/API/OtrContext.cs
+++ b/API/OtrContext.cs
@@ -34,7 +34,6 @@ public partial class OtrContext(
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) =>
         optionsBuilder
-            .UseLazyLoadingProxies()
             .UseNpgsql(_configuration.Value.DefaultConnection);
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/API/Repositories/Implementations/BeatmapRepository.cs
+++ b/API/Repositories/Implementations/BeatmapRepository.cs
@@ -11,8 +11,6 @@ public class BeatmapRepository(OtrContext context) : RepositoryBase<Beatmap>(con
 {
     private readonly OtrContext _context = context;
 
-    public override async Task<IEnumerable<Beatmap>> GetAllAsync() => await _context.Beatmaps.ToListAsync();
-
     public async Task<Beatmap?> GetAsync(long beatmapId) =>
         await _context.Beatmaps.FirstOrDefaultAsync(x => x.BeatmapId == beatmapId);
 

--- a/API/Repositories/Implementations/RepositoryBase.cs
+++ b/API/Repositories/Implementations/RepositoryBase.cs
@@ -95,5 +95,5 @@ public class RepositoryBase<T> : IRepository<T>
         return await _context.SaveChangesAsync();
     }
 
-    public virtual async Task<IEnumerable<T>> GetAllAsync() => await _context.Set<T>().ToListAsync();
+    public virtual async Task<IEnumerable<T>> GetAllAsync() => await _context.Set<T>().AsNoTracking().ToListAsync();
 }

--- a/API/Repositories/Implementations/UserRepository.cs
+++ b/API/Repositories/Implementations/UserRepository.cs
@@ -36,6 +36,16 @@ public class UserRepository(OtrContext context) : RepositoryBase<User>(context),
         );
     }
 
+    public async Task<IEnumerable<OAuthClient>> GetClientsAsync(int id) =>
+        (await _context.Users
+            .Include(u => u.Clients)
+            .FirstOrDefaultAsync(u => u.Id == id))?.Clients ?? new List<OAuthClient>();
+
+    public async Task<IEnumerable<Match>> GetSubmissionsAsync(int id) =>
+        (await _context.Users
+            .Include(u => u.SubmittedMatches)
+            .FirstOrDefaultAsync(u => u.Id == id))?.SubmittedMatches ?? new List<Match>();
+
     private IQueryable<User> UserBaseQuery() =>
         _context.Users
             .Include(x => x.Player);

--- a/API/Repositories/Interfaces/IUserRepository.cs
+++ b/API/Repositories/Interfaces/IUserRepository.cs
@@ -11,7 +11,17 @@ public interface IUserRepository : IRepository<User>
     Task<User?> GetByPlayerIdAsync(int playerId);
 
     /// <summary>
-    /// Gets user for the given player id, or create if one doesn't exist
+    /// Gets a user for the given player id, or create if one doesn't exist
     /// </summary>
     Task<User> GetByPlayerIdOrCreateAsync(int playerId);
+
+    /// <summary>
+    /// Gets a list of OAuth clients owned by the user for the given id
+    /// </summary>
+    Task<IEnumerable<OAuthClient>> GetClientsAsync(int id);
+
+    /// <summary>
+    /// Gets a list of matches submitted by the user for the given id
+    /// </summary>
+    Task<IEnumerable<Match>> GetSubmissionsAsync(int id);
 }

--- a/API/Services/Implementations/UserService.cs
+++ b/API/Services/Implementations/UserService.cs
@@ -16,10 +16,10 @@ public class UserService(IUserRepository userRepository, IMatchesRepository matc
         mapper.Map<UserDTO?>(await userRepository.GetAsync(id));
 
     public async Task<IEnumerable<OAuthClientDTO>?> GetClientsAsync(int id) =>
-        mapper.Map<IEnumerable<OAuthClientDTO>?>((await userRepository.GetAsync(id))?.Clients?.ToList());
+        mapper.Map<IEnumerable<OAuthClientDTO>?>(await userRepository.GetClientsAsync(id));
 
     public async Task<IEnumerable<MatchSubmissionStatusDTO>?> GetSubmissionsAsync(int id) =>
-        mapper.Map<IEnumerable<MatchSubmissionStatusDTO>?>((await userRepository.GetAsync(id))?.SubmittedMatches?.ToList());
+        mapper.Map<IEnumerable<MatchSubmissionStatusDTO>?>(await userRepository.GetSubmissionsAsync(id));
 
     public async Task<bool> RejectSubmissionsAsync(int id, int? rejecterUserId,
         MatchVerificationSource verificationSource)


### PR DESCRIPTION
Closes #237

- Disables lazy loading by default - this was causing the `GetAllAsync` repository methods to return ALL associated entities by default. Perhaps this is a reason for some of the performance issues I've noticed lately.
- Use `.AsNoTracking()` for all of the `GetAllAsync` queries unless overridden.
- Remove a useless `GetAllAsync` override in `BeatmapRepository`.

Depends on:

- [x] #299 