### PR TITLE
Improve auditing memory consumption

### DIFF
--- a/Database/Entities/AuditEntityBase.cs
+++ b/Database/Entities/AuditEntityBase.cs
@@ -25,8 +25,11 @@ public abstract class AuditEntityBase<TAuditable, TAudit> : IAuditEntity
     [Column("created")]
     public DateTime Created { get; }
 
+    [Column("ref_id_lock")]
+    public int ReferenceIdLock { get; set; }
+
     [Column("ref_id")]
-    public int ReferenceId { get; set; }
+    public int? ReferenceId { get; set; }
 
     [Column("action_user_id")]
     public int? ActionUserId { get; init; }

--- a/Database/Entities/AuditEntityBase.cs
+++ b/Database/Entities/AuditEntityBase.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
 using Database.Entities.Interfaces;
 using Database.Enums;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Database.Entities;
@@ -14,7 +15,7 @@ namespace Database.Entities;
 /// <typeparam name="TAudit">Entity to be audited</typeparam>
 [SuppressMessage("ReSharper", "UnassignedGetOnlyAutoProperty")]
 public abstract class AuditEntityBase<TAuditable, TAudit> : IAuditEntity
-    where TAuditable : IAuditableEntity<TAudit>
+    where TAuditable : IAuditableEntity<TAudit>, IEntity
     where TAudit : IAuditEntity
 {
     [Key]
@@ -26,28 +27,52 @@ public abstract class AuditEntityBase<TAuditable, TAudit> : IAuditEntity
     public DateTime Created { get; }
 
     [Column("ref_id_lock")]
-    public int ReferenceIdLock { get; set; }
+    public int ReferenceIdLock { get; private set; }
 
     [Column("ref_id")]
-    public int? ReferenceId { get; set; }
+    public int? ReferenceId { get; private set; }
 
     [Column("action_user_id")]
-    public int? ActionUserId { get; init; }
+    public int? ActionUserId { get; private set; }
 
     [Column("action_type")]
-    public AuditActionType ActionType { get; }
+    public AuditActionType ActionType { get; private set; }
 
     [Column("changes", TypeName = "jsonb")]
     public IDictionary<string, AuditChangelogEntry> Changes { get; } = new Dictionary<string, AuditChangelogEntry>();
 
-    public virtual void GenerateAudit(EntityEntry origEntityEntry, EntityEntry auditEntityEntry)
+    public virtual void GenerateAudit(EntityEntry origEntityEntry)
     {
-        if (origEntityEntry.Entity is not TAuditable || auditEntityEntry.Entity is not TAudit)
+        if (origEntityEntry.Entity is not TAuditable origEntity)
         {
             return;
         }
 
-        // No need to store a changelog for created entities
+        // Determine action type
+        AuditActionType? auditAction = origEntityEntry.State switch
+        {
+            EntityState.Added => AuditActionType.Created,
+            EntityState.Modified => AuditActionType.Updated,
+            EntityState.Deleted => AuditActionType.Deleted,
+            _ => null
+        };
+
+        if (!auditAction.HasValue)
+        {
+            return;
+        }
+
+        // Populate audit metadata and navigations
+        ReferenceId = origEntity.Id;
+        ReferenceIdLock = origEntity.Id;
+        ActionType = auditAction.Value;
+
+        if (origEntity.ActionBlamedOnUserId.HasValue)
+        {
+            ActionUserId = origEntity.ActionBlamedOnUserId.Value;
+        }
+
+        // No need to store a changelog for created or deleted entities
         if (ActionType is not AuditActionType.Updated)
         {
             return;
@@ -59,20 +84,16 @@ public abstract class AuditEntityBase<TAuditable, TAudit> : IAuditEntity
             .Select(prop => prop.Name)
             .ToList();
 
-        var newChanges = new Dictionary<string, AuditChangelogEntry>();
-
+        // Create changelog
         foreach (PropertyEntry? prop in origEntityEntry.Properties.Where(p => p.IsModified && !excludePropNames.Contains(p.Metadata.Name)))
         {
             if (prop.OriginalValue is not null && prop.CurrentValue is not null && prop.OriginalValue != prop.CurrentValue)
             {
-                newChanges.Add(
+                Changes.Add(
                     prop.Metadata.Name,
                     new AuditChangelogEntry { OriginalValue = prop.OriginalValue, NewValue = prop.CurrentValue }
                 );
             }
         }
-
-        // Setting the current value from the entry makes the change tracker aware of the change
-        auditEntityEntry.Property(nameof(Changes)).CurrentValue = newChanges;
     }
 }

--- a/Database/Entities/Game.cs
+++ b/Database/Entities/Game.cs
@@ -117,6 +117,9 @@ public class Game : UpdateableEntityBase, IProcessableEntity, IAuditableEntity<G
 
     public ICollection<GameAudit> Audits { get; set; } = new List<GameAudit>();
 
+    [NotMapped]
+    public int? ActionBlamedOnUserId { get; set; }
+
     /// <summary>
     /// Denotes if the mod setting was "free mod"
     /// </summary>

--- a/Database/Entities/GameScore.cs
+++ b/Database/Entities/GameScore.cs
@@ -131,6 +131,9 @@ public class GameScore : UpdateableEntityBase, IProcessableEntity, IAuditableEnt
 
     public ICollection<GameScoreAudit> Audits { get; set; } = new List<GameScoreAudit>();
 
+    [NotMapped]
+    public int? ActionBlamedOnUserId { get; set; }
+
     /// <summary>
     /// Accuracy
     /// </summary>

--- a/Database/Entities/Interfaces/IAuditEntity.cs
+++ b/Database/Entities/Interfaces/IAuditEntity.cs
@@ -15,7 +15,7 @@ public interface IAuditEntity : IEntity
     /// Stored as a concrete copy of the primary key of the original entity.
     /// This exists so that an original entity may be deleted but it's audits will still exist
     /// </remarks>
-    public int ReferenceIdLock { get; set; }
+    public int ReferenceIdLock { get; }
 
     /// <summary>
     /// Id of the entity being audited
@@ -25,7 +25,7 @@ public interface IAuditEntity : IEntity
     /// If this property is null, that means the original entity has since been deleted and
     /// <see cref="ReferenceIdLock"/> should be used instead
     /// </remarks>
-    public int? ReferenceId { get; set; }
+    public int? ReferenceId { get; }
 
     /// <summary>
     /// Id of the <see cref="User"/> that took action on the record
@@ -47,7 +47,6 @@ public interface IAuditEntity : IEntity
     /// Populates the audit with values from the given <see cref="EntityEntry"/>
     /// </summary>
     /// <param name="origEntityEntry">The <see cref="EntityEntry"/> for the entity being audited</param>
-    /// <param name="auditEntityEntry">The <see cref="EntityEntry"/> for the audit entity</param>
     /// <remarks>Allows the implementation of custom logic for the way the audit is generated</remarks>
-    public void GenerateAudit(EntityEntry origEntityEntry, EntityEntry auditEntityEntry);
+    public void GenerateAudit(EntityEntry origEntityEntry);
 }

--- a/Database/Entities/Interfaces/IAuditEntity.cs
+++ b/Database/Entities/Interfaces/IAuditEntity.cs
@@ -11,7 +11,21 @@ public interface IAuditEntity : IEntity
     /// <summary>
     /// Id of the entity being audited
     /// </summary>
-    public int ReferenceId { get; set; }
+    /// <remarks>
+    /// Stored as a concrete copy of the primary key of the original entity.
+    /// This exists so that an original entity may be deleted but it's audits will still exist
+    /// </remarks>
+    public int ReferenceIdLock { get; set; }
+
+    /// <summary>
+    /// Id of the entity being audited
+    /// </summary>
+    /// <remarks>
+    /// Used as the foreign key that navigates back to the existing original entity.
+    /// If this property is null, that means the original entity has since been deleted and
+    /// <see cref="ReferenceIdLock"/> should be used instead
+    /// </remarks>
+    public int? ReferenceId { get; set; }
 
     /// <summary>
     /// Id of the <see cref="User"/> that took action on the record

--- a/Database/Entities/Interfaces/IAuditableEntity.cs
+++ b/Database/Entities/Interfaces/IAuditableEntity.cs
@@ -7,6 +7,16 @@ namespace Database.Entities.Interfaces;
 public interface IAuditableEntity<TAudit> where TAudit : IAuditEntity
 {
     /// <summary>
+    /// Id of the <see cref="User"/> that made an auditable action against the entity
+    /// </summary>
+    /// <remarks>
+    /// **This property is NOT meant to be mapped into the database!**
+    /// It is meant to be used on a per-scope basis to identify any user making changes to the entity and
+    /// is used as metadata information for the audits themselves
+    /// </remarks>
+    public int? ActionBlamedOnUserId { get; set; }
+
+    /// <summary>
     /// A collection of <typeparamref name="TAudit"/> that serve as a changelog for the entity
     /// </summary>
     public ICollection<TAudit> Audits { get; set; }

--- a/Database/Entities/Match.cs
+++ b/Database/Entities/Match.cs
@@ -118,4 +118,7 @@ public class Match : UpdateableEntityBase, IAuditableEntity<MatchAudit>, IProces
     public ICollection<RatingAdjustment> PlayerRatingAdjustments { get; set; } = new List<RatingAdjustment>();
 
     public ICollection<MatchAudit> Audits { get; set; } = new List<MatchAudit>();
+
+    [NotMapped]
+    public int? ActionBlamedOnUserId { get; set; }
 }

--- a/Database/Entities/Tournament.cs
+++ b/Database/Entities/Tournament.cs
@@ -108,4 +108,7 @@ public class Tournament : UpdateableEntityBase, IProcessableEntity, IAuditableEn
     public ICollection<PlayerTournamentStats> PlayerTournamentStats { get; set; } = new List<PlayerTournamentStats>();
 
     public ICollection<TournamentAudit> Audits { get; set; } = new List<TournamentAudit>();
+
+    [NotMapped]
+    public int? ActionBlamedOnUserId { get; set; }
 }

