### PR TITLE
Fix unintended disposal of `HttpClient`

### DIFF
--- a/OsuApiClient/OsuClient.cs
+++ b/OsuApiClient/OsuClient.cs
@@ -45,7 +45,6 @@ public sealed class OsuClient(
         CheckDisposed();
 
         _disposed = true;
-        _handler.Dispose();
     }
 
     public async Task<OsuCredentials?> UpdateCredentialsAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
Closes #486

Removes unintended disposal of `HttpClient` (registered via a singleton, should be reused) which occurs inside of `OsuClient` (a scoped service).