### PR TITLE
Add endpoints and relationships for PlayerAdminNotes

### DIFF
--- a/API/Controllers/PlayersController.Admin.cs
+++ b/API/Controllers/PlayersController.Admin.cs
@@ -13,13 +13,11 @@ public partial class PlayersController
     /// Creates an admin note for a player
     /// </summary>
     /// <param name="id">Player id</param>
-    /// <response code="401">If the requester is not properly authorized</response>
     /// <response code="404">If a player matching the given id does not exist</response>
     /// <response code="400">If the authorized user does not exist</response>
     /// <response code="200">Returns the created admin note</response>
     [HttpPost("{id:int}/notes")]
     [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
@@ -61,7 +59,6 @@ public partial class PlayersController
     /// </summary>
     /// <param name="id">Player id</param>
     /// <param name="noteId">Admin note id</param>
-    /// <response code="401">If the requester is not properly authorized</response>
     /// <response code="404">
     /// If a player matching the given id does not exist.
     /// If an admin note matching the given noteId does not exist
@@ -70,7 +67,6 @@ public partial class PlayersController
     /// <response code="200">Returns the updated admin note</response>
     [HttpPatch("{id:int}/notes/{noteId:int}")]
     [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
@@ -100,7 +96,6 @@ public partial class PlayersController
     /// </summary>
     /// <param name="id">Player id</param>
     /// <param name="noteId">Admin note id</param>
-    /// <response code="401">If the requester is not properly authorized</response>
     /// <response code="404">
     /// If a player matching the given id does not exist.
     /// If an admin note matching the given noteId does not exist
@@ -108,7 +103,6 @@ public partial class PlayersController
     /// <response code="200">Returns the updated admin note</response>
     [HttpDelete("{id:int}/notes/{noteId:int}")]
     [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]

--- a/API/Controllers/PlayersController.Admin.cs
+++ b/API/Controllers/PlayersController.Admin.cs
@@ -1,0 +1,127 @@
+using API.Authorization;
+using API.DTOs;
+using API.Utilities.Extensions;
+using Database.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Controllers;
+
+public partial class PlayersController
+{
+    /// <summary>
+    /// Creates an admin note for a player
+    /// </summary>
+    /// <param name="id">Player id</param>
+    /// <response code="401">If the requester is not properly authorized</response>
+    /// <response code="404">If a player matching the given id does not exist</response>
+    /// <response code="400">If the authorized user does not exist</response>
+    /// <response code="200">Returns the created admin note</response>
+    [HttpPost("{id:int}/notes")]
+    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> CreateAdminNoteAsync(int id, [FromBody] string note)
+    {
+        if (!await playerService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        AdminNoteDTO? result = await adminNoteService.CreateAsync<PlayerAdminNote>(id, User.GetSubjectId(), note);
+        return result is not null
+            ? Ok(result)
+            : BadRequest();
+    }
+
+    /// <summary>
+    /// List all admin notes for a player
+    /// </summary>
+    /// <param name="id">Player id</param>
+    /// <response code="404">If a player matching the given id does not exist</response>
+    /// <response code="200">Returns all admin notes from a player</response>
+    [HttpGet("{id:int}/notes")]
+    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<IEnumerable<AdminNoteDTO>>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> ListAdminNotesAsync(int id)
+    {
+        if (!await playerService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        return Ok(await adminNoteService.ListAsync<PlayerAdminNote>(id));
+    }
+
+    /// <summary>
+    /// Updates an admin note for a player
+    /// </summary>
+    /// <param name="id">Player id</param>
+    /// <param name="noteId">Admin note id</param>
+    /// <response code="401">If the requester is not properly authorized</response>
+    /// <response code="404">
+    /// If a player matching the given id does not exist.
+    /// If an admin note matching the given noteId does not exist
+    /// </response>
+    /// <response code="403">If the requester did not create the admin note</response>
+    /// <response code="200">Returns the updated admin note</response>
+    [HttpPatch("{id:int}/notes/{noteId:int}")]
+    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> UpdateAdminNoteAsync(int id, int noteId, [FromBody] string note)
+    {
+        if (!await playerService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        AdminNoteDTO? existingNote = await adminNoteService.GetAsync<PlayerAdminNote>(noteId);
+        if (existingNote is null)
+        {
+            return NotFound();
+        }
+
+        existingNote.Note = note;
+        AdminNoteDTO? result = await adminNoteService.UpdateAsync<PlayerAdminNote>(existingNote);
+
+        return result is not null
+            ? Ok(result)
+            : NotFound();
+    }
+
+    /// <summary>
+    /// Deletes an admin note for a player
+    /// </summary>
+    /// <param name="id">Player id</param>
+    /// <param name="noteId">Admin note id</param>
+    /// <response code="401">If the requester is not properly authorized</response>
+    /// <response code="404">
+    /// If a player matching the given id does not exist.
+    /// If an admin note matching the given noteId does not exist
+    /// </response>
+    /// <response code="200">Returns the updated admin note</response>
+    [HttpDelete("{id:int}/notes/{noteId:int}")]
+    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> DeleteAdminNoteAsync(int id, int noteId)
+    {
+        if (!await playerService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        var result = await adminNoteService.DeleteAsync<PlayerAdminNote>(noteId);
+        return result
+            ? Ok()
+            : NotFound();
+    }
+}

--- a/API/Controllers/PlayersController.cs
+++ b/API/Controllers/PlayersController.cs
@@ -12,7 +12,7 @@ namespace API.Controllers;
 [ApiVersion(1)]
 [EnableCors]
 [Route("api/v{version:apiVersion}/[controller]")]
-public class PlayersController(IPlayerService playerService) : Controller
+public partial class PlayersController(IPlayerService playerService, IAdminNoteService adminNoteService) : Controller
 {
     [HttpGet]
     [Authorize(Roles = OtrClaims.Roles.System)]

--- a/API/Services/Implementations/PlayerService.cs
+++ b/API/Services/Implementations/PlayerService.cs
@@ -46,4 +46,7 @@ public class PlayerService(IPlayersRepository playerRepository, IMapper mapper) 
 
         return dtos;
     }
+
+    public async Task<bool> ExistsAsync(int id) =>
+        await playerRepository.ExistsAsync(id);
 }

--- a/API/Services/Interfaces/IPlayerService.cs
+++ b/API/Services/Interfaces/IPlayerService.cs
@@ -32,4 +32,11 @@ public interface IPlayerService
     /// the <see cref="PlayerCompactDTO"/> will be returned in a default state,
     /// except the <see cref="PlayerCompactDTO.OsuId"/> value will be set</returns>
     Task<IEnumerable<PlayerCompactDTO>> GetAsync(IEnumerable<long> osuIds);
+
+    /// <summary>
+    /// Checks if the player exists
+    /// </summary>
+    /// <param name="id">The player id</param>
+    /// <returns>True if the player exists, false otherwise</returns>
+    Task<bool> ExistsAsync(int id);
 }

--- a/Database/Entities/User.cs
+++ b/Database/Entities/User.cs
@@ -73,11 +73,13 @@ public class User : UpdateableEntityBase
     /// A collection of <see cref="PlayerAdminNote"/>s created by the user
     /// </summary>
     public ICollection<PlayerAdminNote> PlayerAdminNotes { get; set; } = new List<PlayerAdminNote>();
-    
+
+    /// <summary>
     /// A collection of <see cref="GameAdminNote"/>s created by the user
     /// </summary>
     public ICollection<GameAdminNote> GameAdminNotes { get; set; } = new List<GameAdminNote>();
 
+    /// <summary>
     /// A collection of <see cref="MatchAdminNote"/>s created by the user
     /// </summary>
     public ICollection<MatchAdminNote> MatchAdminNotes { get; set; } = new List<MatchAdminNote>();

--- a/Database/Entities/User.cs
+++ b/Database/Entities/User.cs
@@ -68,4 +68,9 @@ public class User : UpdateableEntityBase
     /// A collection of <see cref="TournamentAdminNote"/>s created by the user
     /// </summary>
     public ICollection<TournamentAdminNote> TournamentAdminNotes { get; set; } = new List<TournamentAdminNote>();
+
+    /// <summary>
+    /// A collection of <see cref="PlayerAdminNote"/>s created by the user
+    /// </summary>
+    public ICollection<PlayerAdminNote> PlayerAdminNotes { get; set; } = new List<PlayerAdminNote>();
 }

--- a/Database/Migrations/20241005200223_PlayerAdminNote_User_Relationship.Designer.cs
+++ b/Database/Migrations/20241005200223_PlayerAdminNote_User_Relationship.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Database.Migrations
 {
     [DbContext(typeof(OtrContext))]
-    partial class OtrContextModelSnapshot : ModelSnapshot
+    [Migration("20241005200223_PlayerAdminNote_User_Relationship")]
+    partial class PlayerAdminNote_User_Relationship
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Database/Migrations/20241005200223_PlayerAdminNote_User_Relationship.cs
+++ b/Database/Migrations/20241005200223_PlayerAdminNote_User_Relationship.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class PlayerAdminNote_User_Relationship : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_player_admin_notes_admin_user_id",
+                table: "player_admin_notes",
+                column: "admin_user_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_player_admin_notes_users_admin_user_id",
+                table: "player_admin_notes",
+                column: "admin_user_id",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_player_admin_notes_users_admin_user_id",
+                table: "player_admin_notes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_player_admin_notes_admin_user_id",
+                table: "player_admin_notes");
+        }
+    }
+}