--- a/Database/Interceptors/AuditingInterceptor.cs
+++ b/Database/Interceptors/AuditingInterceptor.cs
@@ -51,6 +51,11 @@ public class AuditingInterceptor : ISaveChangesInterceptor
             )
             .ToList();
 
+        // Changes have already been detected once at this point, so it is being disabled for performance
+        // This prevents the change tracker from detecting changes for each entity eligible for an audit
+        // when looking for an existing (blamed) audit in the context
+        context.ChangeTracker.AutoDetectChangesEnabled = false;
+
         // Create audits
         foreach (EntityEntry entry in auditableEntries)
         {
@@ -109,5 +114,8 @@ public class AuditingInterceptor : ISaveChangesInterceptor
             auditEntry.Property(nameof(IAuditEntity.ActionType)).CurrentValue = auditAction;
             ((IAuditEntity)auditEntry.Entity).GenerateAudit(entry, auditEntry);
         }
+
+        // Re-enable change detection once audits have been created
+        context.ChangeTracker.AutoDetectChangesEnabled = true;
     }
 }

--- a/Database/Migrations/20240830165036_Audits_ReferenceEntity_SetNullOnDelete.Designer.cs
+++ b/Database/Migrations/20240830165036_Audits_ReferenceEntity_SetNullOnDelete.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Database.Migrations
 {
     [DbContext(typeof(OtrContext))]
-    partial class OtrContextModelSnapshot : ModelSnapshot
+    [Migration("20240830165036_Audits_ReferenceEntity_SetNullOnDelete")]
+    partial class Audits_ReferenceEntity_SetNullOnDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Database/Migrations/20240830165036_Audits_ReferenceEntity_SetNullOnDelete.cs
+++ b/Database/Migrations/20240830165036_Audits_ReferenceEntity_SetNullOnDelete.cs
@@ -1,0 +1,230 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class Audits_ReferenceEntity_SetNullOnDelete : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_game_audits_games_ref_id",
+                table: "game_audits");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_game_score_audits_game_scores_ref_id",
+                table: "game_score_audits");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_match_audits_matches_ref_id",
+                table: "match_audits");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_tournament_audits_tournaments_ref_id",
+                table: "tournament_audits");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ref_id",
+                table: "tournament_audits",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ref_id_lock",
+                table: "tournament_audits",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ref_id",
+                table: "match_audits",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ref_id_lock",
+                table: "match_audits",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ref_id",
+                table: "game_score_audits",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ref_id_lock",
+                table: "game_score_audits",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ref_id",
+                table: "game_audits",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ref_id_lock",
+                table: "game_audits",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_game_audits_games_ref_id",
+                table: "game_audits",
+                column: "ref_id",
+                principalTable: "games",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_game_score_audits_game_scores_ref_id",
+                table: "game_score_audits",
+                column: "ref_id",
+                principalTable: "game_scores",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_match_audits_matches_ref_id",
+                table: "match_audits",
+                column: "ref_id",
+                principalTable: "matches",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_tournament_audits_tournaments_ref_id",
+                table: "tournament_audits",
+                column: "ref_id",
+                principalTable: "tournaments",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_game_audits_games_ref_id",
+                table: "game_audits");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_game_score_audits_game_scores_ref_id",
+                table: "game_score_audits");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_match_audits_matches_ref_id",
+                table: "match_audits");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_tournament_audits_tournaments_ref_id",
+                table: "tournament_audits");
+
+            migrationBuilder.DropColumn(
+                name: "ref_id_lock",
+                table: "tournament_audits");
+
+            migrationBuilder.DropColumn(
+                name: "ref_id_lock",
+                table: "match_audits");
+
+            migrationBuilder.DropColumn(
+                name: "ref_id_lock",
+                table: "game_score_audits");
+
+            migrationBuilder.DropColumn(
+                name: "ref_id_lock",
+                table: "game_audits");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ref_id",
+                table: "tournament_audits",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ref_id",
+                table: "match_audits",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ref_id",
+                table: "game_score_audits",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ref_id",
+                table: "game_audits",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_game_audits_games_ref_id",
+                table: "game_audits",
+                column: "ref_id",
+                principalTable: "games",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_game_score_audits_game_scores_ref_id",
+                table: "game_score_audits",
+                column: "ref_id",
+                principalTable: "game_scores",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_match_audits_matches_ref_id",
+                table: "match_audits",
+                column: "ref_id",
+                principalTable: "matches",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_tournament_audits_tournaments_ref_id",
+                table: "tournament_audits",
+                column: "ref_id",
+                principalTable: "tournaments",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/Database/OtrContext.cs
+++ b/Database/OtrContext.cs
@@ -53,13 +53,13 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        var changesConverter = new ValueConverter<IDictionary<string, AuditChangelogEntry>, string>(
+        var auditChangesConverter = new ValueConverter<IDictionary<string, AuditChangelogEntry>, string>(
             v => JsonConvert.SerializeObject(v, Formatting.None),
             v => JsonConvert.DeserializeObject<IDictionary<string, AuditChangelogEntry>>(v)
                  ?? new Dictionary<string, AuditChangelogEntry>()
         );
 
-        var changesComparer = new ValueComparer<IDictionary<string, AuditChangelogEntry>>(
+        var auditChangesComparer = new ValueComparer<IDictionary<string, AuditChangelogEntry>>(
             (c1, c2) => JsonConvert.SerializeObject(c1) == JsonConvert.SerializeObject(c2),
             c => JsonConvert.SerializeObject(c).GetHashCode(),
             c => c.ToDictionary(
@@ -130,7 +130,7 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .HasMany(g => g.Audits)
                 .WithOne()
                 .HasForeignKey(ga => ga.ReferenceId)
-                .OnDelete(DeleteBehavior.Restrict);
+                .OnDelete(DeleteBehavior.SetNull);
 
             entity.HasIndex(g => g.MatchId);
             entity.HasIndex(g => g.StartTime);
@@ -146,15 +146,15 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
             entity.Property(ga => ga.ActionType);
 
             entity.Property(ga => ga.Changes)
-                .HasConversion(changesConverter)
-                .Metadata.SetValueComparer(changesComparer);
+                .HasConversion(auditChangesConverter)
+                .Metadata.SetValueComparer(auditChangesComparer);
 
             // Relation: Game
             entity
                 .HasOne<Game>()
                 .WithMany(g => g.Audits)
                 .HasForeignKey(ga => ga.ReferenceId)
-                .OnDelete(DeleteBehavior.Restrict);
+                .OnDelete(DeleteBehavior.SetNull);
         });
 
         modelBuilder.Entity<GameScore>(entity =>
@@ -184,7 +184,7 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .HasMany(gs => gs.Audits)
                 .WithOne()
                 .HasForeignKey(gsa => gsa.ReferenceId)
-                .OnDelete(DeleteBehavior.Restrict);
+                .OnDelete(DeleteBehavior.SetNull);
 
             entity.HasIndex(gs => gs.PlayerId);
             entity.HasIndex(gs => new { gs.PlayerId, gs.GameId }).IsUnique();
@@ -199,15 +199,15 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
             entity.Property(gsa => gsa.ActionType);
 
             entity.Property(gsa => gsa.Changes)
-                .HasConversion(changesConverter)
-                .Metadata.SetValueComparer(changesComparer);
+                .HasConversion(auditChangesConverter)
+                .Metadata.SetValueComparer(auditChangesComparer);
 
             // Relation: GameScore
             entity
                 .HasOne<GameScore>()
                 .WithMany(gs => gs.Audits)
                 .HasForeignKey(gsa => gsa.ReferenceId)
-                .OnDelete(DeleteBehavior.Restrict);
+                .OnDelete(DeleteBehavior.SetNull);
         });
 
         modelBuilder.Entity<GameWinRecord>(entity =>
@@ -292,7 +292,7 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .HasMany(m => m.Audits)
                 .WithOne()
                 .HasForeignKey(a => a.ReferenceId)
-                .OnDelete(DeleteBehavior.Restrict);
+                .OnDelete(DeleteBehavior.SetNull);
 
             entity.HasIndex(m => m.OsuId).IsUnique();
         });
