### PR TITLE
Hash OAuthClient secrets

### DIFF
--- a/API/Configurations/MapperProfile.cs
+++ b/API/Configurations/MapperProfile.cs
@@ -28,9 +28,12 @@ public class MapperProfile : Profile
             .AfterMap<GenerateLocationUriAction>();
         CreateMap<Match, MatchSearchResultDTO>();
         CreateMap<MatchScore, MatchScoreDTO>().ForMember(x => x.Misses, opt => opt.MapFrom(y => y.CountMiss));
+
         CreateMap<OAuthClient, OAuthClientDTO>()
+            .ForMember(x => x.ClientId, opt => opt.MapFrom(y => y.Id));
+        CreateMap<OAuthClient, OAuthClientCreatedDTO>()
             .ForMember(x => x.ClientId, opt => opt.MapFrom(y => y.Id))
-            .ForMember(x => x.ClientSecret, opt => opt.MapFrom(y => y.Secret));
+            .ForMember(x => x.ClientSecret, opt => opt.Ignore());
 
         CreateMap<RatingAdjustment, RatingAdjustmentDTO>();
         CreateMap<MatchRatingStats, MatchRatingStatsDTO>()

--- a/API/Controllers/OAuthController.cs
+++ b/API/Controllers/OAuthController.cs
@@ -53,12 +53,16 @@ public class OAuthController(IOAuthHandler oAuthHandler) : Controller
     /// <summary>
     /// Create a new OAuth client
     /// </summary>
-    /// <response code="201">If the user is not properly authenticated</response>
-    /// <response code="200">Returns created client credentials</response>
+    /// <remarks>
+    /// Client secret is only returned from creation.
+    /// The user will have to reset the secret if they lose access.
+    /// </remarks>
+    /// <response code="401">If the user is not properly authenticated</response>
+    /// <response code="201">Returns created client credentials</response>
     [HttpPost("client")]
     [Authorize(Roles = OtrClaims.User)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    [ProducesResponseType<OAuthClientDTO>(StatusCodes.Status200OK)]
+    [ProducesResponseType<OAuthClientCreatedDTO>(StatusCodes.Status201Created)]
     public async Task<IActionResult> CreateClientAsync()
     {
         var userId = User.AuthorizedIdentity();
@@ -67,9 +71,9 @@ public class OAuthController(IOAuthHandler oAuthHandler) : Controller
             return Unauthorized();
         }
 
-        OAuthClientDTO result = await oAuthHandler.CreateClientAsync(userId.Value);
+        OAuthClientCreatedDTO result = await oAuthHandler.CreateClientAsync(userId.Value);
 
-        return Ok(result);
+        return CreatedAtAction("GetClients", "Users", new { id = userId }, result);
     }
 
     /// <summary>

--- a/API/Controllers/OAuthController.cs
+++ b/API/Controllers/OAuthController.cs
@@ -1,5 +1,6 @@
 using API.DTOs;
 using API.Handlers.Interfaces;
+using API.Services.Interfaces;
 using API.Utilities;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
@@ -11,7 +12,7 @@ namespace API.Controllers;
 [ApiVersion(1)]
 [AllowAnonymous]
 [Route("api/v{version:apiVersion}/[controller]")]
