### PR TITLE
Implement strict access control to `User` resources

### DIFF
--- a/API/Authorization/AuthorizationPolicies.cs
+++ b/API/Authorization/AuthorizationPolicies.cs
@@ -1,0 +1,15 @@
+using API.Utilities;
+
+namespace API.Authorization;
+
+/// <summary>
+/// String constants that represent authorization policies
+/// </summary>
+public static class AuthorizationPolicies
+{
+    /// <summary>
+    /// Policy that allows access from <see cref="OtrClaims.Admin"/> and <see cref="OtrClaims.System"/> requests,
+    /// as well as redirected requests from unprivileged users to allow accessing their own resources.
+    /// </summary>
+    public const string AccessUserResources = "AccessUserResources";
+}

--- a/API/Authorization/Handlers/AccessUserResourcesAuthorizationHandler.cs
+++ b/API/Authorization/Handlers/AccessUserResourcesAuthorizationHandler.cs
@@ -1,0 +1,40 @@
+using API.Authorization.Requirements;
+using API.Utilities;
+using Microsoft.AspNetCore.Authorization;
+
+namespace API.Authorization.Handlers;
+
+/// <summary>
+/// Handles authorization for the policy <see cref="AuthorizationPolicies.AccessUserResources"/>
+/// </summary>
+public class AccessUserResourcesAuthorizationHandler : AuthorizationHandler<AccessUserResourcesRequirement>
+{
+    /// <inheritdoc/>
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        AccessUserResourcesRequirement requirement
+    )
+    {
+        if (context.Resource is not HttpContext httpContext)
+        {
+            context.Fail();
+            return Task.CompletedTask;
+        }
+
+        var userId = context.User.AuthorizedIdentity();
+        // Reject if the request has no user id or does not pass "id" in route
+        if (!int.TryParse(httpContext.Request.RouteValues["id"]?.ToString(), out var routeId) || !userId.HasValue)
+        {
+            context.Fail();
+            return Task.CompletedTask;
+        }
+
+        // Allow requests that are privileged or have matching user id and target route id
+        if (context.User.IsAdmin() || context.User.IsSystem() || (requirement.AllowSelf && userId == routeId))
+        {
+            context.Succeed(requirement);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/API/Authorization/Requirements/AccessUserResourcesRequirement.cs
+++ b/API/Authorization/Requirements/AccessUserResourcesRequirement.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace API.Authorization.Requirements;
+
+/// <summary>
+/// Requirement that controls user access for the policy <see cref="AuthorizationPolicies.AccessUserResources"/>
+/// </summary>
+public class AccessUserResourcesRequirement(bool allowSelf) : IAuthorizationRequirement
+{
+    /// <summary>
+    /// Denotes users as having access to the target resource
+    /// </summary>
+    public bool AllowSelf { get; } = allowSelf;
+}

--- a/API/Controllers/MeController.cs
+++ b/API/Controllers/MeController.cs
@@ -9,7 +9,6 @@ namespace API.Controllers;
 [ApiController]
 [ApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]")]
-[Authorize(Roles = OtrClaims.User)]
 public class MeController(IUserService userService) : Controller
 {
     /// <summary>
@@ -18,6 +17,7 @@ public class MeController(IUserService userService) : Controller
     /// <response code="401">If the requester is not properly authenticated</response>
     /// <response code="302">Redirects to `GET` `/users/{id}`</response>
     [HttpGet]
+    [Authorize(Roles = OtrClaims.User)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status302Found)]
     public IActionResult Get()
@@ -42,6 +42,7 @@ public class MeController(IUserService userService) : Controller
     /// <response code="404">If a user's player entry does not exist</response>
     /// <response code="302">Redirects to `GET` `/stats/{id}`</response>
     [HttpGet("stats")]
+    [Authorize(Roles = OtrClaims.User)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status302Found)]

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -4,6 +4,9 @@ using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading.RateLimiting;
 using API;
+using API.Authorization;
+using API.Authorization.Handlers;
+using API.Authorization.Requirements;
 using API.BackgroundWorkers;
 using API.Configurations;
 using API.Entities;
@@ -313,6 +316,19 @@ builder
             IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtConfiguration.Key))
         };
     });
+
+#endregion
+
+#region Authorization Configuration
+
+builder.Services.AddAuthorizationBuilder()
+    .AddPolicy(AuthorizationPolicies.AccessUserResources, policy =>
+        policy
+            .RequireAuthenticatedUser()
+            .AddRequirements(new AccessUserResourcesRequirement(allowSelf: true))
+    );
+
+builder.Services.AddSingleton<IAuthorizationHandler, AccessUserResourcesAuthorizationHandler>();
 
 #endregion
 


### PR DESCRIPTION
Since 99% of data that should be publicly accessible is consolidated into `Player` resources, it makes sense to internalize `User` resources to strictly admins and the resource owners.

This pull accomplishes this by implementing a custom authorization policy. The policy checks the passed `id` route parameter against the user id of the incoming request. If the ids match, or if the incoming request is of an admin user or system client, the request is authorized. This allows us to maintain our usage of redirection on `/me` endpoints while still allowing users with elevated privileges access to any user resources.