### PR TITLE
Implement new `MatchWinRecord` schema

### DIFF
--- a/API/Controllers/PlayersController.cs
+++ b/API/Controllers/PlayersController.cs
@@ -14,13 +14,11 @@ namespace API.Controllers;
 [Route("api/v{version:apiVersion}/[controller]")]
 public class PlayersController(IPlayerService playerService) : Controller
 {
-    private readonly IPlayerService _playerService = playerService;
-
     [HttpGet("all")]
     [Authorize(Roles = OtrClaims.System)]
     public async Task<IActionResult> GetAllAsync()
     {
-        IEnumerable<PlayerDTO> players = await _playerService.GetAllAsync();
+        IEnumerable<PlayerDTO> players = await playerService.GetAllAsync();
         return Ok(players);
     }
 
@@ -30,7 +28,7 @@ public class PlayersController(IPlayerService playerService) : Controller
     [EndpointDescription("Get player info searching first by id, then osuId, then username")]
     public async Task<ActionResult<PlayerInfoDTO?>> GetAsync(string key)
     {
-        PlayerInfoDTO? info = await _playerService.GetVersatileAsync(key);
+        PlayerInfoDTO? info = await playerService.GetVersatileAsync(key);
 
         if (info == null)
         {
@@ -44,7 +42,7 @@ public class PlayersController(IPlayerService playerService) : Controller
     [Authorize(Roles = OtrClaims.System)]
     public async Task<ActionResult<IEnumerable<PlayerRanksDTO>>> GetAllRanksAsync()
     {
-        IEnumerable<PlayerRanksDTO> ranks = await _playerService.GetAllRanksAsync();
+        IEnumerable<PlayerRanksDTO> ranks = await playerService.GetAllRanksAsync();
         return Ok(ranks);
     }
 
@@ -52,7 +50,7 @@ public class PlayersController(IPlayerService playerService) : Controller
     [Authorize(Roles = OtrClaims.System)]
     public async Task<ActionResult<IEnumerable<PlayerIdMappingDTO>>> GetIdMappingAsync()
     {
-        IEnumerable<PlayerIdMappingDTO> mapping = await _playerService.GetIdMappingAsync();
+        IEnumerable<PlayerIdMappingDTO> mapping = await playerService.GetIdMappingAsync();
         return Ok(mapping);
     }
 
@@ -64,7 +62,7 @@ public class PlayersController(IPlayerService playerService) : Controller
     )]
     public async Task<IActionResult> GetCountryMappingAsync()
     {
-        IEnumerable<PlayerCountryMappingDTO> mapping = await _playerService.GetCountryMappingAsync();
+        IEnumerable<PlayerCountryMappingDTO> mapping = await playerService.GetCountryMappingAsync();
         return Ok(mapping);
     }
 }