-public class OAuthController(IOAuthHandler oAuthHandler) : Controller
+public class OAuthController(IOAuthHandler oAuthHandler, IOAuthClientService oAuthClientService) : Controller
 {
     /// <summary>
     /// Authorize using an osu! authorization code
@@ -58,11 +59,11 @@ public class OAuthController(IOAuthHandler oAuthHandler) : Controller
     /// The user will have to reset the secret if they lose access.
     /// </remarks>
     /// <response code="401">If the user is not properly authenticated</response>
-    /// <response code="201">Returns created client credentials</response>
+    /// <response code="200">Returns created client credentials</response>
     [HttpPost("client")]
     [Authorize(Roles = OtrClaims.User)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    [ProducesResponseType<OAuthClientCreatedDTO>(StatusCodes.Status201Created)]
+    [ProducesResponseType<OAuthClientCreatedDTO>(StatusCodes.Status200OK)]
     public async Task<IActionResult> CreateClientAsync()
     {
         var userId = User.AuthorizedIdentity();
@@ -71,9 +72,9 @@ public class OAuthController(IOAuthHandler oAuthHandler) : Controller
             return Unauthorized();
         }
 
-        OAuthClientCreatedDTO result = await oAuthHandler.CreateClientAsync(userId.Value);
+        OAuthClientCreatedDTO result = await oAuthClientService.CreateAsync(userId.Value);
 
-        return CreatedAtAction("GetClients", "Users", new { id = userId }, result);
+        return Ok(result);
     }
 
     /// <summary>

--- a/API/Controllers/UsersController.cs
+++ b/API/Controllers/UsersController.cs
@@ -141,14 +141,14 @@ public class UsersController(IUserService userService, IOAuthClientService clien
     /// Delete a user's OAuth client
     /// </summary>
     /// <remarks>
-    /// All users have access to delete clients that they own. Admin users have access
-    /// to delete clients from any user.
+    /// All users have access to delete clients that they own.
+    /// Admin users have access to clients from any user.
     /// </remarks>
     /// <param name="id">Id of the user</param>
     /// <param name="clientId">Id of the OAuth client</param>
     /// <response code="404">If a user or client does not exist</response>
     /// <response code="400">If the deletion was not successful</response>
-    /// <response code="200">Denotes the deletion was successful</response>
+    /// <response code="200">If the deletion was successful</response>
     [HttpDelete("{id:int}/clients/{clientId:int}")]
     [Authorize(Policy = AuthorizationPolicies.AccessUserResources)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -164,5 +164,36 @@ public class UsersController(IUserService userService, IOAuthClientService clien
         return await clientService.DeleteAsync(clientId)
             ? Ok()
             : BadRequest();
+    }
+
+    /// <summary>
+    /// Reset the secret of a user's OAuth client
+    /// </summary>
+    /// <remarks>
+    /// All users have access to reset secrets of clients that they own.
+    /// Admin users have access to clients from any user.
+    /// </remarks>
+    /// <param name="id">Id of the user</param>
+    /// <param name="clientId">Id of the OAuth client</param>
+    /// <response code="404">If a user or client does not exist</response>
+    /// <response code="400">If the secret reset was not successful</response>
+    /// <response code="200">Returns new client credentials if the secret reset was successful</response>
+    [HttpPost("{id:int}/clients/{clientId:int}/secret:reset")]
+    [Authorize(Policy = AuthorizationPolicies.AccessUserResources)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<OAuthClientCreatedDTO>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> ResetClientSecretAsync(int id, int clientId)
+    {
+        if (!await clientService.ExistsAsync(clientId, id))
+        {
+            return NotFound();
+        }
+
+        OAuthClientCreatedDTO? result = await clientService.ResetSecretAsync(clientId);
+
+        return result is not null
+            ? Ok(result)
+            : NotFound();
     }
 }

--- a/API/DTOs/OAuthClientCreatedDTO.cs
+++ b/API/DTOs/OAuthClientCreatedDTO.cs
@@ -1,0 +1,13 @@
+namespace API.DTOs;
+
+/// <summary>
+/// Represents a created OAuth client
+/// </summary>
+/// <remarks>The only time the client secret is available is when a new client is created</remarks>
+public class OAuthClientCreatedDTO : OAuthClientDTO
+{
+    /// <summary>
+    /// Client secret of the client
+    /// </summary>
+    public string ClientSecret { get; set; } = null!;
+}

--- a/API/DTOs/OAuthClientDTO.cs
+++ b/API/DTOs/OAuthClientDTO.cs
@@ -13,11 +13,6 @@ public class OAuthClientDTO
     public int ClientId { get; set; }
 
     /// <summary>
-    /// Client secret of the client
-    /// </summary>
-    public string ClientSecret { get; set; } = null!;
-
-    /// <summary>
     /// List of permissions granted to the client
     /// </summary>
     public string[] Scopes { get; set; } = [];

--- a/API/Entities/OAuthClient.cs
+++ b/API/Entities/OAuthClient.cs
@@ -1,16 +1,17 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using API.Entities.Interfaces;
 
 namespace API.Entities;
 
 [Table("oauth_clients")]
-public class OAuthClient
+public class OAuthClient : IUpdateableEntity
 {
     [Key]
     [Column("id")]
     public int Id { get; set; }
 
-    [MaxLength(70)]
+    [MaxLength(128)]
     [Column("secret")]
     public string Secret { get; set; } = string.Empty;
 
@@ -20,6 +21,12 @@ public class OAuthClient
     [Column("user_id")]
     public int UserId { get; set; }
 
+    [Column("created")]
+    public DateTime Created { get; set; }
+
+    [Column("updated")]
+    public DateTime? Updated { get; set; }
+
     // Column name and value initialization is handled via OtrContext
     /// <summary>
     /// Represents values that override the API rate limit for the OAuthClient
@@ -27,5 +34,5 @@ public class OAuthClient
     public RateLimitOverrides RateLimitOverrides { get; set; } = null!;
 
     [InverseProperty("Clients")]
-    public virtual User User { get; set; } = null!;
+    public User User { get; set; } = null!;
 }

--- a/API/Handlers/Implementations/OAuthHandler.cs
+++ b/API/Handlers/Implementations/OAuthHandler.cs
@@ -21,7 +21,6 @@ namespace API.Handlers.Implementations;
 /// </summary>
 public class OAuthHandler(
     ILogger<OAuthHandler> logger,
-    IOAuthClientService clientService,
     IOAuthClientRepository clientRepository,
     IPlayerRepository playerRepository,
     IUserRepository userRepository,
@@ -153,18 +152,6 @@ public class OAuthHandler(
         };
     }
 
-    public async Task<OAuthClientCreatedDTO> CreateClientAsync(int userId, params string[] scopes)
-    {
-        var secret = GenerateClientSecret();
-
-        while (await clientService.SecretInUse(secret))
-        {
-            secret = GenerateClientSecret();
-        }
-
-        return await clientService.CreateAsync(userId, secret, scopes);
-    }
-
     /// <summary>
     /// Wrapper for generating a JSON Web Token (JWT) for a given client
     /// </summary>
@@ -281,19 +268,6 @@ public class OAuthHandler(
         };
 
         return WriteToken(tokenDescriptor);
-    }
-
-    /// <summary>
-    /// Generates a new alpha-numeric client secret (size 50 chars)
-    /// </summary>
-    [SuppressMessage("ReSharper", "StringLiteralTypo")]
-    private static string GenerateClientSecret()
-    {
-        const int length = 50;
-        const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-
-        var r = new Random();
-        return new string(Enumerable.Repeat(chars, length).Select(s => s[r.Next(s.Length)]).ToArray());
     }
 
     /// <summary>

--- a/API/Handlers/Implementations/OAuthHandler.cs
+++ b/API/Handlers/Implementations/OAuthHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
@@ -8,6 +9,7 @@ using API.Handlers.Interfaces;
 using API.Repositories.Interfaces;
 using API.Services.Interfaces;
 using API.Utilities;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using OsuSharp.Interfaces;
@@ -21,11 +23,12 @@ public class OAuthHandler(
     ILogger<OAuthHandler> logger,
     IOAuthClientService clientService,
     IOAuthClientRepository clientRepository,
-    IOsuClient osuClient,
-    IOptions<JwtConfiguration> jwtConfiguration,
-    IOptions<AuthConfiguration> authConfiguration,
     IPlayerRepository playerRepository,
-    IUserRepository userRepository
+    IUserRepository userRepository,
+    IOsuClient osuClient,
+    IPasswordHasher<OAuthClient> clientSecretHasher,
+    IOptions<JwtConfiguration> jwtConfiguration,
+    IOptions<AuthConfiguration> authConfiguration
     ) : IOAuthHandler
 {
     private const int AccessDurationSeconds = 3600;
@@ -54,7 +57,7 @@ public class OAuthHandler(
         return new OAuthResponseDTO
         {
             AccessToken = GenerateAccessToken(user),
-            RefreshToken = GenerateRefreshToken(user.Id.ToString(), "user"),
+            RefreshToken = GenerateRefreshToken(user.Id.ToString(), OtrClaims.User),
             AccessExpiration = AccessDurationSeconds
         };
     }
@@ -63,9 +66,15 @@ public class OAuthHandler(
     {
         logger.LogDebug("Attempting authorization via client credentials");
 
-        // Get the client and validate secret
         OAuthClient? client = await clientRepository.GetAsync(clientId);
-        if (client is null || client.Secret != clientSecret)
+        if (client is null)
+        {
+            return null;
+        }
+
+        // Validate secret
+        PasswordVerificationResult result = clientSecretHasher.VerifyHashedPassword(client, client.Secret, clientSecret);
+        if (result != PasswordVerificationResult.Success)
         {
             return null;
         }
@@ -79,7 +88,7 @@ public class OAuthHandler(
         return new OAuthResponseDTO
         {
             AccessToken = GenerateAccessToken(client),
-            RefreshToken = GenerateRefreshToken(clientId.ToString(), "client"),
+            RefreshToken = GenerateRefreshToken(clientId.ToString(), OtrClaims.Client),
             AccessExpiration = AccessDurationSeconds
         };
     }
@@ -144,7 +153,7 @@ public class OAuthHandler(
         };
     }
 
-    public async Task<OAuthClientDTO> CreateClientAsync(int userId, params string[] scopes)
+    public async Task<OAuthClientCreatedDTO> CreateClientAsync(int userId, params string[] scopes)
     {
         var secret = GenerateClientSecret();
 
@@ -277,6 +286,7 @@ public class OAuthHandler(
     /// <summary>
     /// Generates a new alpha-numeric client secret (size 50 chars)
     /// </summary>
+    [SuppressMessage("ReSharper", "StringLiteralTypo")]
     private static string GenerateClientSecret()
     {
         const int length = 50;

--- a/API/Handlers/Interfaces/IOAuthHandler.cs
+++ b/API/Handlers/Interfaces/IOAuthHandler.cs
@@ -40,5 +40,5 @@ public interface IOAuthHandler
     /// <param name="userId">The id of the user who owns this client</param>
     /// <param name="scopes">The scopes to assign to the client</param>
     /// <returns>Client credentials for the new client</returns>
-    Task<OAuthClientDTO> CreateClientAsync(int userId, params string[] scopes);
+    Task<OAuthClientCreatedDTO> CreateClientAsync(int userId, params string[] scopes);
 }

--- a/API/Handlers/Interfaces/IOAuthHandler.cs
+++ b/API/Handlers/Interfaces/IOAuthHandler.cs
@@ -33,12 +33,4 @@ public interface IOAuthHandler
     /// Access credentials containing a new access token, or null if the given refresh token is invalid
     /// </returns>
     Task<OAuthResponseDTO?> RefreshAsync(string refreshToken);
-
-    /// <summary>
-    /// Creates a new OAuth client for a user
-    /// </summary>
-    /// <param name="userId">The id of the user who owns this client</param>
-    /// <param name="scopes">The scopes to assign to the client</param>
-    /// <returns>Client credentials for the new client</returns>
-    Task<OAuthClientCreatedDTO> CreateClientAsync(int userId, params string[] scopes);
 }

--- a/API/Migrations/20240517154720_OAuthClient_Add_Created_and_Updated.Designer.cs
+++ b/API/Migrations/20240517154720_OAuthClient_Add_Created_and_Updated.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace API.Migrations
 {
     [DbContext(typeof(OtrContext))]
-    partial class OtrContextModelSnapshot : ModelSnapshot
+    [Migration("20240517154720_OAuthClient_Add_Created_and_Updated")]
+    partial class OAuthClient_Add_Created_and_Updated
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API/Migrations/20240517154720_OAuthClient_Add_Created_and_Updated.cs
+++ b/API/Migrations/20240517154720_OAuthClient_Add_Created_and_Updated.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Migrations
+{
+    /// <inheritdoc />
+    public partial class OAuthClient_Add_Created_and_Updated : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "secret",
+                table: "oauth_clients",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(70)",
+                oldMaxLength: 70);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created",
+                table: "oauth_clients",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "CURRENT_TIMESTAMP");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "updated",
+                table: "oauth_clients",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "created",
+                table: "oauth_clients");
+
+            migrationBuilder.DropColumn(
+                name: "updated",
+                table: "oauth_clients");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "secret",
+                table: "oauth_clients",
+                type: "character varying(70)",
+                maxLength: 70,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128);
+        }
+    }
+}

