### PR TITLE
Remove `system` client permission

### DIFF
--- a/API.Tests/SeedData/SeededBaseStats.cs
+++ b/API.Tests/SeedData/SeededBaseStats.cs
@@ -43,47 +43,47 @@ public static class SeededBaseStats
         }
 
         // Add all of the tiers that are true
-        if (tiers.FilterEliteGrandmaster == true)
+        if (tiers.FilterEliteGrandmaster)
         {
             lb.Add(Get().SetEliteGrandmaster());
         }
 
-        if (tiers.FilterGrandmaster == true)
+        if (tiers.FilterGrandmaster)
         {
             lb.Add(Get().SetGrandmaster());
         }
 
-        if (tiers.FilterMaster == true)
+        if (tiers.FilterMaster)
         {
             lb.Add(Get().SetMaster());
         }
 
-        if (tiers.FilterDiamond == true)
+        if (tiers.FilterDiamond)
         {
             lb.Add(Get().SetDiamond());
         }
 
-        if (tiers.FilterEmerald == true)
+        if (tiers.FilterEmerald)
         {
             lb.Add(Get().SetEmerald());
         }
 
-        if (tiers.FilterPlatinum == true)
+        if (tiers.FilterPlatinum)
         {
             lb.Add(Get().SetPlatinum());
         }
 
-        if (tiers.FilterGold == true)
+        if (tiers.FilterGold)
         {
             lb.Add(Get().SetGold());
         }
 
-        if (tiers.FilterSilver == true)
+        if (tiers.FilterSilver)
         {
             lb.Add(Get().SetSilver());
         }
 
-        if (tiers.FilterBronze == true)
+        if (tiers.FilterBronze)
         {
             lb.Add(Get().SetBronze());
         }

--- a/API.Tests/Utilities/ClaimsPrincipalExtensionsTests.cs
+++ b/API.Tests/Utilities/ClaimsPrincipalExtensionsTests.cs
@@ -12,7 +12,6 @@ public class ClaimsPrincipalExtensionsTests
     {
         var claims = new ClaimsPrincipal();
         Assert.False(claims.IsAdmin());
-        Assert.False(claims.IsSystem());
         Assert.False(claims.IsMatchVerifier());
         Assert.False(claims.IsWhitelisted());
     }

--- a/API.Tests/Utilities/OtrClaimsTests.cs
+++ b/API.Tests/Utilities/OtrClaimsTests.cs
@@ -1,5 +1,4 @@
 using API.Authorization;
-using API.Utilities;
 
 namespace APITests.Utilities;
 

--- a/API.Tests/Utilities/OtrClaimsTests.cs
+++ b/API.Tests/Utilities/OtrClaimsTests.cs
@@ -27,7 +27,6 @@ public class OtrClaimsTests
     }
 
     [Theory]
-    [InlineData(OtrClaims.Roles.System, true)]
     [InlineData(OtrClaims.Roles.Whitelist, true)]
     [InlineData(OtrClaims.RateLimitOverrides, false)]
     [InlineData(OtrClaims.Roles.User, false)]
@@ -48,7 +47,6 @@ public class OtrClaimsTests
     [Theory]
     [InlineData(OtrClaims.Roles.User, true)]
     [InlineData(OtrClaims.Roles.Client, true)]
-    [InlineData(OtrClaims.Roles.System, true)]
     [InlineData(OtrClaims.Roles.Admin, true)]
     [InlineData(OtrClaims.Roles.Verifier, true)]
     [InlineData(OtrClaims.Roles.Submitter, true)]

--- a/API.Tests/Utilities/RateLimitOverridesSerializerTests.cs
+++ b/API.Tests/Utilities/RateLimitOverridesSerializerTests.cs
@@ -1,5 +1,4 @@
 using API.Authorization;
-using API.Utilities;
 using Database.Entities;
 
 namespace APITests.Utilities;

