### PR TITLE
Fix invalid entity field type & fix OAuth issues

### DIFF
--- a/API/Handlers/Implementations/OAuthHandler.cs
+++ b/API/Handlers/Implementations/OAuthHandler.cs
@@ -97,7 +97,7 @@ public class OAuthHandler(
             return new DetailedResponseDTO<AccessCredentialsDTO> { ErrorDetail = "Invalid token" };
         }
 
-        if (claimsPrincipal.GetTokenType() is not OtrClaims.TokenType)
+        if (claimsPrincipal.GetTokenType() is not OtrClaims.TokenTypes.RefreshToken)
         {
             return new DetailedResponseDTO<AccessCredentialsDTO> { ErrorDetail = "Invalid token" };
         }

--- a/API/Middlewares/WhitelistEnforcementMiddleware.cs
+++ b/API/Middlewares/WhitelistEnforcementMiddleware.cs
@@ -24,6 +24,14 @@ public class WhitelistEnforcementMiddleware(RequestDelegate next, ILogger<Whitel
             return;
         }
 
+#if DEBUG
+        if (context.Request.Path.ToString().Contains("swagger"))
+        {
+            await next(context);
+            return;
+        }
+#endif
+
         logger.LogInformation("Rejecting client with identity {id} for whitelist violation", context.User.GetSubjectId());
         context.Response.StatusCode = StatusCodes.Status403Forbidden;
     }

--- a/API/Services/Implementations/JwtService.cs
+++ b/API/Services/Implementations/JwtService.cs
@@ -38,7 +38,7 @@ public class JwtService(
         );
 
     public string GenerateRefreshToken(OAuthClient client) =>
-        GenerateRefreshToken(client.Id.ToString(), OtrClaims.Roles.User);
+        GenerateRefreshToken(client.Id.ToString(), OtrClaims.Roles.Client);
 
     public string GenerateRefreshToken(User user) =>
         GenerateRefreshToken(user.Id.ToString(), OtrClaims.Roles.User);

--- a/Database/Entities/OAuthClient.cs
+++ b/Database/Entities/OAuthClient.cs
@@ -26,7 +26,7 @@ public class OAuthClient : UpdateableEntityBase, IAdminNotableEntity<OAuthClient
     /// A collection of string literals denoting special permissions granted to the client
     /// </summary>
     [Column("scopes")]
-    public ICollection<string> Scopes { get; set; } = new List<string>();
+    public string[] Scopes { get; set; } = [];
 
     // NOTE: Column name and value initialization is handled via OtrContext
     /// <summary>


### PR DESCRIPTION
- Fixes bug with refresh token encoding and decoding
  - A claim was encoded improperly and decoded improperly
- Adds support for viewing swagger while debugging with whitelist enabled
- Converts `ICollection<string>` field to `string[]` to fix SQL serialization bug.
  - Migrations are not needed