### PR TITLE
Add `MatchAdminNoteRepository`, `MatchAdminNoteDTO` and update `MatchDTO`

### DIFF
--- a/API/Configurations/MapperProfile.cs
+++ b/API/Configurations/MapperProfile.cs
@@ -15,7 +15,8 @@ public class MapperProfile : Profile
         CreateMap<Game, GameDTO>();
         CreateMap<GameWinRecord, GameWinRecordDTO>();
         CreateMap<Match, MatchDTO>()
-            .ForMember(x => x.Ruleset, opt => opt.MapFrom(x => x.Tournament.Ruleset));
+            .ForMember(x => x.Ruleset, opt => opt.MapFrom(x => x.Tournament.Ruleset))
+            .ForMember(x => x.AdminNotes, opt => opt.Ignore());
         CreateMap<Match, MatchSubmissionStatusDTO>();
         CreateMap<Match, MatchCreatedResultDTO>()
             .MapAsCreatedResult()

--- a/API/DTOs/AdminNoteDTO.cs
+++ b/API/DTOs/AdminNoteDTO.cs
@@ -1,9 +1,9 @@
 namespace API.DTOs;
 
 /// <summary>
-/// Represents an admin note for a match
+/// Basic information for presenting an admin note
 /// </summary>
-public class MatchAdminNoteDTO
+public class AdminNoteDTO
 {
     /// <summary>
     /// The content of the note

--- a/API/DTOs/MatchAdminNoteDTO.cs
+++ b/API/DTOs/MatchAdminNoteDTO.cs
@@ -1,0 +1,20 @@
+namespace API.DTOs;
+
+/// <summary>
+/// Represents an admin note for a match
+/// </summary>
+public class MatchAdminNoteDTO
+{
+    /// <summary>
+    /// The content of the note
+    /// </summary>
+    public string Note { get; set; } = string.Empty;
+    /// <summary>
+    /// The author (admin user) which created this note
+    /// </summary>
+    public UserDTO Author { get; set; } = null!;
+    /// <summary>
+    /// When the note was created
+    /// </summary>
+    public DateTime Created { get; set; }
+}

--- a/API/DTOs/MatchDTO.cs
+++ b/API/DTOs/MatchDTO.cs
@@ -70,5 +70,5 @@ public class MatchDTO
     /// The admin notes attached to this match. Null if the user is not an admin.
     /// Empty collection if the user is an admin but there are no notes.
     /// </summary>
-    public ICollection<MatchAdminNoteDTO>? AdminNotes { get; set; }
+    public ICollection<AdminNoteDTO>? AdminNotes { get; set; }
 }

--- a/API/DTOs/MatchDTO.cs
+++ b/API/DTOs/MatchDTO.cs
@@ -65,4 +65,10 @@ public class MatchDTO
     /// </summary>
     [SuppressMessage("ReSharper", "CollectionNeverUpdated.Global")]
     public ICollection<GameDTO> Games { get; set; } = new List<GameDTO>();
+
+    /// <summary>
+    /// The admin notes attached to this match. Null if the user is not an admin.
+    /// Empty collection if the user is an admin but there are no notes.
+    /// </summary>
+    public ICollection<MatchAdminNoteDTO>? AdminNotes { get; set; }
 }

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -427,6 +427,7 @@ builder.Services.AddScoped<IApiMatchWinRecordRepository, ApiMatchWinRecordReposi
 builder.Services.AddScoped<IApiPlayerMatchStatsRepository, ApiPlayerMatchStatsRepository>();
 builder.Services.AddScoped<IApiTournamentsRepository, ApiTournamentsRepository>();
 
+builder.Services.AddScoped<IMatchAdminNoteRepository, MatchAdminNoteRepository>();
 builder.Services.AddScoped<IBaseStatsRepository, BaseStatsRepository>();
 builder.Services.AddScoped<IBeatmapsRepository, BeatmapsRepository>();
 builder.Services.AddScoped<IGamesRepository, GamesRepository>();

--- a/Database/Repositories/Implementations/AdminNoteRepositoryBase.cs
+++ b/Database/Repositories/Implementations/AdminNoteRepositoryBase.cs
@@ -1,0 +1,11 @@
+using Database.Entities;
+using Database.Repositories.Interfaces;
+
+namespace Database.Repositories.Implementations;
+
+public abstract class AdminNoteRepositoryBase<TAdminNoteEntity>(OtrContext context)
+    : RepositoryBase<TAdminNoteEntity>(context), IAdminNoteRepository<TAdminNoteEntity>
+    where TAdminNoteEntity : AdminNoteEntityBase
+{
+    public abstract Task<ICollection<TAdminNoteEntity>> GetAdminNotesAsync(int referenceId);
+}

--- a/Database/Repositories/Implementations/MatchAdminNoteRepository.cs
+++ b/Database/Repositories/Implementations/MatchAdminNoteRepository.cs
@@ -1,0 +1,18 @@
+using Database.Entities;
+using Database.Repositories.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Database.Repositories.Implementations;
+
+public class MatchAdminNoteRepository(OtrContext context) : AdminNoteRepositoryBase<MatchAdminNote>(context), IMatchAdminNoteRepository
+{
+    // CS 9107
+    private readonly OtrContext _context = context;
+
+    public override async Task<ICollection<MatchAdminNote>> GetAdminNotesAsync(int referenceId)
+    {
+        return await _context.MatchAdminNotes
+            .Where(x => x.ReferenceId == referenceId)
+            .ToListAsync();
+    }
+}

--- a/Database/Repositories/Interfaces/IAdminNoteRepository.cs
+++ b/Database/Repositories/Interfaces/IAdminNoteRepository.cs
@@ -1,0 +1,15 @@
+using Database.Entities;
+
+namespace Database.Repositories.Interfaces;
+
+public interface IAdminNoteRepository<TAdminNoteEntity> : IRepository<TAdminNoteEntity> where TAdminNoteEntity : AdminNoteEntityBase
+{
+    /// <summary>
+    /// Gets a collection of <typeparamref name="TAdminNoteEntity"/> entities by their parent reference Id.
+    /// </summary>
+    /// <param name="referenceId">The id of the parent entity.</param>
+    /// <example>Say we wish to find all AdminNotes for a particular <see cref="Match"/>.
+    /// The id of the match would be passed as the referenceId argument.</example>
+    /// <returns>A collection of AdminNotes for a particular referenceId</returns>
+    Task<ICollection<TAdminNoteEntity>> GetAdminNotesAsync(int referenceId);
+}

--- a/Database/Repositories/Interfaces/IMatchAdminNoteRepository.cs
+++ b/Database/Repositories/Interfaces/IMatchAdminNoteRepository.cs
@@ -1,0 +1,8 @@
+using Database.Entities;
+
+namespace Database.Repositories.Interfaces;
+
+public interface IMatchAdminNoteRepository : IAdminNoteRepository<MatchAdminNote>
+{
+
+}


### PR DESCRIPTION
Depends on #425

Adds `MatchAdminNoteRepository`, `MatchAdminNoteDTO` and updates `MatchDTO` to include a nullable collection of admin notes.

@myssto, is it safe to use `opt.Ignore()` for this in the `MapperProfile`? I think we need to map this manually if we do include a `UserDTO` inside of the `MatchAdminNoteDTO`. Let me know your thoughts on all of that though.