### PR TITLE
Fix average mod scores being larger than expected

### DIFF
--- a/API/Entities/Game.cs
+++ b/API/Entities/Game.cs
@@ -134,5 +134,5 @@ public class Game : IUpdateableEntity
     /// The win record for the game
     /// </summary>
     [InverseProperty("Game")]
-    public virtual GameWinRecord WinRecord { get; set; } = null!;
+    public virtual GameWinRecord? WinRecord { get; set; }
 }


### PR DESCRIPTION
There were certain cases where the query that calculates the scores and winrates was considering invalid games. This caused scores to be skewed, as well as winrates to count invalid games as a loss by default.