### PR TITLE
Final DataWorkerService fixes for production release

### DIFF
--- a/DataWorkerService/Processors/Matches/MatchStatsProcessor.cs
+++ b/DataWorkerService/Processors/Matches/MatchStatsProcessor.cs
@@ -66,10 +66,12 @@ public class MatchStatsProcessor(
             return;
         }
 
+        // Ordering here matters, GeneratePlayerMatchStats relies on the game.Match having a populated roster.
+        entity.Rosters = GenerateRosters(verifiedGames);
+
         var currentStats = entity.PlayerMatchStats.ToDictionary(k => k.PlayerId, v => v);
         IEnumerable<PlayerMatchStats> generatedStats = GeneratePlayerMatchStats(verifiedGames, currentStats);
 
-        entity.Rosters = GenerateRosters(verifiedGames);
         entity.PlayerMatchStats = [.. generatedStats];
         entity.ProcessingStatus = MatchProcessingStatus.NeedsRatingProcessorData;
     }

--- a/DataWorkerService/Processors/Tournaments/TournamentStatsProcessor.cs
+++ b/DataWorkerService/Processors/Tournaments/TournamentStatsProcessor.cs
@@ -77,12 +77,15 @@ public class TournamentStatsProcessor(
             return;
         }
 
-        // Create a PlayerTournamentStats for each Player
+        // Create a dictionary to track existing PlayerTournamentStats by PlayerId
+        var playerTournamentStatsDict = entity.PlayerTournamentStats
+            .ToDictionary(pts => pts.PlayerId);
+
+        // Create or update a PlayerTournamentStats for each Player
         foreach (Player player in verifiedMatches
                      .SelectMany(m => m.PlayerMatchStats)
                      .Select(pms => pms.Player)
-                     .DistinctBy(p => p.Id)
-                )
+             .DistinctBy(p => p.Id))
         {
             List<PlayerMatchStats> matchStats = [.. verifiedMatches
                 .SelectMany(m => m.PlayerMatchStats)
@@ -92,25 +95,37 @@ public class TournamentStatsProcessor(
                 .SelectMany(m => m.PlayerRatingAdjustments)
                 .Where(ra => ra.Player.Id == player.Id)];
 
-            entity.PlayerTournamentStats.Add(new PlayerTournamentStats
+            if (playerTournamentStatsDict.TryGetValue(player.Id, out PlayerTournamentStats? existingStats))
             {
-                AverageRatingDelta = matchAdjustments.Average(ra => ra.RatingDelta),
-                AverageMatchCost = matchStats.Average(pms => pms.MatchCost),
-                AverageScore = (int)matchStats.Average(pms => pms.AverageScore),
-                AveragePlacement = matchStats.Average(pms => pms.AveragePlacement),
-                AverageAccuracy = matchStats.Average(pms => pms.AverageAccuracy),
-                MatchesPlayed = matchStats.Count,
-                MatchesWon = matchStats.Count(pms => pms.Won),
-                MatchesLost = matchStats.Count(pms => !pms.Won),
-                GamesPlayed = matchStats.Sum(pms => pms.GamesPlayed),
-                GamesWon = matchStats.Sum(pms => pms.GamesWon),
-                GamesLost = matchStats.Sum(pms => pms.GamesLost),
-                TeammateIds = [.. matchStats.SelectMany(pms => pms.TeammateIds).Distinct()],
-                PlayerId = player.Id,
-                TournamentId = entity.Id
-            });
+                UpdatePlayerTournamentStats(existingStats, matchAdjustments, matchStats);
+            }
+            else
+            {
+                // Add a new PlayerTournamentStats
+                var stats = new PlayerTournamentStats { PlayerId = player.Id, TournamentId = entity.Id };
+                UpdatePlayerTournamentStats(stats, matchAdjustments, matchStats);
+
+                entity.PlayerTournamentStats.Add(stats);
+            }
         }
 
         entity.ProcessingStatus = TournamentProcessingStatus.Done;
+    }
+
+    private static void UpdatePlayerTournamentStats(PlayerTournamentStats existingStats, IEnumerable<RatingAdjustment> matchAdjustments,
+        List<PlayerMatchStats> matchStats)
+    {
+        existingStats.AverageRatingDelta = matchAdjustments.Average(ra => ra.RatingDelta);
+        existingStats.AverageMatchCost = matchStats.Average(pms => pms.MatchCost);
+        existingStats.AverageScore = (int)matchStats.Average(pms => pms.AverageScore);
+        existingStats.AveragePlacement = matchStats.Average(pms => pms.AveragePlacement);
+        existingStats.AverageAccuracy = matchStats.Average(pms => pms.AverageAccuracy);
+        existingStats.MatchesPlayed = matchStats.Count;
+        existingStats.MatchesWon = matchStats.Count(pms => pms.Won);
+        existingStats.MatchesLost = matchStats.Count(pms => !pms.Won);
+        existingStats.GamesPlayed = matchStats.Sum(pms => pms.GamesPlayed);
+        existingStats.GamesWon = matchStats.Sum(pms => pms.GamesWon);
+        existingStats.GamesLost = matchStats.Sum(pms => pms.GamesLost);
+        existingStats.TeammateIds = [.. matchStats.SelectMany(pms => pms.TeammateIds).Distinct()];
     }
 }


### PR DESCRIPTION
Fixes a few bugs which were present in stat generation:

1. No longer attempts to create duplicate PlayerTournamentStats entries.
2. Fixed a bug where MatchRosters were not being generated because the ordering of method calls was incorrect.