### PR TITLE
Add endpoints and relationships for GameScoreAdminNotes

### DIFF
--- a/API/Controllers/GameScoresController.Admin.cs
+++ b/API/Controllers/GameScoresController.Admin.cs
@@ -13,13 +13,11 @@ public partial class GameScoresController
     /// Creates an admin note for a score
     /// </summary>
     /// <param name="id">Score id</param>
-    /// <response code="401">If the requester is not properly authorized</response>
     /// <response code="404">If a score matching the given id does not exist</response>
     /// <response code="400">If the authorized user does not exist</response>
     /// <response code="200">Returns the created admin note</response>
     [HttpPost("{id:int}/notes")]
     [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
@@ -61,7 +59,6 @@ public partial class GameScoresController
     /// </summary>
     /// <param name="id">Score id</param>
     /// <param name="noteId">Admin note id</param>
-    /// <response code="401">If the requester is not properly authorized</response>
     /// <response code="404">
     /// If a score matching the given id does not exist.
     /// If an admin note matching the given noteId does not exist
@@ -70,7 +67,6 @@ public partial class GameScoresController
     /// <response code="200">Returns the updated admin note</response>
     [HttpPatch("{id:int}/notes/{noteId:int}")]
     [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
@@ -100,7 +96,6 @@ public partial class GameScoresController
     /// </summary>
     /// <param name="id">Score id</param>
     /// <param name="noteId">Admin note id</param>
-    /// <response code="401">If the requester is not properly authorized</response>
     /// <response code="404">
     /// If a score matching the given id does not exist.
     /// If an admin note matching the given noteId does not exist
@@ -108,7 +103,6 @@ public partial class GameScoresController
     /// <response code="200">Returns the updated admin note</response>
     [HttpDelete("{id:int}/notes/{noteId:int}")]
     [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]

--- a/API/Controllers/GameScoresController.Admin.cs
+++ b/API/Controllers/GameScoresController.Admin.cs
@@ -1,0 +1,127 @@
+using API.Authorization;
+using API.DTOs;
+using API.Utilities.Extensions;
+using Database.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Controllers;
+
+public partial class GameScoresController
+{
+    /// <summary>
+    /// Creates an admin note for a score
+    /// </summary>
+    /// <param name="id">Score id</param>
+    /// <response code="401">If the requester is not properly authorized</response>
+    /// <response code="404">If a score matching the given id does not exist</response>
+    /// <response code="400">If the authorized user does not exist</response>
+    /// <response code="200">Returns the created admin note</response>
+    [HttpPost("{id:int}/notes")]
+    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> CreateAdminNoteAsync(int id, [FromBody] string note)
+    {
+        if (!await gameScoresService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        AdminNoteDTO? result = await adminNoteService.CreateAsync<GameScoreAdminNote>(id, User.GetSubjectId(), note);
+        return result is not null
+            ? Ok(result)
+            : BadRequest();
+    }
+
+    /// <summary>
+    /// List all admin notes for a score
+    /// </summary>
+    /// <param name="id">Score id</param>
+    /// <response code="404">If a score matching the given id does not exist</response>
+    /// <response code="200">Returns all admin notes from a score</response>
+    [HttpGet("{id:int}/notes")]
+    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<IEnumerable<AdminNoteDTO>>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> ListAdminNotesAsync(int id)
+    {
+        if (!await gameScoresService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        return Ok(await adminNoteService.ListAsync<GameScoreAdminNote>(id));
+    }
+
+    /// <summary>
+    /// Updates an admin note for a score
+    /// </summary>
+    /// <param name="id">Score id</param>
+    /// <param name="noteId">Admin note id</param>
+    /// <response code="401">If the requester is not properly authorized</response>
+    /// <response code="404">
+    /// If a score matching the given id does not exist.
+    /// If an admin note matching the given noteId does not exist
+    /// </response>
+    /// <response code="403">If the requester did not create the admin note</response>
+    /// <response code="200">Returns the updated admin note</response>
+    [HttpPatch("{id:int}/notes/{noteId:int}")]
+    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> UpdateAdminNoteAsync(int id, int noteId, [FromBody] string note)
+    {
+        if (!await gameScoresService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        AdminNoteDTO? existingNote = await adminNoteService.GetAsync<GameScoreAdminNote>(noteId);
+        if (existingNote is null)
+        {
+            return NotFound();
+        }
+
+        existingNote.Note = note;
+        AdminNoteDTO? result = await adminNoteService.UpdateAsync<GameScoreAdminNote>(existingNote);
+
+        return result is not null
+            ? Ok(result)
+            : NotFound();
+    }
+
+    /// <summary>
+    /// Deletes an admin note for a score
+    /// </summary>
+    /// <param name="id">Score id</param>
+    /// <param name="noteId">Admin note id</param>
+    /// <response code="401">If the requester is not properly authorized</response>
+    /// <response code="404">
+    /// If a score matching the given id does not exist.
+    /// If an admin note matching the given noteId does not exist
+    /// </response>
+    /// <response code="200">Returns the updated admin note</response>
+    [HttpDelete("{id:int}/notes/{noteId:int}")]
+    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> DeleteAdminNoteAsync(int id, int noteId)
+    {
+        if (!await gameScoresService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        var result = await adminNoteService.DeleteAsync<GameScoreAdminNote>(noteId);
+        return result
+            ? Ok()
+            : NotFound();
+    }
+}

--- a/API/Controllers/GameScoresController.cs
+++ b/API/Controllers/GameScoresController.cs
@@ -1,7 +1,6 @@
 using API.Authorization;
 using API.DTOs;
 using API.Services.Interfaces;
-using API.Utilities;
 using API.Utilities.Extensions;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;

--- a/API/Controllers/GameScoresController.cs
+++ b/API/Controllers/GameScoresController.cs
@@ -13,7 +13,7 @@ namespace API.Controllers;
 [ApiController]
 [ApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]")]
-public class GameScoresController(IGameScoresService gameScoresService) : Controller
+public partial class GameScoresController(IGameScoresService gameScoresService, IAdminNoteService adminNoteService) : Controller
 {
     /// <summary>
     ///  Amend score data

--- a/API/Services/Implementations/GameScoresService.cs
+++ b/API/Services/Implementations/GameScoresService.cs
@@ -30,4 +30,7 @@ public class GameScoresService(IGameScoresRepository gameScoresRepository, IMapp
         await gameScoresRepository.UpdateAsync(existing);
         return mapper.Map<GameScoreDTO>(existing);
     }
+
+    public async Task<bool> ExistsAsync(int id) =>
+        await gameScoresRepository.ExistsAsync(id);
 }

--- a/API/Services/Interfaces/IGameScoresService.cs
+++ b/API/Services/Interfaces/IGameScoresService.cs
@@ -18,4 +18,11 @@ public interface IGameScoresService
     /// <param name="match">The DTO containing the new values</param>
     /// <returns>The updated DTO</returns>
     Task<GameScoreDTO?> UpdateAsync(int id, GameScoreDTO score);
+
+    /// <summary>
+    /// Checks if the score exists
+    /// </summary>
+    /// <param name="id">The score id</param>
+    /// <returns>True if the score exists, false otherwise</returns>
+    Task<bool> ExistsAsync(int id);
 }

--- a/Database/Entities/User.cs
+++ b/Database/Entities/User.cs
@@ -68,4 +68,9 @@ public class User : UpdateableEntityBase
     /// A collection of <see cref="TournamentAdminNote"/>s created by the user
     /// </summary>
     public ICollection<TournamentAdminNote> TournamentAdminNotes { get; set; } = new List<TournamentAdminNote>();
+
+    /// <summary>
+    /// A collection of <see cref="GameScoreAdminNote"/>s created by the user
+    /// </summary>
+    public ICollection<GameScoreAdminNote> GameScoreAdminNotes { get; set; } = new List<GameScoreAdminNote>();
 }

--- a/Database/Migrations/20241005195146_GameScore_AdminNotes_OwnedByUser.Designer.cs
+++ b/Database/Migrations/20241005195146_GameScore_AdminNotes_OwnedByUser.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Database.Migrations
 {
     [DbContext(typeof(OtrContext))]
-    partial class OtrContextModelSnapshot : ModelSnapshot
+    [Migration("20241005195146_GameScore_AdminNotes_OwnedByUser")]
+    partial class GameScore_AdminNotes_OwnedByUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Database/Migrations/20241005195146_GameScore_AdminNotes_OwnedByUser.cs
+++ b/Database/Migrations/20241005195146_GameScore_AdminNotes_OwnedByUser.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class GameScore_AdminNotes_OwnedByUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_game_score_admin_notes_admin_user_id",
+                table: "game_score_admin_notes",
+                column: "admin_user_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_game_score_admin_notes_users_admin_user_id",
+                table: "game_score_admin_notes",
+                column: "admin_user_id",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_game_score_admin_notes_users_admin_user_id",
+                table: "game_score_admin_notes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_game_score_admin_notes_admin_user_id",
+                table: "game_score_admin_notes");
+        }
+    }
+}

--- a/Database/OtrContext.cs
+++ b/Database/OtrContext.cs
@@ -226,9 +226,16 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
 
             entity.Property(gsan => gsan.Created).HasDefaultValueSql(SqlCurrentTimestamp);
 
+            // Relation: Score
             entity.HasOne(gsan => gsan.Score)
                 .WithMany(gs => gs.AdminNotes)
                 .HasForeignKey(gsan => gsan.ReferenceId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Relation: User
+            entity.HasOne(gsan => gsan.AdminUser)
+                .WithMany(gs => gs.GameScoreAdminNotes)
+                .HasForeignKey(gsan => gsan.AdminUserId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
 
@@ -827,6 +834,12 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .HasMany(u => u.Clients)
                 .WithOne(c => c.User)
                 .HasForeignKey(c => c.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Relation: GameScoreAdminNotes
+            entity.HasMany(u => u.GameScoreAdminNotes)
+                .WithOne(gsan => gsan.AdminUser)
+                .HasForeignKey(gsan => gsan.AdminUserId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
 


### PR DESCRIPTION
Part of #379
- Adds `GET`, `POST`, `PATCH`, `DELETE` endpoints for `GameScoreAdminNote`s
- Configures relationship between `GameScoreAdminNote` to `User` and vice versa.
- Adds migrations for these relationships