### PR TITLE
Improve swagger doc generation

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -53,6 +53,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.PostgreSQL" Version="2.3.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Unchase.Swashbuckle.AspNetCore.Extensions" Version="2.7.1" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\.dockerignore">

--- a/API/Middlewares/RequestLoggingMiddleware.cs
+++ b/API/Middlewares/RequestLoggingMiddleware.cs
@@ -10,6 +10,7 @@ public class RequestLoggingMiddleware(RequestDelegate next, ILogger<RequestLoggi
 #if DEBUG
         if (context.Request.Path.StartsWithSegments("/swagger"))
         {
+            await next(context);
             return;
         }
 #endif

--- a/API/Middlewares/RequestLoggingMiddleware.cs
+++ b/API/Middlewares/RequestLoggingMiddleware.cs
@@ -7,6 +7,13 @@ public class RequestLoggingMiddleware(RequestDelegate next, ILogger<RequestLoggi
 {
     public async Task Invoke(HttpContext context)
     {
+#if DEBUG
+        if (context.Request.Path.StartsWithSegments("/swagger"))
+        {
+            return;
+        }
+#endif
+
         await LogRequest(context.Request);
 
         Stream originalBodyStream = context.Response.Body;

--- a/API/SwaggerGen/BitwiseFlagEnumSchemaFilter.cs
+++ b/API/SwaggerGen/BitwiseFlagEnumSchemaFilter.cs
@@ -1,0 +1,21 @@
+using System.Reflection;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace API.SwaggerGen;
+
+/// <summary>
+/// Appends a custom attribute to the schemas generated for enums that are bitwise flags
+/// </summary>
+public class BitwiseFlagEnumSchemaFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        Type? type = context.Type;
+        if (type is not null && type.IsEnum && type.GetCustomAttribute<FlagsAttribute>() is not null)
+        {
+            schema.Extensions.Add("x-bitwiseFlag", new OpenApiBoolean(true));
+        }
+    }
+}

--- a/Database/Database.csproj
+++ b/Database/Database.csproj
@@ -6,6 +6,14 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <PropertyGroup>
+      <NoWarn>CS1591</NoWarn>
+      <NoWarn>CS8981</NoWarn>
+    </PropertyGroup>
+    <PropertyGroup>
+      <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
     <ItemGroup>
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="8.0.5" />

--- a/Database/Entities/AuditEntityBase.cs
+++ b/Database/Entities/AuditEntityBase.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 namespace Database.Entities;
 
 /// <summary>
-/// Base class for a <typeparamref name="TAudit"/> entity that serves as an audit for a <see cref="TAuditable"/> entity
+/// Base class for a <typeparamref name="TAudit"/> entity that serves as an audit for an auditable entity
 /// </summary>
 /// <typeparam name="TAuditable">Derived audit</typeparam>
 /// <typeparam name="TAudit">Entity to be audited</typeparam>


### PR DESCRIPTION
Improves the swagger doc generation in preparation for automatic client code generation
- Prevents the `RequestLoggingMiddleware` from logging requests to `/swagger` when running in debug environments
- Startup flag to generate and write the swagger spec to disc
- Adds `Database` assembly xml comments
- Add custom JSON extensions to enums in the swagger spec for better documentation