--- a/API/Authorization/AuthorizationPolicies.cs
+++ b/API/Authorization/AuthorizationPolicies.cs
@@ -6,7 +6,7 @@ namespace API.Authorization;
 public static class AuthorizationPolicies
 {
     /// <summary>
-    /// Policy that allows access from <see cref="OtrClaims.Roles.Admin"/> and <see cref="OtrClaims.Roles.System"/>
+    /// Policy that allows access from <see cref="OtrClaims.Roles.Admin"/>
     /// requests, as well as redirected requests from unprivileged users to allow accessing their own resources.
     /// </summary>
     public const string AccessUserResources = "AccessUserResources";

--- a/API/Authorization/Handlers/AccessUserResourcesAuthorizationHandler.cs
+++ b/API/Authorization/Handlers/AccessUserResourcesAuthorizationHandler.cs
@@ -29,7 +29,7 @@ public class AccessUserResourcesAuthorizationHandler : AuthorizationHandler<Acce
         }
 
         // Allow requests that are privileged or have matching user id and target route id
-        if (context.User.IsAdmin() || context.User.IsSystem() || (requirement.AllowSelf && context.User.GetSubjectId() == routeId))
+        if (context.User.IsAdmin() || (requirement.AllowSelf && context.User.GetSubjectId() == routeId))
         {
             context.Succeed(requirement);
         }

--- a/API/Authorization/OtrClaims.cs
+++ b/API/Authorization/OtrClaims.cs
@@ -31,12 +31,6 @@ public static class OtrClaims
         public const string Client = "client";
 
         /// <summary>
-        /// Role for internal privileged clients
-        /// </summary>
-        /// <example>o!TR processor</example>
-        public const string System = "system";
-
-        /// <summary>
         /// Role for privileged users
         /// </summary>
         public const string Admin = "admin";
