### PR TITLE
Modify default rate limit windows

### DIFF
--- a/DataWorkerService/Services/Implementations/PlayersService.cs
+++ b/DataWorkerService/Services/Implementations/PlayersService.cs
@@ -76,7 +76,7 @@ public class PlayersService(
                 player.Country = result.CountryCode;
                 player.Ruleset = result.Ruleset;
 
-                if (player.User is not null && !player.User.Settings.DefaultRulesetIsControlled)
+                if (player.User is not null && player.User.Settings.DefaultRulesetIsControlled)
                 {
                     player.User.Settings.DefaultRuleset = result.Ruleset;
                 }

--- a/DataWorkerService/Services/Implementations/PlayersService.cs
+++ b/DataWorkerService/Services/Implementations/PlayersService.cs
@@ -76,7 +76,7 @@ public class PlayersService(
                 player.Country = result.CountryCode;
                 player.Ruleset = result.Ruleset;
 
-                if (player.User is not null && player.User.Settings.DefaultRulesetIsControlled)
+                if (player.User?.Settings is { DefaultRulesetIsControlled: false })
                 {
                     player.User.Settings.DefaultRuleset = result.Ruleset;
                 }

--- a/OsuApiClient/Net/Authorization/FixedWindowRateLimit.cs
+++ b/OsuApiClient/Net/Authorization/FixedWindowRateLimit.cs
@@ -15,32 +15,17 @@ internal sealed class FixedWindowRateLimit(FetchPlatform platform, int? rateLimi
     /// <summary>
     /// Timespan that represents the lifetime of the bucket
     /// </summary>
-    private TimeSpan Window { get; } = platform switch
-    {
-        FetchPlatform.Osu => TimeSpan.FromSeconds(60),
-        FetchPlatform.OsuTrack => TimeSpan.FromSeconds(120),
-        _ => TimeSpan.FromSeconds(120)
-    };
+    private TimeSpan Window { get; } = TimeSpan.FromSeconds(60);
 
     /// <summary>
     /// Maximum number of tokens available in the bucket
     /// </summary>
-    public int TokenLimit { get; } = rateLimitOverride ?? platform switch
-    {
-        FetchPlatform.Osu => 60,
-        FetchPlatform.OsuTrack => 30,
-        _ => 30
-    };
+    public int TokenLimit { get; } = rateLimitOverride ?? 60;
 
     /// <summary>
     /// Number of tokens remaining in the bucket
     /// </summary>
-    public int RemainingTokens { get; private set; } = rateLimitOverride ?? platform switch
-    {
-        FetchPlatform.Osu => 60,
-        FetchPlatform.OsuTrack => 30,
-        _ => 30
-    };
+    public int RemainingTokens { get; private set; } = rateLimitOverride ?? 60;
 
     /// <summary>
     /// Timespan that represents the time the bucket will expire

--- a/OsuApiClient/Net/Authorization/FixedWindowRateLimit.cs
+++ b/OsuApiClient/Net/Authorization/FixedWindowRateLimit.cs
@@ -1,11 +1,9 @@
-using OsuApiClient.Enums;
-
 namespace OsuApiClient.Net.Authorization;
 
 /// <summary>
 /// Represents a fixed window rate limit
 /// </summary>
-internal sealed class FixedWindowRateLimit(FetchPlatform platform, int? rateLimitOverride)
+internal sealed class FixedWindowRateLimit(int? rateLimitOverride)
 {
     /// <summary>
     /// Timestamp that the window was created

--- a/OsuApiClient/Net/Requests/RequestHandler/DefaultRequestHandler.cs
+++ b/OsuApiClient/Net/Requests/RequestHandler/DefaultRequestHandler.cs
@@ -40,8 +40,8 @@ internal sealed class DefaultRequestHandler(
     private readonly IDictionary<FetchPlatform, FixedWindowRateLimit> _rateLimits =
         new Dictionary<FetchPlatform, FixedWindowRateLimit>
         {
-            [FetchPlatform.Osu] = new(FetchPlatform.Osu, configuration.OsuRateLimit),
-            [FetchPlatform.OsuTrack] = new(FetchPlatform.OsuTrack, configuration.OsuTrackRateLimit)
+            [FetchPlatform.Osu] = new(configuration.OsuRateLimit),
+            [FetchPlatform.OsuTrack] = new(configuration.OsuTrackRateLimit)
         };
 
     private bool _disposed;


### PR DESCRIPTION
- Changes the default rate limit windows for all platforms to a time period of 60 seconds.
- Increases the default rate limit of the osu!track API (30 seconds per 2 minutes is very unrealistic)

Primarily making this change because prod has no way to override the frequency at which tokens reset for different platforms. This allows prod to call the osu!track API every 60 seconds which is necessary.