### PR TITLE
Replace semaphore with global mutex

### DIFF
--- a/OsuApiClient/Net/Authorization/FixedWindowRateLimit.cs
+++ b/OsuApiClient/Net/Authorization/FixedWindowRateLimit.cs
@@ -44,6 +44,12 @@ internal sealed class FixedWindowRateLimit(int? rateLimitOverride)
         RemainingTokens = TokenLimit;
     }
 
+    public void ForcefullyCooldown(TimeSpan duration)
+    {
+        Created = DateTimeOffset.Now.Add(duration);
+        RemainingTokens = 0;
+    }
+
     /// <summary>
     /// Subtracts 1 from <see cref="RemainingTokens"/>
     /// </summary>

--- a/OsuApiClient/Net/Authorization/FixedWindowRateLimit.cs
+++ b/OsuApiClient/Net/Authorization/FixedWindowRateLimit.cs
@@ -44,9 +44,8 @@ internal sealed class FixedWindowRateLimit(int? rateLimitOverride)
         RemainingTokens = TokenLimit;
     }
 
-    public void ForcefullyCooldown(TimeSpan duration)
+    public void ClearRemainingTokens()
     {
-        Created = DateTimeOffset.Now.Add(duration);
         RemainingTokens = 0;
     }
 

--- a/OsuApiClient/Net/Requests/RequestHandler/DefaultRequestHandler.cs
+++ b/OsuApiClient/Net/Requests/RequestHandler/DefaultRequestHandler.cs
@@ -22,8 +22,8 @@ internal sealed class DefaultRequestHandler(
     IOsuClientConfiguration configuration
 ) : IRequestHandler
 {
-    private const string GlobalMutexName = "OTR_2b1c2e2f-9c62-4433-9066-dfb7a397d03d";
-    private static readonly Mutex s_mutex = new(true, GlobalMutexName);
+    private const string GlobalMutexName = "Global\OTR_2b1c2e2f-9c62-4433-9066-dfb7a397d03d";
+    private static readonly Mutex s_mutex = new(false, GlobalMutexName);
 
     private readonly HttpClient _httpClient = new()
     {
@@ -99,10 +99,10 @@ internal sealed class DefaultRequestHandler(
     /// Sends a request
     /// </summary>
     /// <remarks>
-    /// Everything inside of this method is controlled by a named <see cref="Mutex"/>.
+    /// Execution of this method is protected by a named <see cref="Mutex"/>.
     /// Each operation must execute on the same thread, therefore asynchronous calls are not possible.
-    /// The Mutex exists to prevent the situation where multiple processes are using the same
-    /// osu! API client and calling multiple requests against it simultaneously.
+    /// The mutex exists to prevent situations where multiple processes utilizing the request handler
+    /// attempt to make network requests at the same time
     /// </remarks>
     /// <param name="request">Request details</param>
     /// <param name="cancellationToken">Cancellation token</param>

--- a/OsuApiClient/Net/Requests/RequestHandler/DefaultRequestHandler.cs
+++ b/OsuApiClient/Net/Requests/RequestHandler/DefaultRequestHandler.cs
@@ -22,7 +22,7 @@ internal sealed class DefaultRequestHandler(
     IOsuClientConfiguration configuration
 ) : IRequestHandler
 {
-    private const string GlobalMutexName = "Global\OTR_2b1c2e2f-9c62-4433-9066-dfb7a397d03d";
+    private const string GlobalMutexName = @"Global\OTR_2b1c2e2f-9c62-4433-9066-dfb7a397d03d";
     private static readonly Mutex s_mutex = new(false, GlobalMutexName);
 
     private readonly HttpClient _httpClient = new()


### PR DESCRIPTION
Adds support for fail-safe rate limiting in the event of a 429 response. This fixes an issue where the client will continue to spam if it thinks it has tokens available when the platform returns 429. Also moves the semaphore to surround the entire request lifecycle rather than just one part of it. This includes the part where rate limits are being respected. My assumption is that previously, some parts of the request lifecycle were thread safe while others weren't.

![image](https://github.com/user-attachments/assets/ab9c2ce8-f3be-4f4c-9653-c1708ccb0e23)
