### PR TITLE
Fix duplicate tournament stat entries

### DIFF
--- a/DataWorkerService/Processors/Tournaments/TournamentStatsProcessor.cs
+++ b/DataWorkerService/Processors/Tournaments/TournamentStatsProcessor.cs
@@ -78,6 +78,9 @@ public class TournamentStatsProcessor(
             return;
         }
 
+        // Reference set of ids to prevent duplicate insertions
+        var existingPlayerIds = entity.PlayerTournamentStats.Select(pts => pts.PlayerId).ToHashSet();
+
         // Create a PlayerTournamentStats for each Player
         foreach (Player player in verifiedMatches
                      .SelectMany(m => m.PlayerMatchStats)
@@ -85,6 +88,11 @@ public class TournamentStatsProcessor(
                      .DistinctBy(p => p.Id)
                 )
         {
+            if (existingPlayerIds.Contains(player.Id))
+            {
+                continue;
+            }
+
             IEnumerable<PlayerMatchStats> matchStats = verifiedMatches
                 .SelectMany(m => m.PlayerMatchStats)
                 .Where(pms => pms.Player.Id == player.Id)


### PR DESCRIPTION
When re-running the processor/dataworker flow multiple times, tournament stats will be generated and attempted to be inserted multiple times. This PR adds a check to skip adding new tournament stats if they already exist for the player, for the current tournament.

Depends on:

- [x] #571 

@myssto can you confirm if this is a safe implementation? I think so because tournament stats don't seem to be variable between runs.