### PR TITLE
Add support for `verified` filter on `/matches/{id}`, include `Players` on `MatchDTO`, and other fixes

### DIFF
--- a/API/Configurations/MapperProfile.cs
+++ b/API/Configurations/MapperProfile.cs
@@ -21,7 +21,9 @@ public class MapperProfile : Profile
         CreateMap<GameScore, GameScoreDTO>().ForMember(x => x.Misses, opt => opt.MapFrom(y => y.CountMiss));
 
         CreateMap<Match, MatchDTO>()
-            .ForMember(x => x.Ruleset, opt => opt.MapFrom(x => x.Tournament.Ruleset));
+            .ForMember(x => x.Ruleset, opt => opt.MapFrom(x => x.Tournament.Ruleset))
+            .ForMember(x => x.Players, opt => opt.Ignore());
+
         CreateMap<Match, MatchSubmissionStatusDTO>();
         CreateMap<Match, MatchCreatedResultDTO>()
             .MapAsCreatedResult()

--- a/API/Configurations/MapperProfile.cs
+++ b/API/Configurations/MapperProfile.cs
@@ -38,7 +38,8 @@ public class MapperProfile : Profile
 
         CreateMap<RatingAdjustment, RatingAdjustmentDTO>();
 
-        CreateMap<Player, PlayerCompactDTO>();
+        CreateMap<Player, PlayerCompactDTO>()
+            .ForMember(x => x.UserId, opt => opt.MapFrom(y => y.User!.Id));
         CreateMap<PlayerOsuRulesetData, PlayerOsuRulesetDataDTO>();
 
         CreateMap<Tournament, TournamentCompactDTO>();

