### PR TITLE
Add thread safety for external API fetch operations

### DIFF
--- a/DataWorkerService/BackgroundServices/TournamentProcessorService.cs
+++ b/DataWorkerService/BackgroundServices/TournamentProcessorService.cs
@@ -52,7 +52,7 @@ public class TournamentProcessorService(
             scope.ServiceProvider.GetRequiredService<ITournamentProcessorResolver>();
 
         var tournaments = (await tournamentsRepository.GetNeedingProcessingAsync(_config.BatchSize)).ToList();
-        var multiThreadedTasks = new List<Task>();
+        var parallelTasks = new List<Task>();
 
         foreach (Tournament tournament in tournaments)
         {
@@ -70,11 +70,11 @@ public class TournamentProcessorService(
             else
             {
                 // Run in parallel
-                multiThreadedTasks.Add(ProcessAsync(tournament, tournamentProcessorResolver, stoppingToken));
+                parallelTasks.Add(ProcessAsync(tournament, tournamentProcessorResolver, stoppingToken));
             }
         }
 
-        await Task.WhenAll(multiThreadedTasks);
+        await Task.WhenAll(parallelTasks);
         await context.SaveChangesAsync(stoppingToken);
 
         _stopwatch.Stop();


### PR DESCRIPTION
- Adds thread safety to DefaultRequestHandler by using a SemaphoreSlim with a limit of 1 concurrent thread. This prevents the osu! and osu!track APIs from being called by multiple threads simultaneously.
- Tournaments with a ProcessingStatus of NeedsMatchData will now execute one by one instead of concurrently. This operation was never thread safe.