--- a/API/OtrContext.cs
+++ b/API/OtrContext.cs
@@ -252,6 +252,9 @@ public partial class OtrContext(
                     rlo.Property(p => p.PermitLimit).HasDefaultValue(null);
                     rlo.Property(p => p.Window).HasDefaultValue(null);
                 });
+
+            entity.Property(x => x.Created).HasDefaultValueSql("CURRENT_TIMESTAMP");
+
             entity
                 .HasOne(e => e.User)
                 .WithMany(e => e.Clients)

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -26,6 +26,7 @@ using Dapper;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -362,6 +363,8 @@ builder.Services.AddDbContext<OtrContext>(o =>
 builder.Services.AddSingleton<ICacheHandler>(
     new CacheHandler(builder.Configuration.BindAndValidate<ConnectionStringsConfiguration>(ConnectionStringsConfiguration.Position).RedisConnection)
 );
+
+builder.Services.AddScoped<IPasswordHasher<OAuthClient>, PasswordHasher<OAuthClient>>();
 
 #endregion
 

--- a/API/Repositories/Implementations/OAuthClientRepository.cs
+++ b/API/Repositories/Implementations/OAuthClientRepository.cs
@@ -20,18 +20,6 @@ public class OAuthClientRepository(OtrContext context, IPasswordHasher<OAuthClie
         return await base.CreateAsync(entity);
     }
 
-    public async Task<bool> SecretInUseAsync(string clientSecret) =>
-        await _context.OAuthClients.AnyAsync(x => x.Secret == clientSecret);
-
-    public async Task<bool> ExistsAsync(int clientId, string clientSecret)
-    {
-        OAuthClient? match = await _context.OAuthClients.FirstOrDefaultAsync(x =>
-            x.Id == clientId && x.Secret == clientSecret
-        );
-
-        return match != null;
-    }
-
     public async Task<bool> ExistsAsync(int id, int userId) =>
         await _context.OAuthClients.AnyAsync(c => c.Id == id && c.UserId == userId);
 
@@ -47,5 +35,15 @@ public class OAuthClientRepository(OtrContext context, IPasswordHasher<OAuthClie
         match.RateLimitOverrides = rateLimitOverrides;
         await UpdateAsync(match);
         return match;
+    }
+
+    [SuppressMessage("ReSharper", "StringLiteralTypo")]
+    public string GenerateClientSecret()
+    {
+        const int length = 50;
+        const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+        var r = new Random();
+        return new string(Enumerable.Repeat(chars, length).Select(s => s[r.Next(s.Length)]).ToArray());
     }
 }