--- a/Database/OtrContext.cs
+++ b/Database/OtrContext.cs
@@ -861,7 +861,7 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .WithOne(pan => pan.AdminUser)
                 .HasForeignKey(pan => pan.AdminUserId)
                 .OnDelete(DeleteBehavior.Cascade);
-          
+
             // Relation: TournamentAdminNotes
             entity
                 .HasMany(u => u.TournamentAdminNotes)
@@ -876,9 +876,12 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .HasForeignKey(man => man.AdminUserId)
                 .OnDelete(DeleteBehavior.Cascade);
 
-            entity.HasMany(u => u.GameAdminNotes)
+            // Relation: User
+            entity
+                .HasMany(u => u.GameAdminNotes)
                 .WithOne(gan => gan.AdminUser)
                 .HasForeignKey(gan => gan.AdminUserId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
 
         modelBuilder.Entity<UserSettings>(entity =>

--- a/Database/OtrContext.cs
+++ b/Database/OtrContext.cs
@@ -606,9 +606,16 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
 
             entity.Property(pan => pan.Created).HasDefaultValueSql(SqlCurrentTimestamp);
 
+            // Relation: Player
             entity.HasOne(pan => pan.Player)
                 .WithMany(p => p.AdminNotes)
-                .HasForeignKey(r => r.ReferenceId)
+                .HasForeignKey(pan => pan.ReferenceId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Relation: User
+            entity.HasOne(pan => pan.AdminUser)
+                .WithMany(u => u.PlayerAdminNotes)
+                .HasForeignKey(pan => pan.AdminUserId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
 
@@ -827,6 +834,13 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .HasMany(u => u.Clients)
                 .WithOne(c => c.User)
                 .HasForeignKey(c => c.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Relation: PlayerAdminNotes
+            entity
+                .HasMany(u => u.PlayerAdminNotes)
+                .WithOne(pan => pan.AdminUser)
+                .HasForeignKey(pan => pan.AdminUserId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
 


### PR DESCRIPTION
Part of #379
- Adds `GET`, `POST`, `PATCH`, `DELETE` endpoints for `PlayerAdminNote`s
- Configures relationship between `PlayerAdminNote` to `User` and vice versa.
- Adds migrations for these relationships