### PR TITLE
Tournament deletion functionality

### DIFF
--- a/API.Tests/Services/LeaderboardServiceTests.cs
+++ b/API.Tests/Services/LeaderboardServiceTests.cs
@@ -36,7 +36,7 @@ public class LeaderboardServiceTests
 
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
 
-        var tournamentsService = new TournamentsService(tournamentsRepository.Object, null, null, null, null);
+        var tournamentsService = new TournamentsService(tournamentsRepository.Object, null, null, null);
 
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 

--- a/API.Tests/Services/LeaderboardServiceTests.cs
+++ b/API.Tests/Services/LeaderboardServiceTests.cs
@@ -36,7 +36,7 @@ public class LeaderboardServiceTests
 
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
 
-        var tournamentsService = new TournamentsService(tournamentsRepository.Object, null, null, null);
+        var tournamentsService = new TournamentsService(tournamentsRepository.Object, null, null, null, null);
 
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 

--- a/API/Controllers/TournamentsController.cs
+++ b/API/Controllers/TournamentsController.cs
@@ -186,4 +186,25 @@ public partial class TournamentsController(
 
         return Ok(result.Matches);
     }
+
+    /// <summary>
+    /// Delete a tournament
+    /// </summary>
+    /// <param name="id">Tournament id</param>
+    /// <response code="404">The tournament does not exist</response>
+    /// <response code="204">The tournament was deleted successfully</response>
+    [HttpDelete("{id:int}")]
+    [Authorize(Roles = OtrClaims.Roles.Admin)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> DeleteAsync(int id)
+    {
+        TournamentDTO? result = await tournamentsService.GetAsync(id);
+        if (result is null)
+        {
+            return NotFound();
+        }
+
+        await tournamentsService.DeleteAsync(id);
+        return NoContent();
+    }
 }

--- a/API/Services/Implementations/TournamentsService.cs
+++ b/API/Services/Implementations/TournamentsService.cs
@@ -12,8 +12,9 @@ public class TournamentsService(
     ITournamentsRepository tournamentsRepository,
     IMatchesRepository matchesRepository,
     IBeatmapsRepository beatmapsRepository,
-    IMapper mapper
-) : ITournamentsService
+    IMapper mapper,
+    ILogger<TournamentsService> logger
+    ) : ITournamentsService
 {
     public async Task<TournamentCreatedResultDTO> CreateAsync(
         TournamentSubmissionDTO submission,
@@ -129,5 +130,17 @@ public class TournamentsService(
 
         await tournamentsRepository.UpdateAsync(existing);
         return mapper.Map<TournamentDTO>(existing);
+    }
+
+    public async Task<bool> DeleteAsync(int id)
+    {
+        var rows = await tournamentsRepository.DeleteAsync(id);
+
+        if (rows > 1)
+        {
+            logger.LogWarning("Expected 1 row to be deleted, but {Rows} were deleted", rows);
+        }
+
+        return rows > 0;
     }
 }

--- a/API/Services/Implementations/TournamentsService.cs
+++ b/API/Services/Implementations/TournamentsService.cs
@@ -12,8 +12,7 @@ public class TournamentsService(
     ITournamentsRepository tournamentsRepository,
     IMatchesRepository matchesRepository,
     IBeatmapsRepository beatmapsRepository,
-    IMapper mapper,
-    ILogger<TournamentsService> logger
+    IMapper mapper
     ) : ITournamentsService
 {
     public async Task<TournamentCreatedResultDTO> CreateAsync(
@@ -132,15 +131,5 @@ public class TournamentsService(
         return mapper.Map<TournamentDTO>(existing);
     }
 
-    public async Task<bool> DeleteAsync(int id)
-    {
-        var rows = await tournamentsRepository.DeleteAsync(id);
-
-        if (rows > 1)
-        {
-            logger.LogWarning("Expected 1 row to be deleted, but {Rows} were deleted", rows);
-        }
-
-        return rows > 0;
-    }
+    public async Task DeleteAsync(int id) => await tournamentsRepository.DeleteAsync(id);
 }

--- a/API/Services/Interfaces/ITournamentsService.cs
+++ b/API/Services/Interfaces/ITournamentsService.cs
@@ -74,6 +74,5 @@ public interface ITournamentsService
     /// Deletes a tournament
     /// </summary>
     /// <param name="id">Tournament id</param>
-    /// <returns>True if deleted successfully</returns>
-    Task<bool> DeleteAsync(int id);
+    Task DeleteAsync(int id);
 }

--- a/API/Services/Interfaces/ITournamentsService.cs
+++ b/API/Services/Interfaces/ITournamentsService.cs
@@ -69,4 +69,11 @@ public interface ITournamentsService
     /// Updates a tournament entity with values from a <see cref="TournamentDTO"/>
     /// </summary>
     Task<TournamentDTO?> UpdateAsync(int id, TournamentDTO wrapper);
+
+    /// <summary>
+    /// Deletes a tournament
+    /// </summary>
+    /// <param name="id">Tournament id</param>
+    /// <returns>True if deleted successfully</returns>
+    Task<bool> DeleteAsync(int id);
 }


### PR DESCRIPTION
Part of #482 

- Adds functionality to delete a tournament via `/tournaments/{id}` `DELETE`.
- Endpoint is admin only