### PR TITLE
Create new `RateLimitOverrides` on `OAuthClient` creation

### DIFF
--- a/API/Services/Implementations/OAuthClientService.cs
+++ b/API/Services/Implementations/OAuthClientService.cs
@@ -22,7 +22,13 @@ public class OAuthClientService(
     public async Task<OAuthClientCreatedDTO> CreateAsync(int userId, params string[] scopes)
     {
         var secret = oAuthClientRepository.GenerateClientSecret();
-        var client = new OAuthClient { Scopes = scopes, Secret = secret, UserId = userId };
+        var client = new OAuthClient
+        {
+            Scopes = scopes,
+            Secret = secret,
+            UserId = userId,
+            RateLimitOverrides = new RateLimitOverrides()
+        };
 
         OAuthClient newClient = await oAuthClientRepository.CreateAsync(client);
 


### PR DESCRIPTION
Without this change, the action `/api/v1/oauth/client` `POST` fails due to the resulting SQL containing a `null` `rate_limit_overrides` item.