--- a/API/Repositories/Interfaces/IOAuthClientRepository.cs
+++ b/API/Repositories/Interfaces/IOAuthClientRepository.cs
@@ -4,12 +4,21 @@ namespace API.Repositories.Interfaces;
 
 public interface IOAuthClientRepository : IRepository<OAuthClient>
 {
-    Task<bool> SecretInUseAsync(string clientSecret);
-    Task<bool> ExistsAsync(int clientId, string clientSecret);
-
     /// <summary>
     /// Denotes a client exists for the given id and userId
     /// </summary>
     Task<bool> ExistsAsync(int id, int userId);
+
+    /// <summary>
+    /// Updates the rate limit overrides of a client for the given id
+    /// </summary>
+    /// <param name="clientId">Id of the client</param>
+    /// <param name="rateLimitOverrides">Updated rate limit overrides</param>
+    /// <returns>The updated client</returns>
     Task<OAuthClient?> SetRatelimitOverridesAsync(int clientId, RateLimitOverrides rateLimitOverrides);
+
+    /// <summary>
+    /// Generates a new alpha-numeric client secret (size 50 chars)
+    /// </summary>
+    string GenerateClientSecret();
 }

--- a/API/Services/Implementations/OAuthClientService.cs
+++ b/API/Services/Implementations/OAuthClientService.cs
@@ -21,25 +21,21 @@ public class OAuthClientService(IOAuthClientRepository repository, IMapper mappe
         return new OAuthClientDTO
         {
             ClientId = clientId,
-            ClientSecret = client.Secret,
             Scopes = client.Scopes,
             RateLimitOverrides = client.RateLimitOverrides
         };
     }
 