@@ -66,7 +60,6 @@ public static class OtrClaims
         [
             User,
             Client,
-            System,
             Admin,
             Verifier,
             Submitter,
@@ -103,7 +96,6 @@ public static class OtrClaims
         /// </remarks>
         public static readonly string[] ClientAssignableRoles =
         [
-            System,
             Whitelist
         ];
 
@@ -168,7 +160,6 @@ public static class OtrClaims
         {
             Roles.User => "Role granted to all users.",
             Roles.Client => "Role granted to all clients.",
-            Roles.System => "Role granted to internal privileged clients.",
             Roles.Admin => "Role granted to privileged users.",
             Roles.Verifier => "Role granted to users with permission to verify submission data.",
             Roles.Submitter => "Role granted to users with permission to submit tournament data.",

--- a/API/Controllers/BeatmapsController.cs
+++ b/API/Controllers/BeatmapsController.cs
@@ -1,7 +1,6 @@
 using API.Authorization;
 using API.DTOs;
 using API.Services.Interfaces;
-using API.Utilities;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -10,7 +9,7 @@ namespace API.Controllers;
 
 [ApiController]
 [ApiVersion(1)]
-[Authorize(Roles = $"{OtrClaims.Roles.System}, {OtrClaims.Roles.Admin}")] // Internal access only at this time
+[Authorize(Roles = OtrClaims.Roles.Admin)] // Internal access only at this time
 [Route("api/v{version:apiVersion}/[controller]")]
 public class BeatmapsController(IBeatmapService beatmapService) : Controller
 {

--- a/API/Controllers/ClientsController.cs
+++ b/API/Controllers/ClientsController.cs
@@ -1,7 +1,6 @@
 using API.Authorization;
 using API.DTOs;
 using API.Services.Interfaces;
-using API.Utilities;
 using Asp.Versioning;
 using Database.Entities;
 using Microsoft.AspNetCore.Authorization;

--- a/API/Controllers/FilteringController.cs
+++ b/API/Controllers/FilteringController.cs
@@ -1,7 +1,6 @@
 using API.Authorization;
 using API.DTOs;
 using API.Services.Interfaces;
-using API.Utilities;
 using API.Utilities.Extensions;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;

--- a/API/Controllers/GameScoresController.cs
+++ b/API/Controllers/GameScoresController.cs
@@ -1,7 +1,6 @@
 using API.Authorization;
 using API.DTOs;
 using API.Services.Interfaces;
-using API.Utilities;
 using API.Utilities.Extensions;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;

--- a/API/Controllers/GamesController.cs
+++ b/API/Controllers/GamesController.cs
@@ -1,7 +1,6 @@
 using API.Authorization;
 using API.DTOs;
 using API.Services.Interfaces;
-using API.Utilities;
 using API.Utilities.Extensions;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;

--- a/API/Controllers/MatchesController.cs
+++ b/API/Controllers/MatchesController.cs
@@ -2,7 +2,6 @@ using System.ComponentModel.DataAnnotations;
 using API.Authorization;
 using API.DTOs;
 using API.Services.Interfaces;
-using API.Utilities;
 using API.Utilities.Extensions;
 using Asp.Versioning;
 using Database.Enums;
@@ -42,7 +41,7 @@ public class MatchesController(IMatchesService matchesService) : Controller
     )
     {
         // Clamp page size for non-admin users
-        if (limit > 5000 && !(User.IsAdmin() || User.IsSystem()))
+        if (limit > 5000 && !User.IsAdmin())
         {
             limit = 5000;
         }
@@ -71,7 +70,7 @@ public class MatchesController(IMatchesService matchesService) : Controller
 
     // TODO: Should be /player/{osuId}/matches instead.
     [HttpGet("player/{osuId:long}")]
-    [Authorize(Roles = $"{OtrClaims.Roles.Admin}, {OtrClaims.Roles.System}")]
+    [Authorize(Roles = OtrClaims.Roles.Admin)]
     public async Task<IActionResult> GetMatchesAsync(long osuId, Ruleset ruleset) =>
         Ok(await matchesService.GetAllForPlayerAsync(osuId, ruleset, DateTime.MinValue, DateTime.MaxValue));
 

--- a/API/Controllers/PlayersController.cs
+++ b/API/Controllers/PlayersController.cs
@@ -14,14 +14,6 @@ namespace API.Controllers;
 [Route("api/v{version:apiVersion}/[controller]")]
 public class PlayersController(IPlayerService playerService) : Controller
 {
-    [HttpGet]
-    [Authorize(Roles = OtrClaims.Roles.System)]
-    public async Task<IActionResult> ListAsync()
-    {
-        IEnumerable<PlayerCompactDTO> players = await playerService.GetAllAsync();
-        return Ok(players);
-    }
-
     [HttpGet("{key}")]
     [Authorize(Roles = $"{OtrClaims.Roles.User}, {OtrClaims.Roles.Client}")]
     [EndpointSummary("Get player info by versatile search")]

--- a/API/Controllers/SearchController.cs
+++ b/API/Controllers/SearchController.cs
@@ -1,7 +1,6 @@
 using API.Authorization;
 using API.DTOs;
 using API.Services.Interfaces;
-using API.Utilities;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/API/Controllers/StatsController.cs
+++ b/API/Controllers/StatsController.cs
@@ -1,7 +1,6 @@
 using API.Authorization;
 using API.DTOs;
 using API.Services.Interfaces;
-using API.Utilities;
 using Asp.Versioning;
 using Database.Enums;
 using Microsoft.AspNetCore.Authorization;

--- a/API/Controllers/TournamentsController.cs
+++ b/API/Controllers/TournamentsController.cs
@@ -69,7 +69,7 @@ public partial class TournamentsController(
         TournamentCreatedResultDTO result = await tournamentsService.CreateAsync(
             tournamentSubmission,
             User.GetSubjectId(),
-            User.IsAdmin() || User.IsSystem()
+            User.IsAdmin()
         );
 
         return CreatedAtAction("Get", new { id = result.Id }, result);

--- a/API/Controllers/UsersController.cs
+++ b/API/Controllers/UsersController.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 using API.Authorization;
 using API.DTOs;
 using API.Services.Interfaces;
-using API.Utilities;
 using API.Utilities.Extensions;
 using Asp.Versioning;
 using Database.Enums;

--- a/API/DTOs/PlayerFilteringResultDTO.cs
+++ b/API/DTOs/PlayerFilteringResultDTO.cs
@@ -30,7 +30,7 @@ public class PlayerFilteringResultDTO
     /// <summary>
     /// The <see cref="FilteringResult"/> in string form
     /// </summary>
-    public string? FilteringResultMessage => FilteringResult.ToString();
+    public string FilteringResultMessage => FilteringResult.ToString();
     /// <summary>
     /// The <see cref="FilteringFailReason"/> in string form
     /// </summary>

--- a/API/Middlewares/WhitelistEnforcementMiddleware.cs
+++ b/API/Middlewares/WhitelistEnforcementMiddleware.cs
@@ -18,7 +18,7 @@ public class WhitelistEnforcementMiddleware(RequestDelegate next, ILogger<Whitel
         }
 
         // Allow whitelisted and privileged requests
-        if (context.User.IsWhitelisted() || context.User.IsAdmin() || context.User.IsSystem())
+        if (context.User.IsWhitelisted() || context.User.IsAdmin())
         {
             await next(context);
             return;

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -328,7 +328,6 @@ builder.Services.AddSwaggerGen(options =>
     {
         [OtrClaims.Roles.User] = OtrClaims.GetDescription(OtrClaims.Roles.User),
         [OtrClaims.Roles.Client] = OtrClaims.GetDescription(OtrClaims.Roles.Client),
-        [OtrClaims.Roles.System] = OtrClaims.GetDescription(OtrClaims.Roles.System),
         [OtrClaims.Roles.Admin] = OtrClaims.GetDescription(OtrClaims.Roles.Admin),
         [OtrClaims.Roles.Verifier] = OtrClaims.GetDescription(OtrClaims.Roles.Verifier),
         [OtrClaims.Roles.Submitter] = OtrClaims.GetDescription(OtrClaims.Roles.Submitter),

--- a/API/Repositories/Implementations/ApiBaseStatsRepository.cs
+++ b/API/Repositories/Implementations/ApiBaseStatsRepository.cs
@@ -61,7 +61,7 @@ public class ApiBaseStatsRepository(
         int? playerId
     )
     {
-        IQueryable<PlayerRating> baseQuery = _context.PlayerRatings.WhereRuleset((Ruleset)ruleset);
+        IQueryable<PlayerRating> baseQuery = _context.PlayerRatings.WhereRuleset(ruleset);
 
         if (chartType == LeaderboardChartType.Country && playerId.HasValue)
         {
@@ -90,7 +90,7 @@ public class ApiBaseStatsRepository(
             return baseQuery;
         }
 
-        baseQuery = FilterByRank((Ruleset)ruleset, baseQuery, filter.MinRank, filter.MaxRank);
+        baseQuery = FilterByRank(ruleset, baseQuery, filter.MinRank, filter.MaxRank);
         baseQuery = FilterByRating(baseQuery, filter.MinRating, filter.MaxRating);
         baseQuery = FilterByMatchesPlayed(baseQuery, filter.MinMatches, filter.MaxMatches);
 

--- a/API/Repositories/Implementations/ApiMatchWinRecordRepository.cs
+++ b/API/Repositories/Implementations/ApiMatchWinRecordRepository.cs
@@ -26,7 +26,7 @@ public class ApiMatchWinRecordRepository(
     {
         List<MatchWinRecord> redTeams = await _context
             .MatchWinRecords.Where(x =>
-                x.Match.Tournament.Ruleset == (Ruleset)ruleset
+                x.Match.Tournament.Ruleset == ruleset
                 && x.Match.StartTime >= dateMin
                 && x.Match.StartTime <= dateMax
                 && x.WinnerRoster.Contains(playerId)
@@ -35,7 +35,7 @@ public class ApiMatchWinRecordRepository(
 
         List<MatchWinRecord> blueTeams = await _context
             .MatchWinRecords.Where(x =>
-                x.Match.Tournament.Ruleset == (Ruleset)ruleset
+                x.Match.Tournament.Ruleset == ruleset
                 && x.Match.StartTime >= dateMin
                 && x.Match.StartTime <= dateMax
                 && x.LoserRoster.Contains(playerId)
@@ -73,7 +73,7 @@ public class ApiMatchWinRecordRepository(
                 || (!x.LoserRoster.Contains(playerId) && x.WinnerRoster.Contains(playerId))
             )
             .Where(x =>
-                x.Match.Tournament.Ruleset == (Ruleset)ruleset
+                x.Match.Tournament.Ruleset == ruleset
                 && x.Match.StartTime >= dateMin
                 && x.Match.StartTime <= dateMax
             )

--- a/API/Repositories/Implementations/ApiPlayerMatchStatsRepository.cs
+++ b/API/Repositories/Implementations/ApiPlayerMatchStatsRepository.cs
@@ -32,7 +32,7 @@ public class ApiPlayerMatchStatsRepository(OtrContext context) : PlayerMatchStat
                 && ms.Game.VerificationStatus == VerificationStatus.Verified
                 && ms.Game.Match.VerificationStatus == VerificationStatus.Verified
                 && ms.Game.WinRecord != null
-                && ms.Game.Match.Tournament.Ruleset == (Ruleset)ruleset
+                && ms.Game.Match.Tournament.Ruleset == ruleset
                 && ms.Game.Match.StartTime >= dateMin
                 && ms.Game.Match.EndTime <= dateMax
             )

--- a/API/Services/Implementations/UserService.cs
+++ b/API/Services/Implementations/UserService.cs
@@ -26,7 +26,7 @@ public class UserService(IUserRepository userRepository, IMatchesRepository matc
 
     public async Task<bool> RejectSubmissionsAsync(int id, int? rejecterUserId)
     {
-        IEnumerable<Match>? submissions = (await userRepository.GetAsync(id))?.SubmittedMatches?.ToList();
+        IEnumerable<Match>? submissions = (await userRepository.GetAsync(id))?.SubmittedMatches.ToList();
         if (submissions is null)
         {
             // Return in the affirmative if the user has no submissions

--- a/API/Utilities/Extensions/ClaimsPrincipalExtensions.cs
+++ b/API/Utilities/Extensions/ClaimsPrincipalExtensions.cs
@@ -13,12 +13,6 @@ public static class ClaimsPrincipalExtensions
         IsInRole(claimsPrincipal, OtrClaims.Roles.Admin);
 
     /// <summary>
-    /// Denotes the principal as having the <see cref="OtrClaims.Roles.System"/> <see cref="OtrClaims.Role"/>
-    /// </summary>
-    public static bool IsSystem(this ClaimsPrincipal claimsPrincipal) =>
-        IsInRole(claimsPrincipal, OtrClaims.Roles.System);
-
-    /// <summary>
     /// Denotes the principal as having the <see cref="OtrClaims.Roles.User"/> <see cref="OtrClaims.Role"/>
     /// </summary>
     public static bool IsUser(this ClaimsPrincipal claimsPrincipal) =>

--- a/DataWorkerService/AutomationChecks/Matches/MatchNameCheck.cs
+++ b/DataWorkerService/AutomationChecks/Matches/MatchNameCheck.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using Database.Enums.Verification;
 using Match = Database.Entities.Match;
 


### PR DESCRIPTION
Removes the `system` client permission from the API. We no longer have a use case for it as the `otr-processor` has direct database access.

Fixes various warnings and removes `/players GET` (list functionality) as there is no longer a use case for it.

Closes #446