### PR TITLE
Skip osu!track fetching if the player has no match stats.

### DIFF
--- a/DataWorkerService/Services/Implementations/PlayersService.cs
+++ b/DataWorkerService/Services/Implementations/PlayersService.cs
@@ -163,6 +163,12 @@ public class PlayersService(
             player.OsuLastFetch
         );
 
+        if (player.MatchStats.Count == 0)
+        {
+            logger.LogDebug("Skipping osu!track update for player, awaiting PlayerMatchStats generation [Id: {Id}].", player.Id);
+            return;
+        }
+
         foreach (Ruleset r in Enum.GetValues<Ruleset>().Where(r => r.IsFetchable()))
         {
             var result = (await osuClient.GetUserStatsHistoryAsync(player.OsuId, r) ?? [])
@@ -173,6 +179,7 @@ public class PlayersService(
                 logger.LogTrace(
                     "Failed to fetch Player osu!track API data. Result has no elements. [Id: {Id} | Ruleset: {Ruleset}]",
                     player.Id, r);
+                continue;
             }
 
             PlayerOsuRulesetData? rulesetData = player.RulesetData.FirstOrDefault(x => x.Ruleset == r);


### PR DESCRIPTION
If the player has no `MatchStats`, it will call the osu!track API and default to the first result (which is incorrect behavior and effectively wastes the API call since we can't guarantee the player's `earliest_known_global_rank` is being set correctly).

This PR will not call the osu!track API if the player has no match stats. This avoids a bug where players will have an invalid `earliest_known_global_rank` value, resulting them in having an invalid starting rating.