--- a/API/DTOs/PlayerMatchStatsDTO.cs
+++ b/API/DTOs/PlayerMatchStatsDTO.cs
@@ -5,10 +5,10 @@ namespace API.DTOs;
 /// </summary>
 public class PlayerMatchStatsDTO
 {
-    public int Id { get; set; }
+    public int PlayerId { get; set; }
     public int MatchId { get; set; }
     public bool Won { get; set; }
-    public int AverageScore { get; set; }
+    public double AverageScore { get; set; }
     public double AverageMisses { get; set; }
     public double AverageAccuracy { get; set; }
     public double AveragePlacement { get; set; }

--- a/API/DTOs/PlayerMatchStatsDTO.cs
+++ b/API/DTOs/PlayerMatchStatsDTO.cs
@@ -1,8 +1,11 @@
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
 namespace API.DTOs;
 
 /// <summary>
 /// Represents a player's match stats
 /// </summary>
+// ReSharper disable once ClassNeverInstantiated.Global
 public class PlayerMatchStatsDTO
 {
     /// <summary>

--- a/API/DTOs/PlayerMatchStatsDTO.cs
+++ b/API/DTOs/PlayerMatchStatsDTO.cs
@@ -1,20 +1,71 @@
 namespace API.DTOs;
 
 /// <summary>
-/// Used for POSTing match statistics to the API
+/// Represents a player's match stats
 /// </summary>
 public class PlayerMatchStatsDTO
 {
+    /// <summary>
+    /// The id of the player
+    /// </summary>
     public int PlayerId { get; set; }
+    /// <summary>
+    /// The id of the match
+    /// </summary>
     public int MatchId { get; set; }
+    /// <summary>
+    /// Whether the player (or their team) won this match
+    /// </summary>
     public bool Won { get; set; }
+    /// <summary>
+    /// The player's average score in this match
+    /// </summary>
     public double AverageScore { get; set; }
+    /// <summary>
+    /// The player's average misses in this match
+    /// </summary>
     public double AverageMisses { get; set; }
+    /// <summary>
+    /// The player's average accuracy in this match
+    /// </summary>
     public double AverageAccuracy { get; set; }
+    /// <summary>
+    /// The player's average placement in this match
+    /// </summary>
     public double AveragePlacement { get; set; }
+    /// <summary>
+    /// The number of games the player (or their team) won in the match.
+    /// </summary>
+    /// <remarks>
+    /// The player must have participated in the game for this to count.
+    /// If they were on the same team as the winner, but not in the lobby,
+    /// this will not count towards the total.
+    /// </remarks>
     public int GamesWon { get; set; }
+    /// <summary>
+    /// The number of games the player (or their team) lost in the match.
+    /// </summary>
+    /// <remarks>
+    ///  The player must have participated in the game for this to count.
+    ///  If they were on the same team as the loser, but not in the lobby,
+    ///  this will not count towards the total.
+    /// </remarks>
     public int GamesLost { get; set; }
+    /// <summary>
+    /// The total number of games the player participated in during this match
+    /// </summary>
     public int GamesPlayed { get; set; }
+    /// <summary>
+    /// A unique list of player ids that were on the same team as the player in this match.
+    /// </summary>
+    /// <remarks>
+    /// Does not include the player's id. Should be empty for a 1v1.
     public int[] TeammateIds { get; set; } = [];
+    /// <summary>
+    /// A unique list of player ids that were on the opposing team as the player in this match.
+    /// </summary>
+    /// <remarks>
+    /// In a 1v1, this would only contain the opponent's id.
+    /// </remarks>
     public int[] OpponentIds { get; set; } = [];
 }

--- a/API/Entities/MatchWinRecord.cs
+++ b/API/Entities/MatchWinRecord.cs
@@ -1,40 +1,62 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using API.Osu.Enums;
 
 namespace API.Entities;
 
 /// <summary>
-/// Represents a record of who played in a match and who won/lost.
+/// Represents a record of who played in a match and who won or lost.
 /// </summary>
 [Table("match_win_records")]
 public class MatchWinRecord
 {
+    /// <summary>
+    /// The id of this record
+    /// </summary>
     [Column("id")]
     public int Id { get; set; }
-
+    /// <summary>
+    /// The id of the match this record is for
+    /// </summary>
     [Column("match_id")]
     public int MatchId { get; set; }
-
+    /// <summary>
+    /// The ids of the players on the losing team
+    /// </summary>
     [Column("loser_roster")]
     public int[] LoserRoster { get; set; } = [];
-
+    /// <summary>
+    /// The ids of the players on the winning team
+    /// </summary>
     [Column("winner_roster")]
     public int[] WinnerRoster { get; set; } = [];
-
+    /// <summary>
+    /// The points the winning team scored
+    /// </summary>
     [Column("winner_points")]
     public int WinnerPoints { get; set; }
-
+    /// <summary>
+    /// The points the losing team scored
+    /// </summary>
     [Column("loser_points")]
     public int LoserPoints { get; set; }
-
+    /// <summary>
+    /// The team that won the match
+    /// </summary>
     [Column("winner_team")]
-    public int? WinnerTeam { get; set; }
-
+    public Team? WinnerTeam { get; set; }
+    /// <summary>
+    /// The team that lost the match
+    /// </summary>
     [Column("loser_team")]
-    public int? LoserTeam { get; set; }
-
+    public Team? LoserTeam { get; set; }
+    /// <summary>
+    /// The type of match this record is for (team or head-to-head)
+    /// </summary>
     [Column("match_type")]
     public Enums.MatchType? MatchType { get; set; }
-
+    /// <summary>
+    /// The <see cref="Match"/> this record belongs to
+    /// </summary>
     [InverseProperty("WinRecord")]
     public virtual Match Match { get; set; } = null!;
 }

--- a/API/Entities/MatchWinRecord.cs
+++ b/API/Entities/MatchWinRecord.cs
@@ -14,18 +14,17 @@ public class MatchWinRecord
     [Column("match_id")]
     public int MatchId { get; set; }
 
-    // Team arrays can represent individual players in individual matches (head to head)
-    [Column("team_blue")]
-    public int[] TeamBlue { get; set; } = [];
+    [Column("loser_roster")]
+    public int[] LoserRoster { get; set; } = [];
 
-    [Column("team_red")]
-    public int[] TeamRed { get; set; } = [];
+    [Column("winner_roster")]
+    public int[] WinnerRoster { get; set; } = [];
 
-    [Column("blue_points")]
-    public int BluePoints { get; set; }
+    [Column("winner_points")]
+    public int WinnerPoints { get; set; }
 
-    [Column("red_points")]
-    public int RedPoints { get; set; }
+    [Column("loser_points")]
+    public int LoserPoints { get; set; }
 
     [Column("winner_team")]
     public int? WinnerTeam { get; set; }

--- a/API/Entities/MatchWinRecord.cs
+++ b/API/Entities/MatchWinRecord.cs
@@ -58,5 +58,5 @@ public class MatchWinRecord
     /// The <see cref="Match"/> this record belongs to
     /// </summary>
     [InverseProperty("WinRecord")]
-    public virtual Match Match { get; set; } = null!;
+    public Match Match { get; set; } = null!;
 }

--- a/API/Entities/PlayerMatchStats.cs
+++ b/API/Entities/PlayerMatchStats.cs
@@ -23,7 +23,7 @@ public class PlayerMatchStats
     public bool Won { get; set; }
 
     [Column("average_score")]
-    public int AverageScore { get; set; }
+    public double AverageScore { get; set; }
 
     [Column("average_misses")]
     public double AverageMisses { get; set; }

--- a/API/Entities/PlayerMatchStats.cs
+++ b/API/Entities/PlayerMatchStats.cs
@@ -1,4 +1,7 @@
 using System.ComponentModel.DataAnnotations.Schema;
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
+// ReSharper disable ClassWithVirtualMembersNeverInherited.Global
+// ReSharper disable EntityFramework.ModelValidation.CircularDependency
 
 namespace API.Entities;
 

--- a/API/Migrations/20240507221604_MatchWinRecord_NewSchema.Designer.cs
+++ b/API/Migrations/20240507221604_MatchWinRecord_NewSchema.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace API.Migrations
 {
     [DbContext(typeof(OtrContext))]
-    partial class OtrContextModelSnapshot : ModelSnapshot
+    [Migration("20240507221604_MatchWinRecord_NewSchema")]
+    partial class MatchWinRecord_NewSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API/Migrations/20240507221604_MatchWinRecord_NewSchema.cs
+++ b/API/Migrations/20240507221604_MatchWinRecord_NewSchema.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Migrations
+{
+    /// <inheritdoc />
+    public partial class MatchWinRecord_NewSchema : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "team_red",
+                table: "match_win_records",
+                newName: "winner_roster");
+
+            migrationBuilder.RenameColumn(
+                name: "team_blue",
+                table: "match_win_records",
+                newName: "loser_roster");
+
+            migrationBuilder.RenameColumn(
+                name: "red_points",
+                table: "match_win_records",
+                newName: "winner_points");
+
+            migrationBuilder.RenameColumn(
+                name: "blue_points",
+                table: "match_win_records",
+                newName: "loser_points");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_match_win_records_team_red",
+                table: "match_win_records",
+                newName: "IX_match_win_records_winner_roster");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_match_win_records_team_blue",
+                table: "match_win_records",
+                newName: "IX_match_win_records_loser_roster");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "winner_roster",
+                table: "match_win_records",
+                newName: "team_red");
+
+            migrationBuilder.RenameColumn(
+                name: "winner_points",
+                table: "match_win_records",
+                newName: "red_points");
+
+            migrationBuilder.RenameColumn(
+                name: "loser_roster",
+                table: "match_win_records",
+                newName: "team_blue");
+
+            migrationBuilder.RenameColumn(
+                name: "loser_points",
+                table: "match_win_records",
+                newName: "blue_points");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_match_win_records_winner_roster",
+                table: "match_win_records",
+                newName: "IX_match_win_records_team_red");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_match_win_records_loser_roster",
+                table: "match_win_records",
+                newName: "IX_match_win_records_team_blue");
+        }
+    }
+}

