### PR TITLE
Disable Qodana PR comment, add fail threshold of 0

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -20,7 +20,8 @@ jobs:
         with:
           args: --linter,jetbrains/qodana-dotnet:2024.2
           use-caches: true
-          post-pr-comment: true
+          post-pr-comment: false
+          fail-threshold: 0
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN_903418561 }}
           QODANA_ENDPOINT: 'https://qodana.cloud'


### PR DESCRIPTION
Closes 

- Disables the large PR comment from Qodana
- Adds a fail threshold of 0, meaning if there are any issues the workflow will fail.