--- a/API/Controllers/MatchesController.cs
+++ b/API/Controllers/MatchesController.cs
@@ -30,6 +30,7 @@ public partial class MatchesController(IMatchesService matchesService, IAdminNot
     /// Get a match
     /// </summary>
     /// <param name="id">Match id</param>
+    /// <param name="verified">Whether the match and all child navigations must be verified</param>
     /// <response code="404">A match matching the given id does not exist</response>
     /// <response code="200">Returns a match</response>
     [HttpGet("{id:int}")]

--- a/API/Controllers/MatchesController.cs
+++ b/API/Controllers/MatchesController.cs
@@ -36,9 +36,9 @@ public partial class MatchesController(IMatchesService matchesService, IAdminNot
     [Authorize(Roles = $"{OtrClaims.Roles.User}, {OtrClaims.Roles.Client}")]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType<MatchDTO>(StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetAsync(int id)
+    public async Task<IActionResult> GetAsync(int id, [FromQuery] bool verified = true)
     {
-        MatchDTO? match = await matchesService.GetAsync(id);
+        MatchDTO? match = await matchesService.GetAsync(id, verified);
 
         return match is null
             ? NotFound()
@@ -60,7 +60,7 @@ public partial class MatchesController(IMatchesService matchesService, IAdminNot
     [ProducesResponseType<MatchDTO>(StatusCodes.Status200OK)]
     public async Task<IActionResult> UpdateAsync(int id, [FromBody] JsonPatchDocument<MatchDTO> patch)
     {
-        MatchDTO? match = await matchesService.GetAsync(id);
+        MatchDTO? match = await matchesService.GetAsync(id, false);
         if (match is null)
         {
             return NotFound();
@@ -94,7 +94,7 @@ public partial class MatchesController(IMatchesService matchesService, IAdminNot
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> DeleteAsync(int id)
     {
-        MatchDTO? result = await matchesService.GetAsync(id);
+        MatchDTO? result = await matchesService.GetAsync(id, false);
         if (result is null)
         {
             return NotFound();

--- a/API/DTOs/MatchDTO.cs
+++ b/API/DTOs/MatchDTO.cs
@@ -71,6 +71,11 @@ public class MatchDTO
     public TournamentCompactDTO Tournament { get; set; } = null!;
 
     /// <summary>
+    /// The participating <see cref="Player"/>s
+    /// </summary>
+    public ICollection<PlayerCompactDTO> Players { get; set; } = [];
+
+    /// <summary>
     /// List of games played during the match
     /// </summary>
     [SuppressMessage("ReSharper", "CollectionNeverUpdated.Global")]

--- a/API/Services/Implementations/MatchesService.cs
+++ b/API/Services/Implementations/MatchesService.cs
@@ -99,8 +99,7 @@ public class MatchesService(
     private async Task<ICollection<PlayerCompactDTO>> GetPlayerCompactsAsync(MatchDTO match)
     {
         IEnumerable<int> playerIds = match.Games
-            .Select(x => x.Scores.Select(y => y.PlayerId))
-            .SelectMany(x => x)
+            .SelectMany(g => g.Scores.Select(s => s.PlayerId))
             .Distinct();
 
         ICollection<PlayerCompactDTO>? players = mapper.Map<ICollection<PlayerCompactDTO>>(await playersRepository.GetAsync(playerIds));

--- a/API/Services/Implementations/MatchesService.cs
+++ b/API/Services/Implementations/MatchesService.cs
@@ -104,6 +104,7 @@ public class MatchesService(
             .Distinct();
 
         ICollection<PlayerCompactDTO>? players = mapper.Map<ICollection<PlayerCompactDTO>>(await playersRepository.GetAsync(playerIds));
+
         return players;
     }
 }

--- a/API/Services/Implementations/MatchesService.cs
+++ b/API/Services/Implementations/MatchesService.cs
@@ -34,10 +34,10 @@ public class MatchesService(
         return mapper.Map<IEnumerable<MatchDTO>>(result);
     }
 
-    public async Task<MatchDTO?> GetAsync(int id)
+    public async Task<MatchDTO?> GetAsync(int id, bool verified)
     {
         MatchDTO? match = mapper
-            .Map<MatchDTO?>(await matchesRepository.GetFullAsync(id));
+            .Map<MatchDTO?>(await matchesRepository.GetFullAsync(id, verified));
 
         if (match is null)
         {

--- a/API/Services/Interfaces/IMatchesService.cs
+++ b/API/Services/Interfaces/IMatchesService.cs
@@ -14,7 +14,8 @@ public interface IMatchesService
     /// Gets a match for the given id including all navigation properties.
     /// </summary>
     /// <param name="id">Match id</param>
-    Task<MatchDTO?> GetAsync(int id);
+    /// <param name="verified">Whether the match (and all child navigations) are verified</param>
+    Task<MatchDTO?> GetAsync(int id, bool verified);
 
     Task<IEnumerable<MatchDTO>> GetAllForPlayerAsync(
         long osuPlayerId,

--- a/Database/Migrations/20250106005917_MatchWinRecord_DeleteBehavior_Cascade.Designer.cs
+++ b/Database/Migrations/20250106005917_MatchWinRecord_DeleteBehavior_Cascade.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Database.Migrations
 {
     [DbContext(typeof(OtrContext))]
-    partial class OtrContextModelSnapshot : ModelSnapshot
+    [Migration("20250106005917_MatchWinRecord_DeleteBehavior_Cascade")]
+    partial class MatchWinRecord_DeleteBehavior_Cascade
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Database/Migrations/20250106005917_MatchWinRecord_DeleteBehavior_Cascade.cs
+++ b/Database/Migrations/20250106005917_MatchWinRecord_DeleteBehavior_Cascade.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class MatchWinRecord_DeleteBehavior_Cascade : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_match_win_records_matches_match_id",
+                table: "match_win_records");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_match_win_records_matches_match_id",
+                table: "match_win_records",
+                column: "match_id",
+                principalTable: "matches",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_match_win_records_matches_match_id",
+                table: "match_win_records");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_match_win_records_matches_match_id",
+                table: "match_win_records",
+                column: "match_id",
+                principalTable: "matches",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+        }
+    }
+}

--- a/Database/OtrContext.cs
+++ b/Database/OtrContext.cs
@@ -332,7 +332,7 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .HasOne(m => m.WinRecord)
                 .WithOne(mwr => mwr.Match)
                 .HasForeignKey<MatchWinRecord>(mwr => mwr.MatchId)
-                .OnDelete(DeleteBehavior.SetNull);
+                .OnDelete(DeleteBehavior.Cascade);
 
             // Relation: Games
             entity
@@ -422,7 +422,7 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .HasOne(mwr => mwr.Match)
                 .WithOne(m => m.WinRecord)
                 .HasForeignKey<MatchWinRecord>(mwr => mwr.MatchId)
-                .OnDelete(DeleteBehavior.SetNull);
+                .OnDelete(DeleteBehavior.Cascade);
 
             entity.HasIndex(mwr => mwr.LoserRoster);
             entity.HasIndex(mwr => mwr.WinnerRoster);

--- a/Database/Repositories/Implementations/PlayersRepository.cs
+++ b/Database/Repositories/Implementations/PlayersRepository.cs
@@ -22,6 +22,11 @@ public class PlayersRepository(OtrContext context) : RepositoryBase<Player>(cont
         return (await _context.Players.Where(p => remainingIds.Contains(p.OsuId)).ToListAsync()).Concat(result);
     }
 
+    public new async Task<ICollection<Player>> GetAsync(IEnumerable<int> ids) =>
+        await _context.Players
+            .Include(p => p.User)
+            .Where(p => ids.Contains(p.Id)).ToListAsync();
+
     public async Task<IEnumerable<Player?>> GetAsync(IEnumerable<long> osuIds) =>
         await _context.Players.Where(p => osuIds.Contains(p.OsuId)).ToListAsync();
 

--- a/Database/Repositories/Implementations/PlayersRepository.cs
+++ b/Database/Repositories/Implementations/PlayersRepository.cs
@@ -22,7 +22,7 @@ public class PlayersRepository(OtrContext context) : RepositoryBase<Player>(cont
         return (await _context.Players.Where(p => remainingIds.Contains(p.OsuId)).ToListAsync()).Concat(result);
     }
 
-    public new async Task<ICollection<Player>> GetAsync(IEnumerable<int> ids) =>
+    public override async Task<ICollection<Player>> GetAsync(IEnumerable<int> ids) =>
         await _context.Players
             .Include(p => p.User)
             .Where(p => ids.Contains(p.Id)).ToListAsync();

--- a/Database/Repositories/Implementations/RepositoryBase.cs
+++ b/Database/Repositories/Implementations/RepositoryBase.cs
@@ -43,7 +43,7 @@ public class RepositoryBase<T> : IRepository<T> where T : class, IEntity
 
     public virtual async Task<T?> GetAsync(int id) => await _context.Set<T>().FindAsync(id);
 
-    public async Task<ICollection<T>> GetAsync(IEnumerable<int> ids) =>
+    public virtual async Task<ICollection<T>> GetAsync(IEnumerable<int> ids) =>
         await _context.Set<T>()
             .Where(x => ids.Contains(x.Id))
             .ToListAsync();

--- a/Database/Repositories/Implementations/RepositoryBase.cs
+++ b/Database/Repositories/Implementations/RepositoryBase.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Database.Repositories.Implementations;
 
-public class RepositoryBase<T> : IRepository<T> where T : class
+public class RepositoryBase<T> : IRepository<T> where T : class, IEntity
 {
     private readonly OtrContext _context;
 
@@ -42,6 +42,12 @@ public class RepositoryBase<T> : IRepository<T> where T : class
     }
 
     public virtual async Task<T?> GetAsync(int id) => await _context.Set<T>().FindAsync(id);
+
+    public async Task<ICollection<T>> GetAsync(IEnumerable<int> ids) =>
+        await _context.Set<T>()
+            .Where(x => ids.Contains(x.Id))
+            .ToListAsync();
+
 
     public virtual async Task<int> UpdateAsync(T entity)
     {

--- a/Database/Repositories/Interfaces/IMatchesRepository.cs
+++ b/Database/Repositories/Interfaces/IMatchesRepository.cs
@@ -37,7 +37,8 @@ public interface IMatchesRepository : IRepository<Match>
     /// </summary>
     /// <remarks>The match and included navigations will not be tracked in the context</remarks>
     /// <param name="id">Match id</param>
-    Task<Match?> GetFullAsync(int id);
+    /// <param name="verified">Whether the match (and all child navigations) are verified</param>
+    Task<Match?> GetFullAsync(int id, bool verified);
 
     Task<IEnumerable<Match>> SearchAsync(string name);
 

--- a/Database/Repositories/Interfaces/IPlayersRepository.cs
+++ b/Database/Repositories/Interfaces/IPlayersRepository.cs
@@ -50,6 +50,15 @@ public interface IPlayersRepository : IRepository<Player>
     Task<IEnumerable<Player>> GetAsync(bool eagerLoad = false);
 
     /// <summary>
+    /// Fetch multiple <see cref="Player"/>s by primary key
+    /// </summary>
+    /// <param name="ids">Primary keys</param>
+    /// <returns>
+    /// A collection of <see cref="Player"/>s, one per provided id, if it exists
+    /// </returns>
+    new Task<ICollection<Player>> GetAsync(IEnumerable<int> ids);
+
+    /// <summary>
     /// Returns a collection of players, one per provided osu! id
     /// </summary>
     /// <param name="osuIds">The osu! player ids</param>

--- a/Database/Repositories/Interfaces/IRepository.cs
+++ b/Database/Repositories/Interfaces/IRepository.cs
@@ -46,7 +46,7 @@ public interface IRepository<T> where T : class, IEntity
     /// Fetch multiple entities by primary key
     /// </summary>
     /// <param name="ids">A collection of <see cref="Player"/> ids</param>
-    /// <returns>A collection of <see cref="T"/>, one per id, if it exists</returns>
+    /// <returns>A collection of <typeparamref name="T"/>, one per id, if it exists</returns>
     Task<ICollection<T>> GetAsync(IEnumerable<int> ids);
 
     /// <summary>

--- a/Database/Repositories/Interfaces/IRepository.cs
+++ b/Database/Repositories/Interfaces/IRepository.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Database.Repositories.Interfaces;
 
-public interface IRepository<T> where T : class
+public interface IRepository<T> where T : class, IEntity
 {
     /// <summary>
     /// Exposes a <see cref="LocalView{T}"/> that tracks <typeparamref name="T"/> entities in the context
@@ -41,6 +41,13 @@ public interface IRepository<T> where T : class
     /// </summary>
     /// <returns>The entity, or null if not found.</returns>
     Task<T?> GetAsync(int id);
+
+    /// <summary>
+    /// Fetch multiple entities by primary key
+    /// </summary>
+    /// <param name="ids">A collection of <see cref="Player"/> ids</param>
+    /// <returns>A collection of <see cref="T"/>, one per id, if it exists</returns>
+    Task<ICollection<T>> GetAsync(IEnumerable<int> ids);
 
     /// <summary>
     /// Updates an entity

--- a/Database/Utilities/Extensions/QueryExtensions.cs
+++ b/Database/Utilities/Extensions/QueryExtensions.cs
@@ -237,23 +237,32 @@ public static class QueryExtensions
     /// <see cref="Match.PlayerRatingAdjustments"/>, <see cref="Match.Games"/>
     /// (<see cref="Game.Scores"/>, <see cref="Game.Beatmap"/>, <see cref="Game.WinRecord"/>)
     /// </summary>
-    public static IQueryable<Match> IncludeChildren(this IQueryable<Match> query) =>
-        query
-            .AsQueryable()
+    public static IQueryable<Match> IncludeChildren(this IQueryable<Match> query, bool verified)
+    {
+        if (verified)
+        {
+            query = query.Include(m => m.Games.Where(g => g.VerificationStatus == VerificationStatus.Verified &&
+                                                          g.ProcessingStatus == GameProcessingStatus.Done))
+                .ThenInclude(g => g.Scores.Where(s => s.VerificationStatus == VerificationStatus.Verified &&
+                                                      s.ProcessingStatus == ScoreProcessingStatus.Done));
+        }
+
+
+        return query
+            .Include(m => m.Games)
+            .ThenInclude(g => g.Scores)
             .Include(m => m.WinRecord)
             .Include(m => m.PlayerMatchStats)
             .Include(m => m.PlayerRatingAdjustments)
-            .Include(m => m.Games)
-            .ThenInclude(g => g.Scores)
             .ThenInclude(s => s.Player)
             .Include(m => m.Games)
-            .ThenInclude(s => s.AdminNotes)
+            .ThenInclude(g => g.AdminNotes)
             .Include(m => m.Games)
             .ThenInclude(g => g.Beatmap)
             .Include(m => m.Games)
-            .ThenInclude(g => g.WinRecord)
-            .Include(m => m.Games)
-            .ThenInclude(g => g.AdminNotes);
+            .ThenInclude(g => g.WinRecord);
+    }
+
 
     /// <summary>
     /// Includes the <see cref="Tournament"/> navigation on this <see cref="Match"/>


### PR DESCRIPTION
Part of #575 

- Fixed bug with `DELETE /matches/{id}` - `MatchWinRecord` had a delete behavior of `SetNull`. However, the foreign key `FK_match_win_records_matches_match_id` is required to be non-null.
- Added `bool verified` to `GET /matches/{id}`
- Added supporting changes to allow inclusion of verified children if specified
- Include `PlayerCompactDTO` of `Players` on `MatchDTO`