### PR TITLE
Add endpoints and relationships for MatchAdminNotes + TournamentAdminNote relationship fixes

### DIFF
--- a/API/Controllers/MatchesController.Admin.cs
+++ b/API/Controllers/MatchesController.Admin.cs
@@ -13,13 +13,11 @@ public partial class MatchesController
     /// Creates an admin note for a match
     /// </summary>
     /// <param name="id">Match id</param>
-    /// <response code="401">If the requester is not properly authorized</response>
     /// <response code="404">If a match matching the given id does not exist</response>
     /// <response code="400">If the authorized user does not exist</response>
     /// <response code="200">Returns the created admin note</response>
     [HttpPost("{id:int}/notes")]
     [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
@@ -61,7 +59,6 @@ public partial class MatchesController
     /// </summary>
     /// <param name="id">Match id</param>
     /// <param name="noteId">Admin note id</param>
-    /// <response code="401">If the requester is not properly authorized</response>
     /// <response code="404">
     /// If a match matching the given id does not exist.
     /// If an admin note matching the given noteId does not exist
@@ -70,7 +67,6 @@ public partial class MatchesController
     /// <response code="200">Returns the updated admin note</response>
     [HttpPatch("{id:int}/notes/{noteId:int}")]
     [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
@@ -100,7 +96,6 @@ public partial class MatchesController
     /// </summary>
     /// <param name="id">Match id</param>
     /// <param name="noteId">Admin note id</param>
-    /// <response code="401">If the requester is not properly authorized</response>
     /// <response code="404">
     /// If a match matching the given id does not exist.
     /// If an admin note matching the given noteId does not exist
@@ -108,7 +103,6 @@ public partial class MatchesController
     /// <response code="200">Returns the updated admin note</response>
     [HttpDelete("{id:int}/notes/{noteId:int}")]
     [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]

--- a/API/Controllers/MatchesController.Admin.cs
+++ b/API/Controllers/MatchesController.Admin.cs
@@ -1,0 +1,127 @@
+using API.Authorization;
+using API.DTOs;
+using API.Utilities.Extensions;
+using Database.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Controllers;
+
+public partial class MatchesController
+{
+    /// <summary>
+    /// Creates an admin note for a match
+    /// </summary>
+    /// <param name="id">Match id</param>
+    /// <response code="401">If the requester is not properly authorized</response>
+    /// <response code="404">If a match matching the given id does not exist</response>
+    /// <response code="400">If the authorized user does not exist</response>
+    /// <response code="200">Returns the created admin note</response>
+    [HttpPost("{id:int}/notes")]
+    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> CreateAdminNoteAsync(int id, [FromBody] string note)
+    {
+        if (!await matchesService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        AdminNoteDTO? result = await adminNoteService.CreateAsync<MatchAdminNote>(id, User.GetSubjectId(), note);
+        return result is not null
+            ? Ok(result)
+            : BadRequest();
+    }
+
+    /// <summary>
+    /// List all admin notes from a match
+    /// </summary>
+    /// <param name="id">Match id</param>
+    /// <response code="404">If a match matching the given id does not exist</response>
+    /// <response code="200">Returns all admin notes from a match</response>
+    [HttpGet("{id:int}/notes")]
+    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<IEnumerable<AdminNoteDTO>>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> ListAdminNotesAsync(int id)
+    {
+        if (!await matchesService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        return Ok(await adminNoteService.ListAsync<MatchAdminNote>(id));
+    }
+
+    /// <summary>
+    /// Updates an admin note for a match
+    /// </summary>
+    /// <param name="id">Match id</param>
+    /// <param name="noteId">Admin note id</param>
+    /// <response code="401">If the requester is not properly authorized</response>
+    /// <response code="404">
+    /// If a match matching the given id does not exist.
+    /// If an admin note matching the given noteId does not exist
+    /// </response>
+    /// <response code="403">If the requester did not create the admin note</response>
+    /// <response code="200">Returns the updated admin note</response>
+    [HttpPatch("{id:int}/notes/{noteId:int}")]
+    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> UpdateAdminNoteAsync(int id, int noteId, [FromBody] string note)
+    {
+        if (!await matchesService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        AdminNoteDTO? existingNote = await adminNoteService.GetAsync<MatchAdminNote>(noteId);
+        if (existingNote is null)
+        {
+            return NotFound();
+        }
+
+        existingNote.Note = note;
+        AdminNoteDTO? result = await adminNoteService.UpdateAsync<MatchAdminNote>(existingNote);
+
+        return result is not null
+            ? Ok(result)
+            : NotFound();
+    }
+
+    /// <summary>
+    /// Deletes an admin note for a match
+    /// </summary>
+    /// <param name="id">Match id</param>
+    /// <param name="noteId">Admin note id</param>
+    /// <response code="401">If the requester is not properly authorized</response>
+    /// <response code="404">
+    /// If a match matching the given id does not exist.
+    /// If an admin note matching the given noteId does not exist
+    /// </response>
+    /// <response code="200">Returns the updated admin note</response>
+    [HttpDelete("{id:int}/notes/{noteId:int}")]
+    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> DeleteAdminNoteAsync(int id, int noteId)
+    {
+        if (!await matchesService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        var result = await adminNoteService.DeleteAsync<MatchAdminNote>(noteId);
+        return result
+            ? Ok()
+            : NotFound();
+    }
+}

--- a/API/Controllers/MatchesController.cs
+++ b/API/Controllers/MatchesController.cs
@@ -15,7 +15,7 @@ namespace API.Controllers;
 [ApiController]
 [ApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]")]
-public class MatchesController(IMatchesService matchesService) : Controller
+public partial class MatchesController(IMatchesService matchesService, IAdminNoteService adminNoteService) : Controller
 {
     /// <summary>
     /// Gets all matches

--- a/API/Services/Implementations/MatchesService.cs
+++ b/API/Services/Implementations/MatchesService.cs
@@ -106,4 +106,7 @@ public class MatchesService(
         await matchesRepository.UpdateAsync(existing);
         return mapper.Map<MatchDTO>(existing);
     }
+
+    public async Task<bool> ExistsAsync(int id) =>
+        await matchesRepository.ExistsAsync(id);
 }

--- a/API/Services/Interfaces/IMatchesService.cs
+++ b/API/Services/Interfaces/IMatchesService.cs
@@ -44,4 +44,11 @@ public interface IMatchesService
     /// <param name="match">The DTO containing the new values</param>
     /// <returns>The updated DTO</returns>
     Task<MatchDTO?> UpdateAsync(int id, MatchDTO match);
+
+    /// <summary>
+    /// Checks if the match exists
+    /// </summary>
+    /// <param name="id">The match id</param>
+    /// <returns>True if the match exists, false otherwise</returns>
+    Task<bool> ExistsAsync(int id);
 }

--- a/Database/Entities/User.cs
+++ b/Database/Entities/User.cs
@@ -68,4 +68,9 @@ public class User : UpdateableEntityBase
     /// A collection of <see cref="TournamentAdminNote"/>s created by the user
     /// </summary>
     public ICollection<TournamentAdminNote> TournamentAdminNotes { get; set; } = new List<TournamentAdminNote>();
+
+    /// <summary>
+    /// A collection of <see cref="MatchAdminNote"/>s created by the user
+    /// </summary>
+    public ICollection<MatchAdminNote> MatchAdminNotes { get; set; } = new List<MatchAdminNote>();
 }

--- a/Database/Migrations/20241005174847_MatchAdminNote_ConfigRelationships_AddMissingTournamentAdminNoteRelationship.Designer.cs
+++ b/Database/Migrations/20241005174847_MatchAdminNote_ConfigRelationships_AddMissingTournamentAdminNoteRelationship.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Database.Migrations
 {
     [DbContext(typeof(OtrContext))]
-    partial class OtrContextModelSnapshot : ModelSnapshot
+    [Migration("20241005174847_MatchAdminNote_ConfigRelationships_AddMissingTournamentAdminNoteRelationship")]
+    partial class MatchAdminNote_ConfigRelationships_AddMissingTournamentAdminNoteRelationship
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Database/Migrations/20241005174847_MatchAdminNote_ConfigRelationships_AddMissingTournamentAdminNoteRelationship.cs
+++ b/Database/Migrations/20241005174847_MatchAdminNote_ConfigRelationships_AddMissingTournamentAdminNoteRelationship.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class MatchAdminNote_ConfigRelationships_AddMissingTournamentAdminNoteRelationship : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "created",
+                table: "match_admin_notes",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "CURRENT_TIMESTAMP",
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "id",
+                table: "match_admin_notes",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityAlwaysColumn)
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_match_admin_notes_admin_user_id",
+                table: "match_admin_notes",
+                column: "admin_user_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_match_admin_notes_users_admin_user_id",
+                table: "match_admin_notes",
+                column: "admin_user_id",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_match_admin_notes_users_admin_user_id",
+                table: "match_admin_notes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_match_admin_notes_admin_user_id",
+                table: "match_admin_notes");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "created",
+                table: "match_admin_notes",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldDefaultValueSql: "CURRENT_TIMESTAMP");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "id",
+                table: "match_admin_notes",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityAlwaysColumn);
+        }
+    }
+}

