### PR TITLE
Add `DiagnosticsController` with `ping` endpoint

### DIFF
--- a/API/Controllers/DiagnosticsController.cs
+++ b/API/Controllers/DiagnosticsController.cs
@@ -1,0 +1,16 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Controllers;
+
+[ApiController]
+[ApiVersion(1)]
+[Route("api/v{version:apiVersion}/[controller]")]
+public class DiagnosticsController : Controller
+{
+    [HttpGet("ping")]
+    [AllowAnonymous]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public Task<IActionResult> PingAsync() => Task.FromResult<IActionResult>(Ok());
+}

--- a/API/Controllers/DiagnosticsController.cs
+++ b/API/Controllers/DiagnosticsController.cs
@@ -9,6 +9,10 @@ namespace API.Controllers;
 [Route("api/v{version:apiVersion}/[controller]")]
 public class DiagnosticsController : Controller
 {
+    /// <summary>
+    /// Allows clients to determine if the server is running  
+    /// </summary>
+    /// <response code="200>The server is running</response> 
     [HttpGet("ping")]
     [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status200OK)]


### PR DESCRIPTION
- Creates a new `DiagnosticsController` with a `/ping` endpoint

Allows us to have a consistent strategy for uptime monitoring