### PR TITLE
Fix stats & add missing ruleset column to `rating_adjustments` table

### DIFF
--- a/API.Tests/Services/LeaderboardServiceTests.cs
+++ b/API.Tests/Services/LeaderboardServiceTests.cs
@@ -3,7 +3,9 @@ using API.Enums;
 using API.Services.Implementations;
 using API.Utilities;
 using APITests.MockRepositories;
+using AutoMapper;
 using Database.Enums;
+using MapperProfile = OsuApiClient.Configurations.MapperProfile;
 
 namespace APITests.Services;
 
@@ -44,7 +46,8 @@ public class LeaderboardServiceTests
             playerRatingsRepository.Object,
             matchStatsRepository.Object,
             playerRepository.Object,
-            tournamentsService
+            tournamentsService,
+            new Mapper(new MapperConfiguration(configuration => configuration.AddProfile(new MapperProfile())))
         );
 
         _leaderboardService = new LeaderboardService(

--- a/API/DTOs/PlayerRatingChartDataPointDTO.cs
+++ b/API/DTOs/PlayerRatingChartDataPointDTO.cs
@@ -1,3 +1,5 @@
+using Database.Enums;
+
 namespace API.DTOs;
 
 /// <summary>
@@ -6,62 +8,67 @@ namespace API.DTOs;
 public class PlayerRatingChartDataPointDTO
 {
     /// <summary>
-    /// Match name
+    /// Match name, if applicable
     /// </summary>
-    public string Name { get; set; } = string.Empty;
+    public string? Name { get; init; }
 
     /// <summary>
-    /// Match id
+    /// Match id, if applicable
     /// </summary>
-    public int? MatchId { get; set; }
+    public int? MatchId { get; init; }
 
     /// <summary>
-    /// osu! match id
+    /// osu! match id, if applicable
     /// </summary>
-    public long? MatchOsuId { get; set; }
+    public long? MatchOsuId { get; init; }
 
     /// <summary>
-    /// Match cost of the player
+    /// Match cost of the player, if applicable
     /// </summary>
-    public double? MatchCost { get; set; }
+    public double? MatchCost { get; init; }
 
     /// <summary>
-    /// Rating of the player before this match occurred
+    /// Rating of the player before the adjustment
     /// </summary>
-    public double RatingBefore { get; set; }
+    public double RatingBefore { get; init; }
 
     /// <summary>
-    /// Rating of the player after this match occurred
+    /// Rating of the player after the adjustment
     /// </summary>
-    public double RatingAfter { get; set; }
+    public double RatingAfter { get; init; }
 
     /// <summary>
     /// Volatility of the player before this match occurred
     /// </summary>
-    public double VolatilityBefore { get; set; }
+    public double VolatilityBefore { get; init; }
 
     /// <summary>
-    /// Volatility of the player after this match occurred
+    /// Volatility of the player after this adjustment
     /// </summary>
-    public double VolatilityAfter { get; set; }
+    public double VolatilityAfter { get; init; }
 
     /// <summary>
-    /// Difference in rating for the player after this match occurred
+    /// Difference in rating between now and the previous adjustment
     /// </summary>
     public double RatingChange => RatingAfter - RatingBefore;
 
     /// <summary>
-    /// Difference in volatility for the player after this match occurred
+    /// Difference in volatility between now and the previous adjustment
     /// </summary>
     public double VolatilityChange => VolatilityAfter - VolatilityBefore;
 
     /// <summary>
-    /// Indicates whether this data point is from a rating change that occurred outside of a match (i.e. decay)
+    /// Ruleset of the adjustment
     /// </summary>
-    public bool IsAdjustment { get; set; }
+    public Ruleset Ruleset { get; init; }
+
+    /// <summary>
+    /// Adjustment type
+    /// </summary>
+    public RatingAdjustmentType RatingAdjustmentType { get; init; }
 
     /// <summary>
     /// Match start time
     /// </summary>
-    public DateTime? Timestamp { get; set; }
+    public DateTime? Timestamp { get; init; }
 }

--- a/API/Repositories/Implementations/ApiMatchRatingStatsRepository.cs
+++ b/API/Repositories/Implementations/ApiMatchRatingStatsRepository.cs
@@ -3,85 +3,92 @@ using API.Repositories.Interfaces;
 using Database;
 using Database.Enums;
 using Database.Repositories.Implementations;
+using Microsoft.EntityFrameworkCore;
 
 namespace API.Repositories.Implementations;
 
-public class ApiMatchRatingStatsRepository(OtrContext context) : MatchRatingStatsRepository(context), IApiMatchRatingStatsRepository
+public class ApiMatchRatingStatsRepository(OtrContext context)
+    : MatchRatingStatsRepository(context), IApiMatchRatingStatsRepository
 {
-    public Task<PlayerRatingChartDTO> GetRatingChartAsync(
+    private readonly OtrContext _context = context;
+
+    public async Task<PlayerRatingChartDTO> GetRatingChartAsync(
         int playerId,
         Ruleset ruleset,
         DateTime? dateMin = null,
         DateTime? dateMax = null
     )
     {
-        // TODO: Rewrite this
-        // // Default date range to min and max values if not provided
-        // dateMin ??= DateTime.MinValue;
-        // dateMax ??= DateTime.MaxValue;
-        //
-        // // Fetch Match Rating Stats and group by Match.StartTime.Date
-        // var matchRatingStats = await _context
-        //     .MatchRatingStats.Where(mrs =>
-        //         mrs.PlayerId == playerId
-        //         && mrs.Match.Tournament.Ruleset == (Ruleset)ruleset
-        //         && mrs.Match.StartTime >= dateMin
-        //         && mrs.Match.StartTime <= dateMax
-        //     )
-        //     .Select(mrs => new
-        //     {
-        //         mrs.Match.StartTime,
-        //         DataPoint = new PlayerRatingChartDataPointDTO
-        //         {
-        //             Name = mrs.Match.Name ?? "<Unknown>",
-        //             MatchId = mrs.MatchId,
-        //             MatchOsuId = mrs.Match.OsuId,
-        //             // MatchCost = mrs.MatchCost,
-        //             RatingBefore = mrs.RatingBefore,
-        //             RatingAfter = mrs.RatingAfter,
-        //             VolatilityBefore = mrs.VolatilityBefore,
-        //             VolatilityAfter = mrs.VolatilityAfter,
-        //             IsAdjustment = false,
-        //             Timestamp = mrs.Match.StartTime
-        //         }
-        //     })
-        //     .ToListAsync();
-        //
-        // // Assuming RatingAdjustments should be grouped by their own timestamp since they may not have a Match.StartTime
-        // var ratingAdjustments = await _context
-        //     .RatingAdjustments
-        //     .Where(ra =>
-        //         ra.PlayerId == playerId
-        //         && ra.Ruleset == (Ruleset)ruleset
-        //         && ra.Timestamp >= dateMin
-        //         && ra.Timestamp <= dateMax
-        //     )
-        //     .Select(ra => new
-        //     {
-        //         ra.Timestamp, // Use Timestamp for grouping as fallback
-        //         DataPoint = new PlayerRatingChartDataPointDTO
-        //         {
-        //             Name = ra.RatingAdjustmentType == 0 ? "Decay" : "Adjustment",
-        //             RatingBefore = ra.RatingBefore,
-        //             RatingAfter = ra.RatingAfter,
-        //             VolatilityBefore = ra.VolatilityBefore,
-        //             VolatilityAfter = ra.VolatilityAfter,
-        //             IsAdjustment = true,
-        //             Timestamp = ra.Timestamp
-        //         }
-        //     })
-        //     .ToListAsync();
-        //
-        // // Combine data points, converting Match.StartTime and RatingAdjustment.Timestamp to Date for grouping
-        // var combinedDataPoints = matchRatingStats
-        //     .Select(mrs => new { mrs.StartTime.Date, mrs.DataPoint })
-        //     .Concat(ratingAdjustments.Select(ra => new { ra.Timestamp.Date, ra.DataPoint }))
-        //     .GroupBy(x => x.Date)
-        //     .OrderBy(g => g.Key)
-        //     .Select(g => g.Select(x => x.DataPoint).ToList())
-        //     .ToList();
+        // Default date range to min and max values if not provided
+        dateMin ??= DateTime.MinValue;
+        dateMax ??= DateTime.MaxValue;
+
+        // Fetch Match Rating Stats and group by Match.StartTime.Date
+        var adjustments = await _context
+            .RatingAdjustments
+            .Where(ra =>
+                ra.PlayerId == playerId
+                && ra.AdjustmentType == RatingAdjustmentType.Match
+                && ra.Match!.Tournament.Ruleset == ruleset
+                && ra.Timestamp >= dateMin
+                && ra.Timestamp <= dateMax
+            )
+            .Select(ra => new
+            {
+                ra.Timestamp,
+                DataPoint = new PlayerRatingChartDataPointDTO
+                {
+                    Name = ra.Match!.Name ?? "<Unknown>",
+                    MatchId = ra.MatchId,
+                    MatchOsuId = ra.Match.OsuId,
+                    MatchCost = _context.PlayerMatchStats
+                        .Where(pms => pms.PlayerId == ra.PlayerId &&
+                                      pms.MatchId == ra.MatchId)
+                        .Select(pms => pms.MatchCost)
+                        .FirstOrDefault(),
+                    RatingBefore = ra.RatingBefore,
+                    RatingAfter = ra.RatingAfter,
+                    VolatilityBefore = ra.VolatilityBefore,
+                    VolatilityAfter = ra.VolatilityAfter,
+                    IsAdjustment = false,
+                    Timestamp = ra.Match.StartTime
+                }
+            }).ToListAsync();
+
+        var ratingAdjustments = await _context
+            .RatingAdjustments
+            .Where(ra =>
+                ra.PlayerId == playerId
+                && ra.Ruleset == ruleset
+                && ra.Timestamp >= dateMin
+                && ra.Timestamp <= dateMax
+            )
+            .Select(ra => new
+            {
+                ra.Timestamp, // Use Timestamp for grouping as fallback
+                DataPoint = new PlayerRatingChartDataPointDTO
+                {
+                    Name = ra.AdjustmentType == RatingAdjustmentType.Decay ? "Decay" : "Adjustment",
+                    RatingBefore = ra.RatingBefore,
+                    RatingAfter = ra.RatingAfter,
+                    VolatilityBefore = ra.VolatilityBefore,
+                    VolatilityAfter = ra.VolatilityAfter,
+                    IsAdjustment = true,
+                    Timestamp = ra.Timestamp
+                }
+            })
+            .ToListAsync();
+
+        // Combine data points, converting Match.StartTime and RatingAdjustment.Timestamp to Date for grouping
+        var combinedDataPoints = adjustments
+            .Select(mrs => new { mrs.Timestamp.Date, mrs.DataPoint })
+            .Concat(ratingAdjustments.Select(ra => new { ra.Timestamp.Date, ra.DataPoint }))
+            .GroupBy(x => x.Date)
+            .OrderBy(g => g.Key)
+            .Select(g => g.Select(x => x.DataPoint).ToList())
+            .ToList();
 
         // Prepare and return the DTO
-        return Task.FromResult(new PlayerRatingChartDTO { ChartData = new List<List<PlayerRatingChartDataPointDTO>>() });
+        return new PlayerRatingChartDTO { ChartData = combinedDataPoints };
     }
 }

--- a/API/Repositories/Implementations/ApiMatchRatingStatsRepository.cs
+++ b/API/Repositories/Implementations/ApiMatchRatingStatsRepository.cs
@@ -33,7 +33,6 @@ public class ApiMatchRatingStatsRepository(OtrContext context)
                 && ra.Timestamp >= dateMin
                 && ra.Timestamp <= dateMax
             )
-            .OrderBy(ra => ra.Timestamp)
             .Select(ra =>
             new PlayerRatingChartDataPointDTO
             {

--- a/API/Repositories/Implementations/ApiMatchRatingStatsRepository.cs
+++ b/API/Repositories/Implementations/ApiMatchRatingStatsRepository.cs
@@ -37,19 +37,24 @@ public class ApiMatchRatingStatsRepository(OtrContext context)
             .Select(ra =>
             new PlayerRatingChartDataPointDTO
             {
-                Name = string.IsNullOrEmpty(ra.Match.Name) ? "<Unknown>" : ra.Match.Name,
+                Name = ra.Match == null
+                    ? null
+                    : ra.Match.Name,
                 MatchId = ra.MatchId,
-                MatchOsuId = ra.Match.OsuId,
+                MatchOsuId = ra.Match == null
+                    ? null
+                    : ra.Match.OsuId,
                 MatchCost = _context.PlayerMatchStats
-                        .Where(pms => pms.PlayerId == ra.PlayerId &&
-                                      pms.MatchId == ra.MatchId)
-                        .Select(pms => pms.MatchCost)
-                        .FirstOrDefault(),
+                    .Where(pms => pms.PlayerId == ra.PlayerId &&
+                                  pms.MatchId == ra.MatchId)
+                    .Select(pms => pms.MatchCost)
+                    .FirstOrDefault(),
                 RatingBefore = ra.RatingBefore,
                 RatingAfter = ra.RatingAfter,
                 VolatilityBefore = ra.VolatilityBefore,
                 VolatilityAfter = ra.VolatilityAfter,
-                IsAdjustment = true,
+                Ruleset = ra.Ruleset,
+                RatingAdjustmentType = ra.AdjustmentType,
                 Timestamp = ra.Timestamp
             })
             .OrderBy(ra => ra.Timestamp)

--- a/API/Services/Implementations/PlayerRatingsService.cs
+++ b/API/Services/Implementations/PlayerRatingsService.cs
@@ -75,7 +75,7 @@ public class PlayerRatingsService(
             WinRate = winRate,
             TournamentsPlayed = tournamentsPlayed,
             RankProgress = rankProgress,
-            Adjustments = mapper.Map<ICollection<RatingAdjustmentDTO>>(currentStats.Adjustments)
+            Adjustments = mapper.Map<ICollection<RatingAdjustmentDTO>>(currentStats.Adjustments.OrderBy(a => a.Timestamp))
         };
     }
 

--- a/API/Services/Implementations/PlayerRatingsService.cs
+++ b/API/Services/Implementations/PlayerRatingsService.cs
@@ -3,6 +3,7 @@ using API.Enums;
 using API.Repositories.Interfaces;
 using API.Services.Interfaces;
 using API.Utilities;
+using AutoMapper;
 using Database.Entities.Processor;
 using Database.Enums;
 using Database.Repositories.Interfaces;
@@ -13,7 +14,8 @@ public class PlayerRatingsService(
     IApiPlayerRatingsRepository playerRatingsRepository,
     IPlayerMatchStatsRepository matchStatsRepository,
     IPlayersRepository playerRepository,
-    ITournamentsService tournamentsService
+    ITournamentsService tournamentsService,
+    IMapper mapper
 ) : IPlayerRatingsService
 {
     public async Task<IEnumerable<PlayerRatingStatsDTO?>> GetAsync(long osuPlayerId)
@@ -72,7 +74,8 @@ public class PlayerRatingsService(
             Volatility = currentStats.Volatility,
             WinRate = winRate,
             TournamentsPlayed = tournamentsPlayed,
-            RankProgress = rankProgress
+            RankProgress = rankProgress,
+            Adjustments = mapper.Map<ICollection<RatingAdjustmentDTO>>(currentStats.Adjustments)
         };
     }
 

--- a/API/Services/Implementations/PlayerStatsService.cs
+++ b/API/Services/Implementations/PlayerStatsService.cs
@@ -11,7 +11,6 @@ using Database.Repositories.Interfaces;
 namespace API.Services.Implementations;
 
 public class PlayerStatsService(
-    ILogger<PlayerStatsService> logger,
     IPlayerRatingsService playerRatingsService,
     IApiMatchWinRecordRepository matchWinRecordRepository,
     IApiPlayerMatchStatsRepository matchStatsRepository,

--- a/API/Services/Implementations/PlayerStatsService.cs
+++ b/API/Services/Implementations/PlayerStatsService.cs
@@ -173,8 +173,8 @@ public class PlayerStatsService(
         DateTime? dateMax = null)
     {
         return (await ratingStatsRepository.GetForPlayerAsync(playerId, ruleset, dateMin, dateMax))
-            .SelectMany(x => x)
-            .Max(x => x.RatingAfter);
+            .SelectMany(ra => ra)
+            .Max(ra => ra.RatingAfter);
     }
 
     private async Task<PlayerRatingStatsDTO?> GetCurrentAsync(int playerId, Ruleset ruleset)
@@ -261,7 +261,7 @@ public class PlayerStatsService(
         var adjustments =
             (await ratingStatsRepository.GetForPlayerAsync(id, ruleset, dateMin, dateMax))
             .ToList()
-            .SelectMany(x => x)
+            .SelectMany(ra => ra)
             .ToList();
 
         if (matchStats.Count == 0)
@@ -274,7 +274,7 @@ public class PlayerStatsService(
             // TODO: Different way of calcing this
             // AverageMatchCostAggregate = ratingStats.Average(x => x.MatchCost),
             HighestRating = adjustments.Max(x => x.RatingAfter),
-            RatingGained = adjustments.Last().RatingAfter - adjustments.First().RatingAfter,
+            RatingGained = adjustments.Last().RatingAfter - adjustments.FirstOrDefault()?.RatingAfter ?? 0,
             GamesWon = matchStats.Sum(x => x.GamesWon),
             GamesLost = matchStats.Sum(x => x.GamesLost),
             GamesPlayed = matchStats.Sum(x => x.GamesPlayed),

--- a/Database/Entities/Processor/PlayerRating.cs
+++ b/Database/Entities/Processor/PlayerRating.cs
@@ -72,5 +72,5 @@ public class PlayerRating : EntityBase
     /// A collection of <see cref="RatingAdjustment"/>s that represent
     /// the individual changes to the <see cref="PlayerRating"/> over time
     /// </summary>
-    public ICollection<RatingAdjustment> Adjustments { get; init; } = [];
+    public ICollection<RatingAdjustment> Adjustments { get; set; } = [];
 }

--- a/Database/Entities/Processor/RatingAdjustment.cs
+++ b/Database/Entities/Processor/RatingAdjustment.cs
@@ -22,10 +22,16 @@ namespace Database.Entities.Processor;
 public class RatingAdjustment : EntityBase
 {
     /// <summary>
-    /// The <see cref="RatingAdjustmentType"/> of the adjustment
+    /// The <see cref="RatingAdjustmentType"/>
     /// </summary>
     [Column("adjustment_type")]
     public RatingAdjustmentType AdjustmentType { get; init; }
+
+    /// <summary>
+    ///     The <see cref="Ruleset" />
+    /// </summary>
+    [Column("ruleset")]
+    public Ruleset Ruleset { get; set; }
 
     /// <summary>
     /// Timestamp for when the adjustment was applied

--- a/Database/Migrations/20241220080909_RatingAdjustment_AddRuleset.Designer.cs
+++ b/Database/Migrations/20241220080909_RatingAdjustment_AddRuleset.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Database.Migrations
 {
     [DbContext(typeof(OtrContext))]
-    partial class OtrContextModelSnapshot : ModelSnapshot
+    [Migration("20241220080909_RatingAdjustment_AddRuleset")]
+    partial class RatingAdjustment_AddRuleset
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Database/Migrations/20241220080909_RatingAdjustment_AddRuleset.cs
+++ b/Database/Migrations/20241220080909_RatingAdjustment_AddRuleset.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class RatingAdjustment_AddRuleset : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ruleset",
+                table: "rating_adjustments",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ruleset",
+                table: "rating_adjustments");
+        }
+    }
+}

--- a/Database/Repositories/Implementations/MatchRatingStatsRepository.cs
+++ b/Database/Repositories/Implementations/MatchRatingStatsRepository.cs
@@ -14,7 +14,7 @@ public class MatchRatingStatsRepository(OtrContext context)
 {
     private readonly OtrContext _context = context;
 
-    public async Task<IEnumerable<IEnumerable<RatingAdjustment>>> GetForPlayerAsync(
+    public async Task<IEnumerable<RatingAdjustment>> GetForPlayerAsync(
         int playerId,
         Ruleset ruleset,
         DateTime? dateMin = null,
@@ -27,13 +27,11 @@ public class MatchRatingStatsRepository(OtrContext context)
         return await _context.RatingAdjustments
             .Where(ra =>
                 ra.PlayerId == playerId
-                && ra.AdjustmentType == RatingAdjustmentType.Match
                 && ra.Ruleset == ruleset
                 && ra.Timestamp >= dateMin
                 && ra.Timestamp <= dateMax
             )
             .Include(ra => ra.Match!.Tournament)
-            .GroupBy(ra => ra.Timestamp)
             .ToListAsync();
     }
 

--- a/Database/Repositories/Implementations/MatchRatingStatsRepository.cs
+++ b/Database/Repositories/Implementations/MatchRatingStatsRepository.cs
@@ -6,9 +6,11 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Database.Repositories.Implementations;
 
-[SuppressMessage("Performance", "CA1862:Use the \'StringComparison\' method overloads to perform case-insensitive string comparisons")]
+[SuppressMessage("Performance",
+    "CA1862:Use the \'StringComparison\' method overloads to perform case-insensitive string comparisons")]
 [SuppressMessage("ReSharper", "SpecifyStringComparison")]
-public class MatchRatingStatsRepository(OtrContext context) : RepositoryBase<RatingAdjustment>(context), IMatchRatingStatsRepository
+public class MatchRatingStatsRepository(OtrContext context)
+    : RepositoryBase<RatingAdjustment>(context), IMatchRatingStatsRepository
 {
     private readonly OtrContext _context = context;
 
@@ -23,21 +25,17 @@ public class MatchRatingStatsRepository(OtrContext context) : RepositoryBase<Rat
         dateMax ??= DateTime.MaxValue;
 
         return await _context.RatingAdjustments
-            .Where(x =>
-                x.PlayerId == playerId
-                && x.AdjustmentType == RatingAdjustmentType.Match
-                && x.Match!.Tournament.Ruleset == ruleset
-                && x.Match.StartTime >= dateMin
-                && x.Match.StartTime <= dateMax
+            .Where(ra =>
+                ra.PlayerId == playerId
+                && ra.AdjustmentType == RatingAdjustmentType.Match
+                && ra.Ruleset == ruleset
+                && ra.Timestamp >= dateMin
+                && ra.Timestamp <= dateMax
             )
-            .Include(x => x.Match)
-            .ThenInclude(x => x!.Tournament)
-            .GroupBy(x => x.Match!.StartTime.Date)
+            .Include(ra => ra.Match!.Tournament)
+            .GroupBy(ra => ra.Timestamp)
             .ToListAsync();
     }
-
-    public async Task TruncateAsync() =>
-        await _context.Database.ExecuteSqlRawAsync("TRUNCATE TABLE match_rating_stats RESTART IDENTITY");
 
     public async Task<IEnumerable<RatingAdjustment>> TeammateRatingStatsAsync(
         int playerId,

--- a/Database/Repositories/Implementations/PlayerRatingsRepository.cs
+++ b/Database/Repositories/Implementations/PlayerRatingsRepository.cs
@@ -26,26 +26,12 @@ public class PlayerRatingsRepository(OtrContext context, IPlayersRepository play
 
     public async Task<PlayerRating?> GetAsync(int playerId, Ruleset ruleset)
     {
-        var results = await _context.PlayerRatings
+        PlayerRating? result = await _context.PlayerRatings
             .Include(pr => pr.Adjustments)
             .Where(pr => pr.PlayerId == playerId && pr.Ruleset == ruleset)
-            .Select(pr => new
-            {
-                PlayerRating =
-                    pr, // TODO: Should probably include all RatingAdjustments regardless of type and have web not display initial
-                Adjustments = pr.Adjustments.Where(ra => ra.AdjustmentType != RatingAdjustmentType.Initial)
-                    .OrderBy(ra => ra.Timestamp)
-                    .ToList()
-            })
             .FirstOrDefaultAsync();
 
-        if (results is null)
-        {
-            return null;
-        }
-
-        results.PlayerRating.Adjustments = [.. results.Adjustments];
-        return results.PlayerRating;
+        return result;
     }
 
 

--- a/Database/Repositories/Implementations/PlayerRatingsRepository.cs
+++ b/Database/Repositories/Implementations/PlayerRatingsRepository.cs
@@ -24,15 +24,11 @@ public class PlayerRatingsRepository(OtrContext context, IPlayersRepository play
         return await _context.PlayerRatings.Where(x => x.PlayerId == id.Value).ToListAsync();
     }
 
-    public async Task<PlayerRating?> GetAsync(int playerId, Ruleset ruleset)
-    {
-        PlayerRating? result = await _context.PlayerRatings
+    public async Task<PlayerRating?> GetAsync(int playerId, Ruleset ruleset) =>
+        await _context.PlayerRatings
             .Include(pr => pr.Adjustments)
             .Where(pr => pr.PlayerId == playerId && pr.Ruleset == ruleset)
             .FirstOrDefaultAsync();
-
-        return result;
-    }
 
 
     public async Task<int> HighestRankAsync(Ruleset ruleset, string? country = null)

--- a/Database/Repositories/Implementations/PlayersRepository.cs
+++ b/Database/Repositories/Implementations/PlayersRepository.cs
@@ -30,7 +30,8 @@ public class PlayersRepository(OtrContext context) : RepositoryBase<Player>(cont
         if (eagerLoad)
         {
             return await _context
-                .Players.Include(x => x.Scores)
+                .Players
+                .Include(x => x.Scores)
                 .Include(x => x.Ratings)
                 .AsNoTracking()
                 .ToListAsync();

--- a/Database/Repositories/Interfaces/IMatchRatingStatsRepository.cs
+++ b/Database/Repositories/Interfaces/IMatchRatingStatsRepository.cs
@@ -22,8 +22,6 @@ public interface IMatchRatingStatsRepository : IRepository<RatingAdjustment>
         DateTime? dateMax = null
     );
 
-    Task TruncateAsync();
-
     Task<IEnumerable<RatingAdjustment>> TeammateRatingStatsAsync(
         int playerId,
         int teammateId,

--- a/Database/Repositories/Interfaces/IMatchRatingStatsRepository.cs
+++ b/Database/Repositories/Interfaces/IMatchRatingStatsRepository.cs
@@ -15,7 +15,7 @@ public interface IMatchRatingStatsRepository : IRepository<RatingAdjustment>
     /// <param name="dateMin"></param>
     /// <param name="dateMax"></param>
     /// <returns></returns>
-    Task<IEnumerable<IEnumerable<RatingAdjustment>>> GetForPlayerAsync(
+    Task<IEnumerable<RatingAdjustment>> GetForPlayerAsync(
         int playerId,
         Ruleset ruleset,
         DateTime? dateMin = null,


### PR DESCRIPTION
- Adds a `ruleset` column to the `rating_adjustments` table. This is something we missed when first implementing and is required. Without it, it's not possible to know which player's ruleset-specific rating is impacted by a non-match adjustment.
- Reintroduces support for player statistics via `/player/{id}/stats`. This functionality broke during our big rewrite. Although further rewrites are definitely required, this is better than nothing. Web should be updated to point to the data which is returned by this endpoint.