-    public async Task<OAuthClientDTO> CreateAsync(int userId, string secret, params string[] scopes)
+    public async Task<OAuthClientCreatedDTO> CreateAsync(int userId, string secret, params string[] scopes)
     {
         var client = new OAuthClient { Scopes = scopes, Secret = secret, UserId = userId };
 
         OAuthClient newClient = await _repository.CreateAsync(client);
 
-        return new OAuthClientDTO
-        {
-            ClientId = newClient.Id,
-            ClientSecret = newClient.Secret,
-            Scopes = newClient.Scopes,
-            RateLimitOverrides = newClient.RateLimitOverrides
-        };
+        OAuthClientCreatedDTO dto = mapper.Map<OAuthClientCreatedDTO>(newClient);
+        dto.ClientSecret = secret;
+
+        return dto;
     }
 
     public async Task<bool> SecretInUse(string clientSecret) =>

--- a/API/Services/Implementations/OAuthClientService.cs
+++ b/API/Services/Implementations/OAuthClientService.cs
@@ -3,34 +3,28 @@ using API.Entities;
 using API.Repositories.Interfaces;
 using API.Services.Interfaces;
 using AutoMapper;
+using Microsoft.AspNetCore.Identity;
 
 namespace API.Services.Implementations;
 
-public class OAuthClientService(IOAuthClientRepository repository, IMapper mapper) : IOAuthClientService
+public class OAuthClientService(
+    IOAuthClientRepository oAuthClientRepository,
+    IPasswordHasher<OAuthClient> passwordHasher,
+    IMapper mapper
+    ) : IOAuthClientService
 {
-    private readonly IOAuthClientRepository _repository = repository;
+    public async Task<bool> ExistsAsync(int id, int userId) =>
+        await oAuthClientRepository.ExistsAsync(id, userId);
 
-    public async Task<OAuthClientDTO?> GetAsync(int clientId)
+    public async Task<OAuthClientDTO?> GetAsync(int id) =>
+        mapper.Map<OAuthClientDTO?>(await oAuthClientRepository.GetAsync(id));
+
+    public async Task<OAuthClientCreatedDTO> CreateAsync(int userId, params string[] scopes)
     {
-        OAuthClient? client = await _repository.GetAsync(clientId);
-        if (client == null)
-        {
-            return null;
-        }
-
-        return new OAuthClientDTO
-        {
-            ClientId = clientId,
-            Scopes = client.Scopes,
-            RateLimitOverrides = client.RateLimitOverrides
-        };
-    }
-
-    public async Task<OAuthClientCreatedDTO> CreateAsync(int userId, string secret, params string[] scopes)
-    {
+        var secret = oAuthClientRepository.GenerateClientSecret();
         var client = new OAuthClient { Scopes = scopes, Secret = secret, UserId = userId };
 
-        OAuthClient newClient = await _repository.CreateAsync(client);
+        OAuthClient newClient = await oAuthClientRepository.CreateAsync(client);
 
         OAuthClientCreatedDTO dto = mapper.Map<OAuthClientCreatedDTO>(newClient);
         dto.ClientSecret = secret;
@@ -38,15 +32,29 @@ public class OAuthClientService(IOAuthClientRepository repository, IMapper mappe
         return dto;
     }
 
-    public async Task<bool> SecretInUse(string clientSecret) =>
-        await _repository.SecretInUseAsync(clientSecret);
-
-    public async Task<OAuthClientDTO?> SetRatelimitOverridesAsync(int clientId, RateLimitOverrides rateLimitOverrides) =>
-        mapper.Map<OAuthClientDTO>(await _repository.SetRatelimitOverridesAsync(clientId, rateLimitOverrides));
-
-    public async Task<bool> ExistsAsync(int id, int userId) =>
-        await _repository.ExistsAsync(id, userId);
-
     public async Task<bool> DeleteAsync(int id) =>
-        (await _repository.DeleteAsync(id)).HasValue;
+        (await oAuthClientRepository.DeleteAsync(id)).HasValue;
+
+    public async Task<OAuthClientDTO?> SetRatelimitOverridesAsync(int id, RateLimitOverrides rateLimitOverrides) =>
+        mapper.Map<OAuthClientDTO>(await oAuthClientRepository.SetRatelimitOverridesAsync(id, rateLimitOverrides));
+
+    public async Task<OAuthClientCreatedDTO?> ResetSecretAsync(int id)
+    {
+        OAuthClient? client = await oAuthClientRepository.GetAsync(id);
+        if (client is null)
+        {
+            return null;
+        }
+
+        var newSecret = oAuthClientRepository.GenerateClientSecret();
+        var hashedSecret = passwordHasher.HashPassword(client, newSecret);
+
+        client.Secret = hashedSecret;
+        await oAuthClientRepository.UpdateAsync(client);
+
+        OAuthClientCreatedDTO dto = mapper.Map<OAuthClientCreatedDTO>(client);
+        dto.ClientSecret = newSecret;
+
+        return dto;
+    }
 }

--- a/API/Services/Interfaces/IOAuthClientService.cs
+++ b/API/Services/Interfaces/IOAuthClientService.cs
@@ -6,42 +6,46 @@ namespace API.Services.Interfaces;
 public interface IOAuthClientService
 {
     /// <summary>
-    /// Gets an OAuthClient that matches the given client id, if it exists.
-    /// </summary>
-    Task<OAuthClientDTO?> GetAsync(int clientId);
-
-    /// <summary>
-    /// Creates an OAuthClient for the given user and scopes.
-    /// </summary>
-    /// <param name="userId">The id of the user that owns this client</param>
-    /// <param name="secret">The client secret</param>
-    /// <param name="scopes">The scopes this client has access to</param>
-    Task<OAuthClientCreatedDTO> CreateAsync(int userId, string secret, params string[] scopes);
-
-    /// <summary>
-    /// Returns true if there already exists a client with this secret.
-    /// </summary>
-    /// <param name="clientSecret">The new secret to check</param>
-    Task<bool> SecretInUse(string clientSecret);
-
-    /// <summary>
-    /// Applies the provided <see cref="RateLimitOverrides"/> to the
-    /// client which has the id of <see cref="clientId"/>
-    /// </summary>
-    /// <param name="clientId">The id of the client</param>
-    /// <param name="rateLimitOverrides">The new <see cref="RateLimitOverrides"/></param>
-    /// <returns>A valid <see cref="OAuthClientDTO"/> with the current state of the client,
-    /// null if any errors are encountered.</returns>
-    Task<OAuthClientDTO?> SetRatelimitOverridesAsync(int clientId, RateLimitOverrides rateLimitOverrides);
-
-    /// <summary>
     /// Denotes a client exists for the given id and is owned by userId
     /// </summary>
     Task<bool> ExistsAsync(int id, int userId);
 
     /// <summary>
-    /// Deletes a client
+    /// Gets an OAuthClient for the given id
+    /// </summary>
+    Task<OAuthClientDTO?> GetAsync(int id);
+
+    /// <summary>
+    /// Creates an OAuthClient for the given user and scopes
+    /// </summary>
+    /// <param name="userId">The id of the user that owns this client</param>
+    /// <param name="scopes">The scopes to assign to the client</param>
+    Task<OAuthClientCreatedDTO> CreateAsync(int userId, params string[] scopes);
+
+    /// <summary>
+    /// Deletes a client with the given id
     /// </summary>
     /// <returns>True if successful</returns>
     Task<bool> DeleteAsync(int id);
+
+    /// <summary>
+    /// Updates the rate limit overrides for a client with the given id
+    /// </summary>
+    /// <param name="id">Id of the client</param>
+    /// <param name="rateLimitOverrides">The new <see cref="RateLimitOverrides"/></param>
+    /// <returns>
+    /// The client with updated rate limit overrides,
+    /// or null if any errors occur
+    /// </returns>
+    Task<OAuthClientDTO?> SetRatelimitOverridesAsync(int id, RateLimitOverrides rateLimitOverrides);
+
+    /// <summary>
+    /// Resets the secret of a client with the given id
+    /// </summary>
+    /// <param name="id">Id of the client</param>
+    /// <returns>
+    /// The client with new secret in plaintext (un-hashed),
+    /// or null if a client does not exist
+    /// </returns>
+    Task<OAuthClientCreatedDTO?> ResetSecretAsync(int id);
 }

--- a/API/Services/Interfaces/IOAuthClientService.cs
+++ b/API/Services/Interfaces/IOAuthClientService.cs
@@ -16,7 +16,7 @@ public interface IOAuthClientService
     /// <param name="userId">The id of the user that owns this client</param>
     /// <param name="secret">The client secret</param>
     /// <param name="scopes">The scopes this client has access to</param>
-    Task<OAuthClientDTO> CreateAsync(int userId, string secret, params string[] scopes);
+    Task<OAuthClientCreatedDTO> CreateAsync(int userId, string secret, params string[] scopes);
 
     /// <summary>
     /// Returns true if there already exists a client with this secret.


### PR DESCRIPTION
Instead of client secrets being stored in the database as plaintext, they are now hashed and validated using Identity Framework's `IPasswordHasher<T>`. This pull includes some light refactoring of the `OAuthHandler`, as I feel delegating the creation and updating of clients to the client service and repository is more proper.

Now that we do not have access to the plaintext client secrets, the secret for a client will only ever be returned once when a client is created. If a user loses access to the secret, they will have to reset it.

`/me` should have client access and manipulation endpoints, but I will implement that in a new pull. I don't believe web has implemented features regarding clients at all, so this should be safe to push through.

**Deployment Note**: `oauth_clients` table needs to be truncated. All existing clients should be re-created (or secrets reset) as they will no longer be able to be authorized after this pull.

# New Endpoints
- `POST` `/users/{id}/clients/{clientId}/secret:reset`
  - Generates a new secret for an existing client
  - Returns a new `OAuthClientCreatedDTO`
  - Example (Reset client secret of user 703, client 3)
    - Request
      ```js
       fetch("otr.stagec.xyz/api/v1/users/703/clients/3/secret:reset",
         {
           method: "POST",
           headers: new Headers().append("Authorization", "Bearer {}")
         });
      ```
     - Result
       ```json
       {
         "clientId": 3,
         "clientSecret": "asdasdasdasdasdasdasdasdasdasd",
         "scopes": [],
         "rateLimitOverrides": { "permitLimit": null, "window": null }
       }
       ```

# Breaking Changes

## Schema Changes
- `OAuthClientDTO` (Returns from `GET` `/users/clients`, etc)
  - Removed `clientSecret`
  - ```json
     {
         "clientId": 3,
         "scopes": [],
         "rateLimitOverrides": { "permitLimit": null, "window": null }
     }
    ```
- New `OAuthClientCreatedDTO` (Returns from `POST` `/oauth/client`, `POST` `/users/{id}/clients/{clientId}/secret:reset`)
  - Endpoints that return this DTO will be the only time the secret is viewable in plaintext (un-hashed)
  -  ```json
       {
         "clientId": 3,
         "clientSecret": "asdasdasdasdasdasdasdasdasdasd",
         "scopes": [],
         "rateLimitOverrides": { "permitLimit": null, "window": null }
       }
       ```

Closes #146