--- a/Database/OtrContext.cs
+++ b/Database/OtrContext.cs
@@ -352,9 +352,20 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
 
         modelBuilder.Entity<MatchAdminNote>(entity =>
         {
-            entity.HasOne(m => m.Match)
+            entity.Property(tan => tan.Id).UseIdentityAlwaysColumn();
+
+            entity.Property(tan => tan.Created).HasDefaultValueSql(SqlCurrentTimestamp);
+
+            // Relation: Match
+            entity.HasOne(man => man.Match)
                 .WithMany(m => m.AdminNotes)
                 .HasForeignKey(m => m.ReferenceId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Relation: User
+            entity.HasOne(man => man.AdminUser)
+                .WithMany(u => u.MatchAdminNotes)
+                .HasForeignKey(m => m.AdminUserId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
 
@@ -827,6 +838,21 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .HasMany(u => u.Clients)
                 .WithOne(c => c.User)
                 .HasForeignKey(c => c.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // == Admin Notes ==
+            // Relation: TournamentAdminNotes
+            entity
+                .HasMany(u => u.TournamentAdminNotes)
+                .WithOne(tan => tan.AdminUser)
+                .HasForeignKey(tan => tan.AdminUserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Relation: MatchAdminNotes
+            entity
+                .HasMany(u => u.MatchAdminNotes)
+                .WithOne(man => man.AdminUser)
+                .HasForeignKey(man => man.AdminUserId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
 


### PR DESCRIPTION
Part of #379 

- Adds `GET`, `POST`, `PATCH`, `DELETE` endpoints for `MatchAdminNote`s
- Configures relationship between `MatchAdminNote` to `User` and vice versa.
- Adds missing relationship from `User` to `TournamentAdminNote`
- Adds migrations for these relationships