### PR TITLE
[OAuthClientAdminNotes] Create entity, migrations and configure relationships

### DIFF
--- a/Database/Entities/OAuthClient.cs
+++ b/Database/Entities/OAuthClient.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
+using Database.Entities.Interfaces;
 
 namespace Database.Entities;
 
@@ -9,7 +10,7 @@ namespace Database.Entities;
 /// </summary>
 [Table("oauth_clients")]
 [SuppressMessage("ReSharper", "PropertyCanBeMadeInitOnly.Global")]
-public class OAuthClient : UpdateableEntityBase
+public class OAuthClient : UpdateableEntityBase, IAdminNotableEntity<OAuthClientAdminNote>
 {
     /// <summary>
     /// Authorization secret
@@ -43,4 +44,6 @@ public class OAuthClient : UpdateableEntityBase
     /// The <see cref="Entities.User"/> that owns the <see cref="OAuthClient"/>
     /// </summary>
     public User User { get; set; } = null!;
+
+    public ICollection<OAuthClientAdminNote> AdminNotes { get; set; } = new List<OAuthClientAdminNote>();
 }

--- a/Database/Entities/OAuthClientAdminNote.cs
+++ b/Database/Entities/OAuthClientAdminNote.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Database.Entities;
+
+[Table("oauth_client_admin_notes")]
+public class OAuthClientAdminNote : AdminNoteEntityBase
+{
+    public OAuthClient OAuthClient { get; set; } = null!;
+}

--- a/Database/Migrations/20240923012404_OAuthClientAdminNotes.Designer.cs
+++ b/Database/Migrations/20240923012404_OAuthClientAdminNotes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Database.Migrations
 {
     [DbContext(typeof(OtrContext))]
-    partial class OtrContextModelSnapshot : ModelSnapshot
+    [Migration("20240923012404_OAuthClientAdminNotes")]
+    partial class OAuthClientAdminNotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Database/Migrations/20240923012404_OAuthClientAdminNotes.cs
+++ b/Database/Migrations/20240923012404_OAuthClientAdminNotes.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class OAuthClientAdminNotes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "oauth_client_admin_notes",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityAlwaysColumn),
+                    created = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    updated = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    note = table.Column<string>(type: "text", nullable: false),
+                    ref_id = table.Column<int>(type: "integer", nullable: false),
+                    admin_user_id = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_oauth_client_admin_notes", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_oauth_client_admin_notes_oauth_clients_ref_id",
+                        column: x => x.ref_id,
+                        principalTable: "oauth_clients",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_oauth_client_admin_notes_ref_id",
+                table: "oauth_client_admin_notes",
+                column: "ref_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "oauth_client_admin_notes");
+        }
+    }
+}

--- a/Database/OtrContext.cs
+++ b/Database/OtrContext.cs
@@ -372,11 +372,32 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                     rlo.Property(p => p.Window).HasDefaultValue(null);
                 });
 
+            // Relation: Admin Notes
+            entity
+                .HasMany(c => c.AdminNotes)
+                .WithOne(an => an.OAuthClient)
+                .HasForeignKey(an => an.ReferenceId)
+                .OnDelete(DeleteBehavior.Cascade);
+
             // Relation: User
             entity
                 .HasOne(c => c.User)
                 .WithMany(u => u.Clients)
                 .HasForeignKey(c => c.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<OAuthClientAdminNote>(entity =>
+        {
+            entity.Property(oacan => oacan.Id).UseIdentityAlwaysColumn();
+
+            entity.Property(oacan => oacan.Created).HasDefaultValueSql(SqlCurrentTimestamp);
+
+            // Relation: OAuthClient
+            entity
+                .HasOne(oacan => oacan.OAuthClient)
+                .WithMany(oac => oac.AdminNotes)
+                .HasForeignKey(oacan => oacan.ReferenceId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
 


### PR DESCRIPTION
Creates `OAuthClientAdminNote`, configures relationship to `OAuthClient` and creates migrations. Part of #378