### PR TITLE
Add `/tournaments/{id}:rerun-auto-checks` `POST`

### DIFF
--- a/API.Tests/Utilities/EnumUtilsTests.cs
+++ b/API.Tests/Utilities/EnumUtilsTests.cs
@@ -1,0 +1,22 @@
+using Database.Enums.Verification;
+using Database.Utilities;
+
+namespace APITests.Utilities;
+
+public class EnumUtilsTests
+{
+    [Theory]
+    [InlineData(VerificationStatus.PreRejected, VerificationStatus.Rejected)]
+    [InlineData(VerificationStatus.PreVerified, VerificationStatus.Verified)]
+    [InlineData(VerificationStatus.Rejected, VerificationStatus.Rejected)]
+    [InlineData(VerificationStatus.Verified, VerificationStatus.Verified)]
+    [InlineData(VerificationStatus.None, VerificationStatus.None)]
+    public void EnumUtils_ConfirmPreStatus_BehavesCorrectly(VerificationStatus current, VerificationStatus expected)
+    {
+        // Act
+        VerificationStatus actual = EnumUtils.ConfirmPreStatus(current);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+}

--- a/API/Controllers/TournamentsController.Admin.cs
+++ b/API/Controllers/TournamentsController.Admin.cs
@@ -10,6 +10,50 @@ namespace API.Controllers;
 public partial class TournamentsController
 {
     /// <summary>
+    /// Marks pre-rejected items as rejected, marks pre-verified
+    /// items as verified. Applies for the tournament and all children.
+    /// </summary>
+    /// <param name="id">Tournament id</param>
+    /// <response code="404">If a tournament matching the given id does not exist</response>
+    /// <response code="200">All items were updated successfully</response>
+    [HttpPost("{id:int}:accept-pre-statuses")]
+    [Authorize(Roles = OtrClaims.Roles.Admin)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> AcceptPreStatusesAsync(int id)
+    {
+        if (!await tournamentsService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        await tournamentsService.AcceptVerificationStatuses(id);
+        return Ok();
+    }
+
+    /// <summary>
+    /// Rerun automation checks for a tournament
+    /// </summary>
+    /// <param name="id">Tournament id</param>
+    /// <param name="force">Whether to overwrite data which has already been Verified or Rejected</param>
+    /// <response code="404">If a tournament matching the given id does not exist</response>
+    /// <response code="200">The entities were updated successfully</response>
+    [HttpPost("{id:int}:accept-pre-statuses")]
+    [Authorize(Roles = OtrClaims.Roles.Admin)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> RerunAutomationChecksAsync(int id, [FromQuery] bool force = false)
+    {
+        if (!await tournamentsService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        await tournamentsService.RerunAutomationChecksAsync(id, force);
+        return Ok();
+    }
+
+    /// <summary>
     /// Creates an admin note for a tournament
     /// </summary>
     /// <param name="id">Tournament id</param>
@@ -18,8 +62,7 @@ public partial class TournamentsController
     /// <response code="400">If the authorized user does not exist</response>
     /// <response code="200">Returns the created admin note</response>
     [HttpPost("{id:int}/notes")]
-    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [Authorize(Roles = OtrClaims.Roles.Admin)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
@@ -43,7 +86,7 @@ public partial class TournamentsController
     /// <response code="404">If a tournament matching the given id does not exist</response>
     /// <response code="200">Returns all admin notes from a tournament</response>
     [HttpGet("{id:int}/notes")]
-    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
+    [Authorize(Roles = OtrClaims.Roles.Admin)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType<IEnumerable<AdminNoteDTO>>(StatusCodes.Status200OK)]
     public async Task<IActionResult> ListAdminNotesAsync(int id)
@@ -69,8 +112,7 @@ public partial class TournamentsController
     /// <response code="403">If the requester did not create the admin note</response>
     /// <response code="200">Returns the updated admin note</response>
     [HttpPatch("{id:int}/notes/{noteId:int}")]
-    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [Authorize(Roles = OtrClaims.Roles.Admin)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]
@@ -107,8 +149,7 @@ public partial class TournamentsController
     /// </response>
     /// <response code="200">Returns the updated admin note</response>
     [HttpDelete("{id:int}/notes/{noteId:int}")]
-    [Authorize(Roles = $"{OtrClaims.Roles.Admin}")]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [Authorize(Roles = OtrClaims.Roles.Admin)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType<AdminNoteDTO>(StatusCodes.Status200OK)]

--- a/API/Controllers/TournamentsController.Admin.cs
+++ b/API/Controllers/TournamentsController.Admin.cs
@@ -38,7 +38,7 @@ public partial class TournamentsController
     /// <param name="force">Whether to overwrite data which has already been Verified or Rejected</param>
     /// <response code="404">If a tournament matching the given id does not exist</response>
     /// <response code="200">The entities were updated successfully</response>
-    [HttpPost("{id:int}:accept-pre-statuses")]
+    [HttpPost("{id:int}:rerun-auto-checks")]
     [Authorize(Roles = OtrClaims.Roles.Admin)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status200OK)]

--- a/API/Services/Implementations/TournamentsService.cs
+++ b/API/Services/Implementations/TournamentsService.cs
@@ -132,4 +132,9 @@ public class TournamentsService(
     }
 
     public async Task DeleteAsync(int id) => await tournamentsRepository.DeleteAsync(id);
+
+    public async Task AcceptVerificationStatuses(int id) => await tournamentsRepository.AcceptVerificationStatuses(id);
+
+    public async Task RerunAutomationChecksAsync(int id, bool force = false) =>
+        await tournamentsRepository.RerunAutomationChecks(id, force);
 }

--- a/API/Services/Interfaces/ITournamentsService.cs
+++ b/API/Services/Interfaces/ITournamentsService.cs
@@ -75,4 +75,20 @@ public interface ITournamentsService
     /// </summary>
     /// <param name="id">Tournament id</param>
     Task DeleteAsync(int id);
+
+    /// <summary>
+    /// If the tournament is pre-rejected or pre-verified, updates the tournament
+    /// to be rejected or verified respectively. This update strategy is applied
+    /// to all child <see cref="Match"/>es, <see cref="Game"/>s, and
+    /// <see cref="GameScore"/>s
+    /// </summary>
+    /// <param name="id">Tournament id</param>
+    Task AcceptVerificationStatuses(int id);
+
+    /// <summary>
+    /// Reruns automation checks for a tournament and all child entities
+    /// </summary>
+    /// <param name="id">Tournament id</param>
+    /// <param name="force">Whether to overwrite fully Verified/Rejected data (dangerous)</param>
+    Task RerunAutomationChecksAsync(int id, bool force = false);
 }

--- a/Database/Repositories/Implementations/TournamentsRepository.cs
+++ b/Database/Repositories/Implementations/TournamentsRepository.cs
@@ -4,6 +4,7 @@ using Database.Entities.Processor;
 using Database.Enums;
 using Database.Enums.Verification;
 using Database.Repositories.Interfaces;
+using Database.Utilities;
 using Database.Utilities.Extensions;
 using Microsoft.EntityFrameworkCore;
 

--- a/Database/Repositories/Interfaces/ITournamentsRepository.cs
+++ b/Database/Repositories/Interfaces/ITournamentsRepository.cs
@@ -57,4 +57,20 @@ public interface ITournamentsRepository : IRepository<Tournament>
     /// <param name="ruleset">An optional ruleset to filter by</param>
     Task<ICollection<Tournament>> GetAsync(int page, int pageSize, TournamentQuerySortType querySortType,
         bool descending = false, bool verified = true, Ruleset? ruleset = null);
+
+    /// <summary>
+    /// If the tournament is pre-rejected or pre-verified, updates the tournament
+    /// to be rejected or verified respectively. This update strategy is applied
+    /// to all child <see cref="Match"/>es, <see cref="Game"/>s, and
+    /// <see cref="GameScore"/>s
+    /// </summary>
+    /// <param name="id">Tournament id</param>
+    Task AcceptVerificationStatuses(int id);
+
+    /// <summary>
+    /// Reruns automation checks for a tournament and all child entities
+    /// </summary>
+    /// <param name="id">Tournament id</param>
+    /// <param name="force">Whether to overwrite fully Verified/Rejected data (dangerous)</param>
+    Task RerunAutomationChecks(int id, bool force = false);
 }

--- a/Database/Utilities/EnumUtils.cs
+++ b/Database/Utilities/EnumUtils.cs
@@ -1,0 +1,23 @@
+using Database.Enums.Verification;
+
+namespace Database.Utilities;
+
+public static class EnumUtils
+{
+    /// <summary>
+    /// Marks a <see cref="VerificationStatus"/> as Rejected if the status is PreRejected
+    /// and Verified if the status is PreVerified
+    /// </summary>
+    /// <param name="status">The 'pre' verification status to confirm</param>
+    /// <returns>
+    /// The confirmed status, or the provided status if
+    /// <see cref="status"/> is not PreRejected or PreVerified
+    /// </returns>
+    public static VerificationStatus ConfirmPreStatus(VerificationStatus status) =>
+        status switch
+        {
+            VerificationStatus.PreRejected => VerificationStatus.Rejected,
+            VerificationStatus.PreVerified => VerificationStatus.Verified,
+            _ => status
+        };
+}


### PR DESCRIPTION
Depends on #521
Part of #482 
Closes #482 

- Implements all of the behavior defined in #482 for the `/tournaments/{id}:rerun-auto-checks` endpoint