### PR TITLE
Add endpoints and relationships for GameAdminNotes

### DIFF
--- a/API/Controllers/GamesController.Admin.cs
+++ b/API/Controllers/GamesController.Admin.cs
@@ -13,13 +13,11 @@ public partial class GamesController
     /// Creates an admin note for a game
     /// </summary>
     /// <param name="id">Game id</param>
-    /// <response code="401">If the requester is not properly authorized</response>
     /// <response code="404">If a game matching the given id does not exist</response>
     /// <response code="400">If the authorized user does not exist</response>
     /// <response code="200">Returns the created admin note</response>
     [HttpPost("{id:int}/notes")]
     [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
@@ -61,7 +59,6 @@ public partial class GamesController
     /// </summary>
     /// <param name="id">Game id</param>
     /// <param name="noteId">Admin note id</param>
-    /// <response code="401">If the requester is not properly authorized</response>
     /// <response code="404">
     /// If a game matching the given id does not exist.
     /// If an admin note matching the given noteId does not exist
@@ -70,7 +67,6 @@ public partial class GamesController
     /// <response code="200">Returns the updated admin note</response>
     [HttpPatch("{id:int}/notes/{noteId:int}")]
     [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
@@ -100,7 +96,6 @@ public partial class GamesController
     /// </summary>
     /// <param name="id">Game id</param>
     /// <param name="noteId">Admin note id</param>
-    /// <response code="401">If the requester is not properly authorized</response>
     /// <response code="404">
     /// If a game matching the given id does not exist.
     /// If an admin note matching the given noteId does not exist
@@ -108,7 +103,6 @@ public partial class GamesController
     /// <response code="200">Returns the updated admin note</response>
     [HttpDelete("{id:int}/notes/{noteId:int}")]
     [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]

--- a/API/Controllers/GamesController.Admin.cs
+++ b/API/Controllers/GamesController.Admin.cs
@@ -1,0 +1,127 @@
+using API.Authorization;
+using API.DTOs;
+using API.Utilities.Extensions;
+using Database.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Controllers;
+
+public partial class GamesController
+{
+    /// <summary>
+    /// Creates an admin note for a game
+    /// </summary>
+    /// <param name="id">Game id</param>
+    /// <response code="401">If the requester is not properly authorized</response>
+    /// <response code="404">If a game matching the given id does not exist</response>
+    /// <response code="400">If the authorized user does not exist</response>
+    /// <response code="200">Returns the created admin note</response>
+    [HttpPost("{id:int}/notes")]
+    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> CreateAdminNoteAsync(int id, [FromBody] string note)
+    {
+        if (!await gamesService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        AdminNoteDTO? result = await adminNoteService.CreateAsync<GameAdminNote>(id, User.GetSubjectId(), note);
+        return result is not null
+            ? Ok(result)
+            : BadRequest();
+    }
+
+    /// <summary>
+    /// List all admin notes from a game
+    /// </summary>
+    /// <param name="id">Game id</param>
+    /// <response code="404">If a game matching the given id does not exist</response>
+    /// <response code="200">Returns all admin notes from a game</response>
+    [HttpGet("{id:int}/notes")]
+    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<IEnumerable<AdminNoteDTO>>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> ListAdminNotesAsync(int id)
+    {
+        if (!await gamesService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        return Ok(await adminNoteService.ListAsync<GameAdminNote>(id));
+    }
+
+    /// <summary>
+    /// Updates an admin note for a game
+    /// </summary>
+    /// <param name="id">Game id</param>
+    /// <param name="noteId">Admin note id</param>
+    /// <response code="401">If the requester is not properly authorized</response>
+    /// <response code="404">
+    /// If a game matching the given id does not exist.
+    /// If an admin note matching the given noteId does not exist
+    /// </response>
+    /// <response code="403">If the requester did not create the admin note</response>
+    /// <response code="200">Returns the updated admin note</response>
+    [HttpPatch("{id:int}/notes/{noteId:int}")]
+    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> UpdateAdminNoteAsync(int id, int noteId, [FromBody] string note)
+    {
+        if (!await gamesService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        AdminNoteDTO? existingNote = await adminNoteService.GetAsync<GameAdminNote>(noteId);
+        if (existingNote is null)
+        {
+            return NotFound();
+        }
+
+        existingNote.Note = note;
+        AdminNoteDTO? result = await adminNoteService.UpdateAsync<GameAdminNote>(existingNote);
+
+        return result is not null
+            ? Ok(result)
+            : NotFound();
+    }
+
+    /// <summary>
+    /// Deletes an admin note for a game
+    /// </summary>
+    /// <param name="id">Game id</param>
+    /// <param name="noteId">Admin note id</param>
+    /// <response code="401">If the requester is not properly authorized</response>
+    /// <response code="404">
+    /// If a game matching the given id does not exist.
+    /// If an admin note matching the given noteId does not exist
+    /// </response>
+    /// <response code="200">Returns the updated admin note</response>
+    [HttpDelete("{id:int}/notes/{noteId:int}")]
+    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> DeleteAdminNoteAsync(int id, int noteId)
+    {
+        if (!await gamesService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        var result = await adminNoteService.DeleteAsync<GameAdminNote>(noteId);
+        return result
+            ? Ok()
+            : NotFound();
+    }
+}

--- a/API/Controllers/GamesController.cs
+++ b/API/Controllers/GamesController.cs
@@ -13,7 +13,7 @@ namespace API.Controllers;
 [ApiController]
 [ApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]")]
-public class GamesController(IGamesService gamesService) : Controller
+public partial class GamesController(IGamesService gamesService, IAdminNoteService adminNoteService) : Controller
 {
     /// <summary>
     /// Amend game data

--- a/API/Services/Implementations/GamesService.cs
+++ b/API/Services/Implementations/GamesService.cs
@@ -32,4 +32,7 @@ public class GamesService(IGamesRepository gamesRepository, IMapper mapper) : IG
         await gamesRepository.UpdateAsync(existing);
         return mapper.Map<GameDTO>(existing);
     }
+
+    public async Task<bool> ExistsAsync(int id) =>
+        await gamesRepository.ExistsAsync(id);
 }

--- a/API/Services/Interfaces/IGamesService.cs
+++ b/API/Services/Interfaces/IGamesService.cs
@@ -18,4 +18,11 @@ public interface IGamesService
     /// <param name="match">The DTO containing the new values</param>
     /// <returns>The updated DTO</returns>
     Task<GameDTO?> UpdateAsync(int id, GameDTO game);
+
+    /// <summary>
+    /// Checks if the game exists
+    /// </summary>
+    /// <param name="id">The game id</param>
+    /// <returns>True if the game exists, false otherwise</returns>
+    Task<bool> ExistsAsync(int id);
 }

--- a/Database/Entities/User.cs
+++ b/Database/Entities/User.cs
@@ -68,4 +68,9 @@ public class User : UpdateableEntityBase
     /// A collection of <see cref="TournamentAdminNote"/>s created by the user
     /// </summary>
     public ICollection<TournamentAdminNote> TournamentAdminNotes { get; set; } = new List<TournamentAdminNote>();
+
+    /// <summary>
+    /// A collection of <see cref="GameAdminNote"/>s created by the user
+    /// </summary>
+    public ICollection<GameAdminNote> GameAdminNotes { get; set; } = new List<GameAdminNote>();
 }

--- a/Database/Migrations/20241005193206_GameAdminNote_Relationship.Designer.cs
+++ b/Database/Migrations/20241005193206_GameAdminNote_Relationship.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Database.Migrations
 {
     [DbContext(typeof(OtrContext))]
-    partial class OtrContextModelSnapshot : ModelSnapshot
+    [Migration("20241005193206_GameAdminNote_Relationship")]
+    partial class GameAdminNote_Relationship
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Database/Migrations/20241005193206_GameAdminNote_Relationship.cs
+++ b/Database/Migrations/20241005193206_GameAdminNote_Relationship.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class GameAdminNote_Relationship : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_game_admin_notes_admin_user_id",
+                table: "game_admin_notes",
+                column: "admin_user_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_game_admin_notes_users_admin_user_id",
+                table: "game_admin_notes",
+                column: "admin_user_id",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_game_admin_notes_users_admin_user_id",
+                table: "game_admin_notes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_game_admin_notes_admin_user_id",
+                table: "game_admin_notes");
+        }
+    }
+}