--- a/API/Migrations/20240508010133_PlayerMatchStats_Double.Designer.cs
+++ b/API/Migrations/20240508010133_PlayerMatchStats_Double.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace API.Migrations
 {
     [DbContext(typeof(OtrContext))]
-    partial class OtrContextModelSnapshot : ModelSnapshot
+    [Migration("20240508010133_PlayerMatchStats_Double")]
+    partial class PlayerMatchStats_Double
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API/Migrations/20240508010133_PlayerMatchStats_Double.cs
+++ b/API/Migrations/20240508010133_PlayerMatchStats_Double.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Migrations
+{
+    /// <inheritdoc />
+    public partial class PlayerMatchStats_Double : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<double>(
+                name: "average_score",
+                table: "player_match_stats",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "average_score",
+                table: "player_match_stats",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+        }
+    }
+}

--- a/API/Migrations/20240509235704_MatchWinRecord_TeamEnum.Designer.cs
+++ b/API/Migrations/20240509235704_MatchWinRecord_TeamEnum.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace API.Migrations
 {
     [DbContext(typeof(OtrContext))]
-    partial class OtrContextModelSnapshot : ModelSnapshot
+    [Migration("20240509235704_MatchWinRecord_TeamEnum")]
+    partial class MatchWinRecord_TeamEnum
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API/Migrations/20240509235704_MatchWinRecord_TeamEnum.cs
+++ b/API/Migrations/20240509235704_MatchWinRecord_TeamEnum.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Migrations
+{
+    /// <inheritdoc />
+    public partial class MatchWinRecord_TeamEnum : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/API/Osu/AutomationChecks/ScoreAutomationChecks.cs
+++ b/API/Osu/AutomationChecks/ScoreAutomationChecks.cs
@@ -19,5 +19,5 @@ public static class ScoreAutomationChecks
         );
     }
 