@@ -306,15 +306,15 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
             entity.Property(ma => ma.ActionType);
 
             entity.Property(ma => ma.Changes)
-                .HasConversion(changesConverter)
-                .Metadata.SetValueComparer(changesComparer);
+                .HasConversion(auditChangesConverter)
+                .Metadata.SetValueComparer(auditChangesComparer);
 
             // Relation: Match
             entity
                 .HasOne<Match>()
                 .WithMany(m => m.Audits)
                 .HasForeignKey(ma => ma.ReferenceId)
-                .OnDelete(DeleteBehavior.Restrict);
+                .OnDelete(DeleteBehavior.SetNull);
         });
 
         modelBuilder.Entity<MatchWinRecord>(entity =>
@@ -554,7 +554,7 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .HasMany(t => t.Audits)
                 .WithOne()
                 .HasForeignKey(ta => ta.ReferenceId)
-                .OnDelete(DeleteBehavior.Restrict);
+                .OnDelete(DeleteBehavior.SetNull);
 
             entity.HasIndex(t => t.Ruleset);
             entity.HasIndex(t => new { t.Name, t.Abbreviation }).IsUnique();
@@ -569,15 +569,15 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
             entity.Property(ta => ta.ActionType);
 
             entity.Property(ta => ta.Changes)
-                .HasConversion(changesConverter)
-                .Metadata.SetValueComparer(changesComparer);
+                .HasConversion(auditChangesConverter)
+                .Metadata.SetValueComparer(auditChangesComparer);
 
             // Relation: Game
             entity
                 .HasOne<Tournament>()
                 .WithMany(t => t.Audits)
                 .HasForeignKey(ta => ta.ReferenceId)
-                .OnDelete(DeleteBehavior.Restrict);
+                .OnDelete(DeleteBehavior.SetNull);
         });
 
         modelBuilder.Entity<User>(entity =>


### PR DESCRIPTION
Audit creation was consuming a lot of memory through inefficient LINQ queries and some flawed design choices. Rewrote a chunk of the logic to compensate and optimize.