### PR TITLE
Fix and improve API rate limiting

### DIFF
--- a/API/Middlewares/RateLimitHeadersMiddleware.cs
+++ b/API/Middlewares/RateLimitHeadersMiddleware.cs
@@ -1,0 +1,44 @@
+using System.Threading.RateLimiting;
+using API.Configurations;
+using API.Utilities.Extensions;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+
+namespace API.Middlewares;
+
+/// <summary>
+/// Middleware that adds rate limit information to the headers of outbound responses
+/// </summary>
+public class RateLimitHeadersMiddleware(
+    RequestDelegate next,
+    IOptions<RateLimiterOptions> rateLimiterOptions,
+    IOptions<RateLimitConfiguration> rateLimiterConfiguration
+)
+{
+    private readonly RateLimitConfiguration _rateLimitConfiguration = rateLimiterConfiguration.Value;
+    private readonly PartitionedRateLimiter<HttpContext> _rateLimiter = rateLimiterOptions.Value.GlobalLimiter!;
+
+    public async Task Invoke(HttpContext context)
+    {
+        if (context.User.Identity is { IsAuthenticated: false })
+        {
+            await next(context);
+            return;
+        }
+
+        RateLimiterStatistics? statistics = _rateLimiter.GetStatistics(context);
+        if (statistics is null)
+        {
+            await next(context);
+            return;
+        }
+
+        context.Response.Headers.Append(
+            "X-RateLimit-Limit",
+            (context.User.GetRateLimitOverrides()?.PermitLimit ?? _rateLimitConfiguration.PermitLimit).ToString()
+        );
+        context.Response.Headers.Append("X-RateLimit-Remaining", statistics.CurrentAvailablePermits.ToString());
+
+        await next(context);
+    }
+}

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -197,7 +197,7 @@ builder.Services.AddRateLimiter(options =>
     {
         PermitLimit = limitOverride ?? rateLimitConfiguration.PermitLimit,
         Window = TimeSpan.FromSeconds(rateLimitConfiguration.Window),
-        QueueLimit = 0,
+        QueueLimit = 0
     };
 });
 
@@ -296,7 +296,7 @@ builder.Services.AddSwaggerGen(options =>
         [OtrClaims.Roles.Admin] = OtrClaims.GetDescription(OtrClaims.Roles.Admin),
         [OtrClaims.Roles.Verifier] = OtrClaims.GetDescription(OtrClaims.Roles.Verifier),
         [OtrClaims.Roles.Submitter] = OtrClaims.GetDescription(OtrClaims.Roles.Submitter),
-        [OtrClaims.Roles.Whitelist] = OtrClaims.GetDescription(OtrClaims.Roles.Whitelist),
+        [OtrClaims.Roles.Whitelist] = OtrClaims.GetDescription(OtrClaims.Roles.Whitelist)
     };
 
     options.AddSecurityDefinition(JwtBearerDefaults.AuthenticationScheme, new OpenApiSecurityScheme


### PR DESCRIPTION
- Updates the rate limiter to use the current claims
- Adds a middleware that adds rate limit information headers to outbound responses
  - Adds a `x-ratelimit-limit` header that populates with the rate limit for the user / client
  - Adds a `x-ratelimit-remaining` header that populates with the number of tokens remaining for the user / client

Funnily enough, I don't think the rate limiter was ever working as intended to begin with? After debugging for a little it seemed like the way we were parsing the claims principal for partitioning (through the `IAuthenticateResultFeature`) was either just not working at all, or incredibly inconsistent. Either way it's good now :D

*I use the royal we as if I wasn't the one who wrote all of this in the first place*