-    public static bool PassesValueCheck(MatchScore score) => score.Score > 0;
+    public static bool PassesValueCheck(MatchScore score) => score.Score > 1000;
 }

--- a/API/OtrContext.cs
+++ b/API/OtrContext.cs
@@ -34,7 +34,6 @@ public partial class OtrContext(
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) =>
         optionsBuilder
-            .UseLazyLoadingProxies()
             .UseNpgsql(_configuration.Value.DefaultConnection);
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/API/OtrContext.cs
+++ b/API/OtrContext.cs
@@ -237,8 +237,8 @@ public partial class OtrContext(
                 .OnDelete(DeleteBehavior.Cascade)
                 .HasConstraintName("match_win_records_matches_id_fk");
 
-            entity.HasIndex(e => e.TeamBlue);
-            entity.HasIndex(e => e.TeamRed);
+            entity.HasIndex(e => e.LoserRoster);
+            entity.HasIndex(e => e.WinnerRoster);
         });
 
         modelBuilder.Entity<OAuthClient>(entity =>

--- a/API/Repositories/Implementations/MatchWinRecordRepository.cs
+++ b/API/Repositories/Implementations/MatchWinRecordRepository.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using API.DTOs;
 using API.Entities;
+using API.Osu.Enums;
 using API.Repositories.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
@@ -11,7 +12,6 @@ namespace API.Repositories.Implementations;
 public class MatchWinRecordRepository(OtrContext context, IPlayerRepository playerRepository) : RepositoryBase<MatchWinRecord>(context), IMatchWinRecordRepository
 {
     private readonly OtrContext _context = context;
-    private readonly IPlayerRepository _playerRepository = playerRepository;
 
     public async Task BatchInsertAsync(IEnumerable<MatchWinRecordDTO> postBody)
     {
@@ -24,8 +24,8 @@ public class MatchWinRecordRepository(OtrContext context, IPlayerRepository play
                 WinnerRoster = item.TeamRed,
                 LoserPoints = item.BluePoints,
                 WinnerPoints = item.RedPoints,
-                WinnerTeam = item.WinnerTeam,
-                LoserTeam = item.LoserTeam,
+                WinnerTeam = (Team?)item.WinnerTeam,
+                LoserTeam = (Team?)item.LoserTeam,
                 MatchType = (Enums.MatchType?)item.MatchType
             };
 
@@ -76,8 +76,8 @@ public class MatchWinRecordRepository(OtrContext context, IPlayerRepository play
             {
                 PlayerId = x.Key,
                 Frequency = x.Count(),
-                OsuId = _playerRepository.GetOsuIdAsync(x.Key).GetAwaiter().GetResult(),
-                Username = _playerRepository.GetUsernameAsync(x.Key).GetAwaiter().GetResult()
+                OsuId = playerRepository.GetOsuIdAsync(x.Key).GetAwaiter().GetResult(),
+                Username = playerRepository.GetUsernameAsync(x.Key).GetAwaiter().GetResult()
             });
     }
 
@@ -114,8 +114,8 @@ public class MatchWinRecordRepository(OtrContext context, IPlayerRepository play
             {
                 PlayerId = x.Key,
                 Frequency = x.Count(),
-                OsuId = _playerRepository.GetOsuIdAsync(x.Key).GetAwaiter().GetResult(),
-                Username = _playerRepository.GetUsernameAsync(x.Key).GetAwaiter().GetResult()
+                OsuId = playerRepository.GetOsuIdAsync(x.Key).GetAwaiter().GetResult(),
+                Username = playerRepository.GetUsernameAsync(x.Key).GetAwaiter().GetResult()
             });
     }
 }

