### PR TITLE
Use split query for `GetNeedingProcessingAsync`

### DIFF
--- a/Database/Repositories/Implementations/TournamentsRepository.cs
+++ b/Database/Repositories/Implementations/TournamentsRepository.cs
@@ -12,7 +12,8 @@ namespace Database.Repositories.Implementations;
 [SuppressMessage("Performance",
     "CA1862:Use the \'StringComparison\' method overloads to perform case-insensitive string comparisons")]
 [SuppressMessage("ReSharper", "SpecifyStringComparison")]
-public class TournamentsRepository(OtrContext context, IBeatmapsRepository beatmapsRepository) : RepositoryBase<Tournament>(context), ITournamentsRepository
+public class TournamentsRepository(OtrContext context, IBeatmapsRepository beatmapsRepository)
+    : RepositoryBase<Tournament>(context), ITournamentsRepository
 {
     private readonly OtrContext _context = context;
 
@@ -25,12 +26,20 @@ public class TournamentsRepository(OtrContext context, IBeatmapsRepository beatm
         await _context.Tournaments
             .AsNoTracking()
             .AsSplitQuery()
-            .Include(t => t.Matches.Where(m => m.VerificationStatus == VerificationStatus.Verified && m.ProcessingStatus == MatchProcessingStatus.Done))
-            .ThenInclude(m => m.Games.Where(g => g.VerificationStatus == VerificationStatus.Verified && g.ProcessingStatus == GameProcessingStatus.Done))
+            .Include(t => t.Matches.Where(m =>
+                m.VerificationStatus == VerificationStatus.Verified &&
+                m.ProcessingStatus == MatchProcessingStatus.Done))
+            .ThenInclude(m => m.Games.Where(g =>
+                g.VerificationStatus == VerificationStatus.Verified && g.ProcessingStatus == GameProcessingStatus.Done))
             .ThenInclude(g => g.Beatmap)
-            .Include(t => t.Matches.Where(m => m.VerificationStatus == VerificationStatus.Verified && m.ProcessingStatus == MatchProcessingStatus.Done))
-            .ThenInclude(m => m.Games.Where(g => g.VerificationStatus == VerificationStatus.Verified && g.ProcessingStatus == GameProcessingStatus.Done))
-            .ThenInclude(g => g.Scores.Where(gs => gs.VerificationStatus == VerificationStatus.Verified && gs.ProcessingStatus == ScoreProcessingStatus.Done))
+            .Include(t => t.Matches.Where(m =>
+                m.VerificationStatus == VerificationStatus.Verified &&
+                m.ProcessingStatus == MatchProcessingStatus.Done))
+            .ThenInclude(m => m.Games.Where(g =>
+                g.VerificationStatus == VerificationStatus.Verified && g.ProcessingStatus == GameProcessingStatus.Done))
+            .ThenInclude(g => g.Scores.Where(gs =>
+                gs.VerificationStatus == VerificationStatus.Verified &&
+                gs.ProcessingStatus == ScoreProcessingStatus.Done))
             .ThenInclude(gs => gs.Player)
             .Include(t => t.SubmittedByUser != null ? t.SubmittedByUser.Player : null)
             .Include(t => t.VerifiedByUser != null ? t.VerifiedByUser.Player : null)
@@ -39,7 +48,7 @@ public class TournamentsRepository(OtrContext context, IBeatmapsRepository beatm
 
     public async Task<IEnumerable<Tournament>> GetNeedingProcessingAsync(int limit) =>
         await _context.Tournaments
-            .AsSingleQuery()
+            .AsSplitQuery()
             .Include(t => t.PooledBeatmaps)
             .Include(t => t.PlayerTournamentStats)
             .Include(t => t.Matches)
@@ -58,7 +67,8 @@ public class TournamentsRepository(OtrContext context, IBeatmapsRepository beatm
             .Include(t => t.Matches)
             .ThenInclude(m => m.Games)
             .ThenInclude(g => g.WinRecord)
-            .Where(t => t.ProcessingStatus != TournamentProcessingStatus.Done && t.ProcessingStatus != TournamentProcessingStatus.NeedsApproval)
+            .Where(t => t.ProcessingStatus != TournamentProcessingStatus.Done &&
+                        t.ProcessingStatus != TournamentProcessingStatus.NeedsApproval)
             .OrderBy(t => t.LastProcessingDate)
             .Take(limit)
             .ToListAsync();
@@ -99,8 +109,8 @@ public class TournamentsRepository(OtrContext context, IBeatmapsRepository beatm
         }
 
         return await query
-                .Page(pageSize, page - 1)
-                .ToListAsync();
+            .Page(pageSize, page - 1)
+            .ToListAsync();
     }
 
     public async Task<Tournament?> AcceptPreVerificationStatusesAsync(int id)
@@ -115,6 +125,7 @@ public class TournamentsRepository(OtrContext context, IBeatmapsRepository beatm
         }
 
         #region Confirm "pre" verification statuses
+
         tournament.ConfirmPreVerificationStatus();
         foreach (Match match in tournament.Matches)
         {
@@ -130,6 +141,7 @@ public class TournamentsRepository(OtrContext context, IBeatmapsRepository beatm
                 }
             }
         }
+
         #endregion
 
         await UpdateAsync(tournament);
@@ -173,7 +185,7 @@ public class TournamentsRepository(OtrContext context, IBeatmapsRepository beatm
             return;
         }
 
-        tournament.PooledBeatmaps = new List<Beatmap>();
+        tournament.PooledBeatmaps = [];
         await UpdateAsync(tournament);
     }
 


### PR DESCRIPTION
- Fixes a critical performance issue with `TournamentsRepository.GetNeedingProcessingAsync()`. Single queries must not be used at this level of complexity - the queries are simply too large and will fail to complete.