### PR TITLE
Include admin notes in GameScoreDTO

### DIFF
--- a/API/DTOs/GameScoreDTO.cs
+++ b/API/DTOs/GameScoreDTO.cs
@@ -8,45 +8,50 @@ public class GameScoreDTO
     /// <summary>
     /// The id of the Player this score belongs to
     /// </summary>
-    public int PlayerId { get; set; }
+    public int PlayerId { get; init; }
 
     /// <summary>
     /// The team the player was on when making this score (red, blue, or none)
     /// </summary>
-    public Team Team { get; set; }
+    public Team Team { get; init; }
 
     /// <summary>
     /// The points earned
     /// </summary>
-    public int Score { get; set; }
+    public int Score { get; init; }
 
     /// <summary>
     /// The mods applied to this score.
     /// </summary>
-    public Mods Mods { get; set; }
+    public Mods Mods { get; init; }
 
     /// <summary>
     /// The number of missed notes
     /// </summary>
-    public int Misses { get; set; }
+    public int Misses { get; init; }
 
     /// <summary>
     /// The current state of verification
     /// </summary>
-    public VerificationStatus VerificationStatus { get; set; }
+    public VerificationStatus VerificationStatus { get; init; }
 
     /// <summary>
     /// The current state of processing
     /// </summary>
-    public ScoreProcessingStatus ProcessingStatus { get; set; }
+    public ScoreProcessingStatus ProcessingStatus { get; init; }
 
     /// <summary>
     /// The rejection reason
     /// </summary>
-    public ScoreRejectionReason RejectionReason { get; set; }
+    public ScoreRejectionReason RejectionReason { get; init; }
 
     /// <summary>
     /// The accuracy of the score
     /// </summary>
-    public double Accuracy { get; set; }
+    public double Accuracy { get; init; }
+
+    /// <summary>
+    /// All associated admin notes
+    /// </summary>
+    public ICollection<AdminNoteDTO> AdminNotes { get; init; } = new List<AdminNoteDTO>();
 }

--- a/Database/Utilities/Extensions/QueryExtensions.cs
+++ b/Database/Utilities/Extensions/QueryExtensions.cs
@@ -113,6 +113,8 @@ public static class QueryExtensions
             .ThenInclude(g => g.Scores)
             .ThenInclude(s => s.Player)
             .Include(m => m.Games)
+            .ThenInclude(s => s.AdminNotes)
+            .Include(m => m.Games)
             .ThenInclude(g => g.Beatmap)
             .Include(m => m.Games)
             .ThenInclude(g => g.WinRecord)


### PR DESCRIPTION
Closes #492

Adds support for including admin notes on all game scores which are included in match / tournament get queries