### PR TITLE
Fix returning invalid data in some cases

### DIFF
--- a/API/BackgroundWorkers/OsuMatchDataWorker.cs
+++ b/API/BackgroundWorkers/OsuMatchDataWorker.cs
@@ -121,14 +121,7 @@ public class OsuMatchDataWorker(
             // Score verification checks
             foreach (MatchScore score in game.MatchScores)
             {
-                if (!ScoreAutomationChecks.PassesAutomationChecks(score))
-                {
-                    score.IsValid = false;
-                }
-                else
-                {
-                    score.IsValid = true;
-                }
+                score.IsValid = ScoreAutomationChecks.PassesAutomationChecks(score);
             }
 
             GameRejectionReason? rejectionReason = GameAutomationChecks.IdentifyRejectionReason(game);

--- a/API/BackgroundWorkers/OsuMatchDataWorker.cs
+++ b/API/BackgroundWorkers/OsuMatchDataWorker.cs
@@ -123,18 +123,11 @@ public class OsuMatchDataWorker(
             {
                 if (!ScoreAutomationChecks.PassesAutomationChecks(score))
                 {
-                    if (score.IsValid != false)
-                    {
-                        // Avoid unnecessary db calls
-                        score.IsValid = false;
-                    }
+                    score.IsValid = false;
                 }
                 else
                 {
-                    if (score.IsValid != true)
-                    {
-                        score.IsValid = true;
-                    }
+                    score.IsValid = true;
                 }
             }
 

--- a/API/BackgroundWorkers/OsuMatchDataWorker.cs
+++ b/API/BackgroundWorkers/OsuMatchDataWorker.cs
@@ -95,22 +95,20 @@ public class OsuMatchDataWorker(
         IGamesRepository gamesRepository
     )
     {
-        logger.LogInformation("Performing automated checks on match {Match}", match.MatchId);
         // Match verification checks
-        if (!MatchAutomationChecks.PassesAllChecks(match))
+        if (MatchAutomationChecks.PassesAllChecks(match))
+        {
+            match.VerificationStatus = match.VerifierUserId is not null ? MatchVerificationStatus.Verified : MatchVerificationStatus.PreVerified;
+            match.VerificationSource = MatchVerificationSource.System;
+            match.VerificationInfo = null;
+        }
+        else
         {
             match.VerificationStatus = MatchVerificationStatus.Rejected;
             match.VerificationSource = MatchVerificationSource.System;
             match.VerificationInfo = "Failed automation checks";
 
             match.NeedsAutoCheck = false;
-            logger.LogInformation("Match {Match} failed automation checks", match.MatchId);
-        }
-        else
-        {
-            match.VerificationStatus = match.VerifiedBy is not null ? MatchVerificationStatus.Verified : MatchVerificationStatus.PreVerified;
-            match.VerificationSource = MatchVerificationSource.System;
-            match.VerificationInfo = null;
         }
 
         // Game verification checks
@@ -130,12 +128,6 @@ public class OsuMatchDataWorker(
                         // Avoid unnecessary db calls
                         score.IsValid = false;
                     }
-
-                    logger.LogDebug(
-                        "Score [Player: {Player} | Game: {Game}] failed automation checks",
-                        score.PlayerId,
-                        game.GameId
-                    );
                 }
                 else
                 {
@@ -143,12 +135,6 @@ public class OsuMatchDataWorker(
                     {
                         score.IsValid = true;
                     }
-
-                    logger.LogTrace(
-                        "Score [Player: {Player} | Game: {Game}] passed automation checks",
-                        score.PlayerId,
-                        game.GameId
-                    );
                 }
             }
 
@@ -166,12 +152,6 @@ public class OsuMatchDataWorker(
                 // Game has passed automation checks
                 game.RejectionReason = null;
                 game.VerificationStatus = match.VerificationStatus == MatchVerificationStatus.Verified ? GameVerificationStatus.Verified : GameVerificationStatus.PreVerified;
-
-                logger.LogDebug(
-                    "Game {Game} passed automation checks and is marked as {Status}",
-                    game.GameId,
-                    game.VerificationStatus.ToString()
-                );
             }
 
             gamesRepository.MarkUpdated(game);
@@ -195,7 +175,7 @@ public class OsuMatchDataWorker(
 
             if (updatedEntity == null)
             {
-                logger.LogWarning(
+                logger.LogInformation(
                     "Failed to process match {MatchId} because result from ApiMatchService processing was null",
                     match.MatchId
                 );

--- a/API/Osu/AutomationChecks/GameAutomationChecks.cs
+++ b/API/Osu/AutomationChecks/GameAutomationChecks.cs
@@ -64,7 +64,7 @@ public static class GameAutomationChecks
     public static bool PassesTeamSizeCheck(Game game)
     {
         Tournament tournament = game.Match.Tournament;
-        var validScores = game.MatchScores.Where(x => x.IsValid == true).ToList();
+        var validScores = game.MatchScores.Where(x => x.IsValid).ToList();
 
         int? teamSize = tournament.TeamSize;
         if (teamSize is < 1 or > 8)
@@ -170,12 +170,12 @@ public static class GameAutomationChecks
         }
 
         s_logger.Information(
-            "{Prefix} Tournament {TournamentId} has a game mode that differs from game, can't verify game {GameId} [Tournament: Mode={TMode} | Game: Mode={GMode}]",
+            "{Prefix} Tournament {TournamentId} has a game mode that differs from game, can't verify game {GameId} [Tournament: Ruleset={TMode} | Game: Ruleset={GMode}]",
             LogPrefix,
             tournament.Id,
             game.GameId,
             (Ruleset)tournament.Mode,
-            game.Ruleset
+            game.Ruleset.ToString()
         );
 
         return false;

--- a/API/Osu/AutomationChecks/GameAutomationChecks.cs
+++ b/API/Osu/AutomationChecks/GameAutomationChecks.cs
@@ -96,8 +96,8 @@ public static class GameAutomationChecks
             return satisfiesOneVersusOne;
         }
 
-        var countRed = validScores.Count(s => s is { Team: (int)Team.Red });
-        var countBlue = validScores.Count(s => s is { Team: (int)Team.Blue });
+        var countRed = validScores.Count(s => s.Team == (int)Team.Red);
+        var countBlue = validScores.Count(s => s.Team == (int)Team.Blue);
 
         if (countRed == 0 || countBlue == 0)
         {

--- a/API/Osu/AutomationChecks/GameAutomationChecks.cs
+++ b/API/Osu/AutomationChecks/GameAutomationChecks.cs
@@ -221,11 +221,11 @@ public static class GameAutomationChecks
         }
 
         s_logger.Information(
-            "{Prefix} Tournament {TournamentId} has a game mode that differs from game, can't verify game {GameId} [Tournament: Mode={TMode} | Game: Mode={GMode}",
+            "{Prefix} Tournament {TournamentId} has a game mode that differs from game, can't verify game {GameId} [Tournament: Mode={TMode} | Game: Mode={GMode}]",
             LogPrefix,
             tournament.Id,
             game.GameId,
-            tournament.Mode,
+            (Ruleset)tournament.Mode,
             game.Ruleset
         );
 

--- a/API/Osu/AutomationChecks/GameAutomationChecks.cs
+++ b/API/Osu/AutomationChecks/GameAutomationChecks.cs
@@ -64,6 +64,7 @@ public static class GameAutomationChecks
     public static bool PassesTeamSizeCheck(Game game)
     {
         Tournament tournament = game.Match.Tournament;
+        var validScores = game.MatchScores.Where(x => x.IsValid == true).ToList();
 
         int? teamSize = tournament.TeamSize;
         if (teamSize is < 1 or > 8)
@@ -79,122 +80,70 @@ public static class GameAutomationChecks
             return false;
         }
 
-        var teamVs = game.TeamType == TeamType.TeamVs;
-        if (teamSize == 1 && !teamVs)
+        if (teamSize == 1)
         {
-            var countPlayers = game.MatchScores.Count;
-            var refereePresent = game.MatchScores.Any(score => score.Score <= AutomationChecksUtils.MinimumScore);
-
-            var countAfterReferees = countPlayers - game.MatchScores.Count(score => score.Score <= AutomationChecksUtils.MinimumScore);
-
-            var satisfiesOneVersusOne = refereePresent ? countAfterReferees == 2 : countPlayers == 2;
+            var satisfiesOneVersusOne = validScores.Count == 2;
             if (!satisfiesOneVersusOne)
             {
                 s_logger.Information(
-                    "{Prefix} Match {MatchId} has a team size of 1, but does not satisfy the 1v1 checks, can't verify game {GameId} [had {CountPlayers} players | Referee: {Ref}]",
+                    "{Prefix} Match {MatchId} has a team size of 1, but does not satisfy the 1v1 checks, can't verify game {GameId}",
                     LogPrefix,
                     game.Match.MatchId,
-                    game.GameId,
-                    countPlayers,
-                    refereePresent
+                    game.GameId
                 );
             }
 
             return satisfiesOneVersusOne;
         }
 
-        // teamSize is greater than 1 or is TeamVS
-
-        var countRed = game.MatchScores.Count(s => s is { Team: (int)Team.Red, Score: > AutomationChecksUtils.MinimumScore });
-        var countBlue = game.MatchScores.Count(s => s is { Team: (int)Team.Blue, Score: > AutomationChecksUtils.MinimumScore });
-        var countNoTeam = game.MatchScores.Count(s => s.Team == (int)Team.NoTeam);
-
-        if (countNoTeam > 0)
-        {
-            s_logger.Information(
-                "{Prefix} Match {MatchId} has scores with no team but is in TeamVS mode, can't verify game {GameId}",
-                LogPrefix,
-                game.Match.MatchId,
-                game.GameId
-            );
-
-            return false;
-        }
+        var countRed = validScores.Count(s => s is { Team: (int)Team.Red });
+        var countBlue = validScores.Count(s => s is { Team: (int)Team.Blue });
 
         if (countRed == 0 || countBlue == 0)
         {
             // Situation where either no scores or valid, or there are only scores from one team, something isn't right.
             s_logger.Information(
-                "{Prefix} Match {MatchId} has no team size for red or blue, can't verify game {GameId} (likely a warmup)",
+                "{Prefix} Match {MatchId} has no team size for red or blue, can't verify game {GameId} (likely a warmup) [Red: {Red} | Blue: {Blue}]",
                 LogPrefix,
                 game.Match.MatchId,
+                game.GameId,
+                countRed,
+                countBlue
+            );
+
+            return false;
+        }
+
+        if (countRed != countBlue)
+        {
+            // We don't need to worry about referees here as they have already been marked as invalid in the scores list.
+            s_logger.Information(
+                "{Prefix} Match {MatchId} has a mismatched team size: [Red: {Red} | Blue: {Blue}], can't verify game {GameId}",
+                LogPrefix,
+                game.Match.MatchId,
+                countRed,
+                countBlue,
                 game.GameId
             );
 
             return false;
         }
 
-        var hasReferee = false;
-        if (countRed != countBlue)
+        if (countRed != teamSize || countBlue != teamSize)
         {
-            /*
-             * Requirements for referee to be valid and present:
-             *
-             * - After referees are filtered out, the teams are perfectly even.
-             */
-            var refCountRed = game.MatchScores.Count(s => s is { Team: (int)Team.Red, Score: <= AutomationChecksUtils.MinimumScore });
-            var refCountBlue = game.MatchScores.Count(s => s is { Team: (int)Team.Blue, Score: <= AutomationChecksUtils.MinimumScore });
+            s_logger.Information(
+                "{Prefix} Match {MatchId} has a mismatched team size: [Red: {Red} | Blue: {Blue}], can't verify game {GameId}",
+                LogPrefix,
+                game.Match.MatchId,
+                countRed,
+                countBlue,
+                game.GameId
+            );
 
-            hasReferee = (countRed - refCountRed) == (countBlue - refCountBlue);
-
-            if (!hasReferee)
-            {
-                s_logger.Information(
-                    "{Prefix} Match {MatchId} has a mismatched team size: [Red: {Red} | Blue: {Blue}], can't verify game {GameId}",
-                    LogPrefix,
-                    game.Match.MatchId,
-                    countRed,
-                    countBlue,
-                    game.GameId
-                );
-
-                return false;
-            }
+            return false;
         }
 
-        if (!IsMismatchedTeamSize(countRed, countBlue, tournament.TeamSize, hasReferee))
-        {
-            return true;
-        }
-
-        s_logger.Information(
-            "{Prefix} Match {MatchId} has an unexpected team configuration: [Expected: {Expected}] [Red: {Red} | Blue: {Blue}], can't verify game {GameId} (Referee present: {HasReferee})",
-            LogPrefix,
-            game.Match.MatchId,
-            tournament.TeamSize,
-            countRed,
-            countBlue,
-            game.GameId,
-            hasReferee
-        );
-
-        return false;
-    }
-
-    private static bool IsMismatchedTeamSize(int red, int blue, int expectedSize, bool hasReferee)
-    {
-        // If the ref is present, the team sizes can be off by exactly one.
-        if (hasReferee)
-        {
-            // Should always equal 1 if the ref is present.
-            // If not, the team sizes are definitely mismatched.
-            return Math.Abs(red - blue) != 1;
-        }
-
-        var redUnexpected = red != expectedSize;
-        var blueUnexpected = blue != expectedSize;
-
-        return redUnexpected || blueUnexpected;
+        return true;
     }
 
     public static bool PassesRulesetCheck(Game game)

--- a/API/Osu/AutomationChecks/GameAutomationChecks.cs
+++ b/API/Osu/AutomationChecks/GameAutomationChecks.cs
@@ -64,7 +64,7 @@ public static class GameAutomationChecks
     public static bool PassesTeamSizeCheck(Game game)
     {
         Tournament tournament = game.Match.Tournament;
-        var validScores = game.MatchScores.Where(x => x.IsValid).ToList();
+        var validScores = game.MatchScores.Where(x => x.IsValid == true).ToList();
 
         int? teamSize = tournament.TeamSize;
         if (teamSize is < 1 or > 8)

--- a/API/Osu/AutomationChecks/MatchAutomationChecks.cs
+++ b/API/Osu/AutomationChecks/MatchAutomationChecks.cs
@@ -17,7 +17,7 @@ public static class MatchAutomationChecks
         var passes = match.TournamentId == match.Tournament.Id;
         if (!passes)
         {
-            s_logger.Warning(
+            s_logger.Information(
                 "{Prefix} Match {MatchID} has no tournament, failing automation checks",
                 LogPrefix,
                 match.MatchId

--- a/API/Repositories/Implementations/MatchesRepository.cs
+++ b/API/Repositories/Implementations/MatchesRepository.cs
@@ -24,12 +24,7 @@ public class MatchesRepository(
 
     public override async Task<Match?> GetAsync(int id) =>
         // Get the match with all associated data
-        await _context
-            .Matches.Include(x => x.Games)
-            .ThenInclude(x => x.MatchScores)
-            .Include(x => x.Games)
-            .ThenInclude(x => x.Beatmap)
-            .FirstOrDefaultAsync(x => x.Id == id);
+        await MatchBaseQuery(false).FirstOrDefaultAsync(x => x.Id == id);
 
     public async Task InvalidateCacheEntriesAsync()
     {
@@ -46,10 +41,6 @@ public class MatchesRepository(
         return await query
             // Include all MatchDTO navigational properties
             .Include(m => m.Tournament)
-            .Include(m => m.Games.Where(x => x.VerificationStatus == GameVerificationStatus.Verified))
-            .ThenInclude(g => g.Beatmap)
-            .Include(m => m.Games)
-            .ThenInclude(g => g.MatchScores.Where(x => x.IsValid == true))
             .OrderBy(m => m.Id)
             // Set index to start of desired page
             .Skip(limit * page)
@@ -350,7 +341,8 @@ public class MatchesRepository(
                 .Matches.Include(x => x.Games)
                 .ThenInclude(x => x.MatchScores)
                 .Include(x => x.Games)
-                .ThenInclude(x => x.Beatmap);
+                .ThenInclude(x => x.Beatmap)
+                .OrderBy(x => x.StartTime);
         }
 
         return _context

--- a/API/Repositories/Implementations/MatchesRepository.cs
+++ b/API/Repositories/Implementations/MatchesRepository.cs
@@ -34,11 +34,8 @@ public class MatchesRepository(
     // Suppression: This query will inherently produce a large number of records by including
     // games and match scores. The query itself is almost as efficient as possible (as far as we know)
     [SuppressMessage("ReSharper.DPA", "DPA0007: Large number of DB records")]
-    public async Task<IEnumerable<Match>> GetAsync(int limit, int page, bool filterUnverified = true)
-    {
-        IQueryable<Match> query = MatchBaseQuery(filterUnverified);
-
-        return await query
+    public async Task<IEnumerable<Match>> GetAsync(int limit, int page, bool filterUnverified = true) =>
+        await MatchBaseQuery(filterUnverified)
             // Include all MatchDTO navigational properties
             .Include(m => m.Tournament)
             .OrderBy(m => m.Id)
@@ -47,7 +44,6 @@ public class MatchesRepository(
             // Take only next n entities
             .Take(limit)
             .ToListAsync();
-    }
 
     public async Task<IEnumerable<MatchSearchResultDTO>> SearchAsync(string name)
     {
@@ -341,8 +337,7 @@ public class MatchesRepository(
                 .Matches.Include(x => x.Games)
                 .ThenInclude(x => x.MatchScores)
                 .Include(x => x.Games)
-                .ThenInclude(x => x.Beatmap)
-                .OrderBy(x => x.StartTime);
+                .ThenInclude(x => x.Beatmap);
         }
 
         return _context
@@ -350,7 +345,6 @@ public class MatchesRepository(
             .Include(x => x.Games.Where(y => y.VerificationStatus == GameVerificationStatus.Verified))
             .ThenInclude(x => x.MatchScores.Where(y => y.IsValid == true))
             .Include(x => x.Games.Where(y => y.VerificationStatus == GameVerificationStatus.Verified))
-            .ThenInclude(x => x.Beatmap)
-            .OrderBy(x => x.StartTime);
+            .ThenInclude(x => x.Beatmap);
     }
 }

--- a/API/Services/Implementations/MatchesService.cs
+++ b/API/Services/Implementations/MatchesService.cs
@@ -68,10 +68,10 @@ public class MatchesService(
         IEnumerable<Match> result = await matchesRepository.GetAsync(limit, page, filterUnverified);
         var count = result.Count();
 
-        return new PagedResultDTO<MatchDTO>()
+        return new PagedResultDTO<MatchDTO>
         {
             Next = count == limit
-                ? urlHelperService.Action(new CreatedAtRouteValues()
+                ? urlHelperService.Action(new CreatedAtRouteValues
                 {
                     Controller = nameof(MatchesController),
                     Action = nameof(MatchesController.ListAsync),
@@ -79,7 +79,7 @@ public class MatchesService(
                 })
                 : null,
             Previous = page > 1
-                ? urlHelperService.Action(new CreatedAtRouteValues()
+                ? urlHelperService.Action(new CreatedAtRouteValues
                 {
                     Controller = nameof(MatchesController),
                     Action = nameof(MatchesController.ListAsync),

--- a/APITests/AutomationChecks/AutomationChecksTests.cs
+++ b/APITests/AutomationChecks/AutomationChecksTests.cs
@@ -69,7 +69,8 @@ public class AutomationChecksTests
                 MaxCombo = 620,
                 Score = 489984,
                 Team = (int)Team.Red,
-                Game = games.First()
+                Game = games.First(),
+                IsValid = true
             },
             new()
             {
@@ -81,7 +82,8 @@ public class AutomationChecksTests
                 MaxCombo = 545,
                 Score = 400720,
                 Team = (int)Team.Blue,
-                Game = games.First()
+                Game = games.First(),
+                IsValid = true
             }
         };
 
@@ -284,14 +286,27 @@ public class AutomationChecksTests
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
         match
             .Games.First()
-            .MatchScores.Add(
-                new MatchScore
-                {
-                    PlayerId = -1,
-                    Score = 500_000,
-                    Team = (int)Team.Red
-                }
-            );
+            .MatchScores = new List<MatchScore>
+        {
+            new()
+            {
+                PlayerId = 1,
+                Score = 500_000,
+                Team = (int)Team.Red
+            },
+            new()
+            {
+                PlayerId = 2,
+                Score = 500_000,
+                Team = (int)Team.Red
+            },
+            new()
+            {
+                PlayerId = 3,
+                Score = 500_000,
+                Team = (int)Team.Blue
+            }
+        };
 
         Assert.False(GameAutomationChecks.PassesTeamSizeCheck(match.Games.First()));
     }
@@ -302,14 +317,27 @@ public class AutomationChecksTests
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
         match
             .Games.First()
-            .MatchScores.Add(
-                new MatchScore
-                {
-                    PlayerId = -1,
-                    Score = 500_000,
-                    Team = (int)Team.Blue
-                }
-            );
+            .MatchScores = new List<MatchScore>
+        {
+            new()
+            {
+                PlayerId = 1,
+                Score = 500_000,
+                Team = (int)Team.Blue
+            },
+            new()
+            {
+                PlayerId = 2,
+                Score = 500_000,
+                Team = (int)Team.Blue
+            },
+            new()
+            {
+                PlayerId = 3,
+                Score = 500_000,
+                Team = (int)Team.Red
+            }
+        };
 
         Assert.False(GameAutomationChecks.PassesTeamSizeCheck(match.Games.First()));
     }
@@ -318,7 +346,33 @@ public class AutomationChecksTests
     public void Game_FailsTeamSizeCheck_WhenOneScoreIsZero()
     {
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
-        match.Games.First().MatchScores.First().Score = 0;
+        match.Games.First().MatchScores = new List<MatchScore>
+        {
+            new()
+            {
+                PlayerId = 1,
+                Score = 0,
+                Team = (int)Team.Red
+            },
+            new()
+            {
+                PlayerId = 2,
+                Score = 250_000,
+                Team = (int)Team.Red
+            },
+            new()
+            {
+                PlayerId = 3,
+                Score = 250_000,
+                Team = (int)Team.Blue
+            },
+            new()
+            {
+                PlayerId = 4,
+                Score = 250_000,
+                Team = (int)Team.Blue
+            }
+        };
 
         Assert.False(GameAutomationChecks.PassesTeamSizeCheck(match.Games.First()));
     }
@@ -470,16 +524,38 @@ public class AutomationChecksTests
     public void Game_FailsTeamSizeCheck_WithAnyNoTeam()
     {
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
+
+        match.Tournament.TeamSize = 2;
+
         match
             .Games.First()
-            .MatchScores.Add(
-                new MatchScore
-                {
-                    PlayerId = -1,
-                    Score = 500_000,
-                    Team = (int)Team.NoTeam
-                }
-            );
+            .MatchScores = new List<MatchScore>
+        {
+            new()
+            {
+                PlayerId = 1,
+                Score = 500_000,
+                Team = (int)Team.NoTeam
+            },
+            new()
+            {
+                PlayerId = 2,
+                Score = 500_000,
+                Team = (int)Team.Red
+            },
+            new()
+            {
+                PlayerId = 3,
+                Score = 500_000,
+                Team = (int)Team.Blue
+            },
+            new()
+            {
+                PlayerId = 4,
+                Score = 500_000,
+                Team = (int)Team.NoTeam
+            }
+        };
 
         Assert.False(GameAutomationChecks.PassesTeamSizeCheck(match.Games.First()));
     }
@@ -600,15 +676,30 @@ public class AutomationChecksTests
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
 
         match
-            .Games.First()
-            .MatchScores.Add(
-                new MatchScore
-                {
-                    PlayerId = -1,
-                    Score = 500_000,
-                    Team = (int)Team.Red
-                }
-            );
+            .Games.First().MatchScores = new List<MatchScore>
+        {
+            new()
+            {
+                PlayerId = 0,
+                Score = 100000,
+                Team = (int)Team.Red,
+                IsValid = true
+            },
+            new()
+            {
+                PlayerId = 1,
+                Score = 100000,
+                Team = (int)Team.Red,
+                IsValid = true
+            },
+            new()
+            {
+                PlayerId = 2,
+                Score = 100000,
+                Team = (int)Team.Blue,
+                IsValid = true
+            }
+        };
 
         Assert.False(GameAutomationChecks.PassesTeamSizeCheck(match.Games.First()));
     }
@@ -700,14 +791,30 @@ public class AutomationChecksTests
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
         match
             .Games.First()
-            .MatchScores.Add(
-                new MatchScore
-                {
-                    PlayerId = 0,
-                    Score = 0,
-                    Team = (int)Team.Red
-                }
-            );
+            .MatchScores = new List<MatchScore>
+        {
+            new()
+            {
+                PlayerId = 0,
+                Score = 0,
+                Team = (int)Team.Red,
+                IsValid = false
+            },
+            new()
+            {
+                PlayerId = 1,
+                Score = 100503,
+                Team = (int)Team.Red,
+                IsValid = true
+            },
+            new()
+            {
+                PlayerId = 2,
+                Score = 100000,
+                Team = (int)Team.Blue,
+                IsValid = true
+            }
+        };
 
         Assert.True(GameAutomationChecks.PassesScoreSanityCheck(match.Games.First()));
         Assert.True(GameAutomationChecks.PassesTeamSizeCheck(match.Games.First()));
@@ -720,14 +827,30 @@ public class AutomationChecksTests
         API.Entities.Match match = _matchesServiceMock.Object.GetMatchesNeedingAutoCheckAsync().Result.First();
         match
             .Games.First()
-            .MatchScores.Add(
-                new MatchScore
-                {
-                    PlayerId = 0,
-                    Score = 0,
-                    Team = (int)Team.Blue
-                }
-            );
+            .MatchScores = new List<MatchScore>
+        {
+            new()
+            {
+                PlayerId = 0,
+                Score = 0,
+                Team = (int)Team.Blue,
+                IsValid = false
+            },
+            new()
+            {
+                PlayerId = 1,
+                Score = 100503,
+                Team = (int)Team.Blue,
+                IsValid = true
+            },
+            new()
+            {
+                PlayerId = 2,
+                Score = 100000,
+                Team = (int)Team.Red,
+                IsValid = true
+            }
+        };
 
         Assert.True(GameAutomationChecks.PassesScoreSanityCheck(match.Games.First()));
         Assert.True(GameAutomationChecks.PassesTeamSizeCheck(match.Games.First()));
@@ -744,33 +867,38 @@ public class AutomationChecksTests
         {
             new() // Referee
             {
-                PlayerId = 0,
+                PlayerId = 1,
                 Score = 0,
-                Team = (int)Team.Red
+                Team = (int)Team.Red,
+                IsValid = false
             },
             new()
             {
-                PlayerId = 0,
+                PlayerId = 2,
                 Score = 100000,
-                Team = (int)Team.Red
+                Team = (int)Team.Red,
+                IsValid = true
             },
             new()
             {
-                PlayerId = 0,
+                PlayerId = 3,
                 Score = 100000,
-                Team = (int)Team.Red
+                Team = (int)Team.Red,
+                IsValid = true
             },
             new()
             {
-                PlayerId = 0,
+                PlayerId = 4,
                 Score = 100000,
-                Team = (int)Team.Blue
+                Team = (int)Team.Blue,
+                IsValid = true
             },
             new()
             {
-                PlayerId = 0,
+                PlayerId = 5,
                 Score = 100000,
-                Team = (int)Team.Blue
+                Team = (int)Team.Blue,
+                IsValid = true
             }
         };
 
@@ -788,33 +916,38 @@ public class AutomationChecksTests
         {
             new() // Referee
             {
-                PlayerId = 0,
+                PlayerId = 1,
                 Score = 0,
-                Team = (int)Team.Blue
+                Team = (int)Team.Blue,
+                IsValid = false
             },
             new()
             {
-                PlayerId = 0,
+                PlayerId = 2,
                 Score = 100000,
-                Team = (int)Team.Red
+                Team = (int)Team.Red,
+                IsValid = true
             },
             new()
             {
-                PlayerId = 0,
+                PlayerId = 3,
                 Score = 100000,
-                Team = (int)Team.Red
+                Team = (int)Team.Red,
+                IsValid = true
             },
             new()
             {
-                PlayerId = 0,
+                PlayerId = 4,
                 Score = 100000,
-                Team = (int)Team.Blue
+                Team = (int)Team.Blue,
+                IsValid = true
             },
             new()
             {
-                PlayerId = 0,
+                PlayerId = 5,
                 Score = 100000,
-                Team = (int)Team.Blue
+                Team = (int)Team.Blue,
+                IsValid = true
             }
         };
 


### PR DESCRIPTION
Depends on:

- [x] #312

Fixes some bugs relating to how data is returned when we fetch match data via pagination. Also disambiguates test functionality by introducing concrete `MatchScore` lists for games instead of just appending to those lists. Removed a lot of the logic around referee detection, instead we rely on the `MatchScore` itself being marked as `!IsValid` by a previous step in the automation checks flow.