--- a/API/Repositories/Implementations/MatchesRepository.cs
+++ b/API/Repositories/Implementations/MatchesRepository.cs
@@ -40,7 +40,9 @@ public class MatchesRepository(
         await MatchBaseQuery(filterInvalidMatches).FirstAsync(x => x.Id == id);
 
     public async Task<IEnumerable<Match>> GetAsync(IEnumerable<int> ids, bool onlyIncludeFiltered) =>
-        await MatchBaseQuery(onlyIncludeFiltered).Where(x => ids.Contains(x.Id)).ToListAsync();
+        await MatchBaseQuery(onlyIncludeFiltered)
+            .AsNoTracking()
+            .Where(x => ids.Contains(x.Id)).ToListAsync();
 
     public async Task<IEnumerable<int>> GetAllAsync(bool filterInvalidMatches) =>
         await MatchBaseQuery(filterInvalidMatches).Select(x => x.Id).ToListAsync();
@@ -342,7 +344,7 @@ public class MatchesRepository(
             .ThenInclude(x => x.MatchScores.Where(y => y.IsValid == true))
             .Include(x => x.Games.Where(y => y.VerificationStatus == GameVerificationStatus.Verified))
             .ThenInclude(x => x.Beatmap)
-            .Where(x => x.Games.Count > 0)
+            .Where(x => x.Games.Any(y => y.VerificationStatus == GameVerificationStatus.Verified && y.MatchScores.Any(z => z.IsValid == true)))
             .OrderBy(x => x.StartTime);
     }
 }

--- a/API/Services/Implementations/PlayerStatsService.cs
+++ b/API/Services/Implementations/PlayerStatsService.cs
@@ -198,7 +198,7 @@ public class PlayerStatsService(
         {
             var stats = new PlayerMatchStats
             {
-                PlayerId = item.Id,
+                PlayerId = item.PlayerId,
                 MatchId = item.MatchId,
                 Won = item.Won,
                 AverageScore = item.AverageScore,


### PR DESCRIPTION
The otr-processor uses a new `MatchWinRecord` schema as shown here https://github.com/osu-tournament-rating/otr-processor/pull/45

This is necessary to upload the stats correctly to the database.

Closes #298 