--- a/Database/OtrContext.cs
+++ b/Database/OtrContext.cs
@@ -846,7 +846,7 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .WithOne(c => c.User)
                 .HasForeignKey(c => c.UserId)
                 .OnDelete(DeleteBehavior.Cascade);
-  
+
             // == Admin Notes ==
             // Relation: TournamentAdminNotes
             entity
@@ -861,10 +861,10 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .WithOne(man => man.AdminUser)
                 .HasForeignKey(man => man.AdminUserId)
                 .OnDelete(DeleteBehavior.Cascade);
-          
+
             entity.HasMany(u => u.GameAdminNotes)
                 .WithOne(gan => gan.AdminUser)
-                .HasForeignKey(gan => gan.AdminUserId)
+                .HasForeignKey(gan => gan.AdminUserId);
         });
 
         modelBuilder.Entity<UserSettings>(entity =>

--- a/Database/OtrContext.cs
+++ b/Database/OtrContext.cs
@@ -154,9 +154,16 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
 
             entity.Property(gan => gan.Created).HasDefaultValueSql(SqlCurrentTimestamp);
 
-            entity.HasOne(g => g.Game)
+            // Relationship: Game
+            entity.HasOne(gan => gan.Game)
                 .WithMany(g => g.AdminNotes)
-                .HasForeignKey(g => g.ReferenceId)
+                .HasForeignKey(gan => gan.ReferenceId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Relationship: User
+            entity.HasOne(gan => gan.AdminUser)
+                .WithMany(u => u.GameAdminNotes)
+                .HasForeignKey(gan => gan.ReferenceId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
 
@@ -827,6 +834,11 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .HasMany(u => u.Clients)
                 .WithOne(c => c.User)
                 .HasForeignKey(c => c.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasMany(u => u.GameAdminNotes)
+                .WithOne(gan => gan.AdminUser)
+                .HasForeignKey(gan => gan.AdminUserId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
 


### PR DESCRIPTION
Part of #379
- Adds `GET`, `POST`, `PATCH`, `DELETE` endpoints for `GameAdminNote`s
- Configures relationship between `GameAdminNote` to `User` and vice versa.
- Adds migrations for these relationships