### PR TITLE
Fix 500 status when `GET` `/matches/{id}` does not exist

### DIFF
--- a/API/Controllers/MatchesController.cs
+++ b/API/Controllers/MatchesController.cs
@@ -38,18 +38,23 @@ public class MatchesController(IMatchesService matchesService) : Controller
         return Ok(matches);
     }
 
+    /// <summary>
+    /// Get a match
+    /// </summary>
+    /// <param name="id">Match id</param>
+    /// <response code="404">If a match does not exist for the given id</response>
+    /// <response code="200">Returns a match</response>
     [HttpGet("{id:int}")]
     [Authorize(Roles = $"{OtrClaims.User}, {OtrClaims.Client}")]
-    public async Task<ActionResult<MatchDTO>> GetByIdAsync(int id)
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<MatchDTO>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetAsync(int id)
     {
         MatchDTO? match = await _matchesService.GetAsync(id);
 
-        if (match == null)
-        {
-            return NotFound($"Failed to locate match {id}");
-        }
-
-        return Ok(match);
+        return match is null
+            ? NotFound()
+            : Ok(match);
     }
 
     [HttpPost("convert")]

--- a/API/Repositories/Implementations/MatchesRepository.cs
+++ b/API/Repositories/Implementations/MatchesRepository.cs
@@ -55,7 +55,7 @@ public class MatchesRepository(
     }
 
     public async Task<Match?> GetAsync(int id, bool filterInvalidMatches = true) =>
-        await MatchBaseQuery(filterInvalidMatches).FirstAsync(x => x.Id == id);
+        await MatchBaseQuery(filterInvalidMatches).FirstOrDefaultAsync(x => x.Id == id);
 
     public async Task<IEnumerable<Match>> GetAsync(IEnumerable<int> ids, bool onlyIncludeFiltered) =>
         await MatchBaseQuery(onlyIncludeFiltered)

--- a/API/Utilities/CreatedAtRouteValuesHelper.cs
+++ b/API/Utilities/CreatedAtRouteValuesHelper.cs
@@ -25,7 +25,7 @@ public static class CreatedAtRouteValuesHelper
     public static CreatedAtRouteValues GetMatch(int id) =>
         new()
         {
-            Action = nameof(MatchesController.GetByIdAsync),
+            Action = nameof(MatchesController.GetAsync),
             Controller = nameof(MatchesController),
             RouteValues = new { id }
         };


### PR DESCRIPTION
The bug comes from using `.FirstAsync()` which will throw an exception if a result is not found, instead of `.FirstOrDefaultAsync()` which produces a null value. The endpoint now fails gracefully as expected.

Closes #195