### PR TITLE
Improve efficiency of leaderboard querying

### DIFF
--- a/DataWorkerService/Processors/Tournaments/TournamentStatsProcessor.cs
+++ b/DataWorkerService/Processors/Tournaments/TournamentStatsProcessor.cs
@@ -126,6 +126,7 @@ public class TournamentStatsProcessor(
         existingStats.GamesPlayed = matchStats.Sum(pms => pms.GamesPlayed);
         existingStats.GamesWon = matchStats.Sum(pms => pms.GamesWon);
         existingStats.GamesLost = matchStats.Sum(pms => pms.GamesLost);
+        existingStats.MatchWinRate = matchStats.Count(pms => pms.Won) / (double)matchStats.Count;
         existingStats.TeammateIds = [.. matchStats.SelectMany(pms => pms.TeammateIds).Distinct()];
     }
 }

--- a/DataWorkerService/Processors/Tournaments/TournamentStatsProcessor.cs
+++ b/DataWorkerService/Processors/Tournaments/TournamentStatsProcessor.cs
@@ -122,11 +122,11 @@ public class TournamentStatsProcessor(
         existingStats.AverageAccuracy = matchStats.Average(pms => pms.AverageAccuracy);
         existingStats.MatchesPlayed = matchStats.Count;
         existingStats.MatchesWon = matchStats.Count(pms => pms.Won);
-        existingStats.MatchesLost = matchStats.Count(pms => !pms.Won);
+        existingStats.MatchesLost = matchStats.Count - existingStats.MatchesWon;
         existingStats.GamesPlayed = matchStats.Sum(pms => pms.GamesPlayed);
         existingStats.GamesWon = matchStats.Sum(pms => pms.GamesWon);
         existingStats.GamesLost = matchStats.Sum(pms => pms.GamesLost);
-        existingStats.MatchWinRate = matchStats.Count(pms => pms.Won) / (double)matchStats.Count;
+        existingStats.MatchWinRate = existingStats.MatchesWon / (double)matchStats.Count;
         existingStats.TeammateIds = [.. matchStats.SelectMany(pms => pms.TeammateIds).Distinct()];
     }
 }

--- a/Database/Entities/PlayerTournamentStats.cs
+++ b/Database/Entities/PlayerTournamentStats.cs
@@ -64,7 +64,7 @@ public class PlayerTournamentStats : EntityBase
     /// <summary>
     /// The win rate across all matches
     /// </summary>
-    public double MatchWinRate => MatchesWon / (double)MatchesPlayed;
+    public double MatchWinRate { get; set; }
 
     /// <summary>
     /// Ids of all <see cref="Entities.Player"/>s that appeared on the <see cref="Player"/>'s team

--- a/Database/Migrations/20250323025900_Efficient_Indexes__PlayerTournamentStats_Add_MatchWinRate.Designer.cs
+++ b/Database/Migrations/20250323025900_Efficient_Indexes__PlayerTournamentStats_Add_MatchWinRate.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Database.Migrations
 {
     [DbContext(typeof(OtrContext))]
-    partial class OtrContextModelSnapshot : ModelSnapshot
+    [Migration("20250323025900_Efficient_Indexes__PlayerTournamentStats_Add_MatchWinRate")]
+    partial class Efficient_Indexes__PlayerTournamentStats_Add_MatchWinRate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Database/Migrations/20250323025900_Efficient_Indexes__PlayerTournamentStats_Add_MatchWinRate.cs
+++ b/Database/Migrations/20250323025900_Efficient_Indexes__PlayerTournamentStats_Add_MatchWinRate.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class Efficient_Indexes__PlayerTournamentStats_Add_MatchWinRate : Migration
+    {
+        private static readonly string[] columns = new[] { "ruleset", "rating" };
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "match_win_rate",
+                table: "player_tournament_stats",
+                type: "double precision",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_players_country",
+                table: "players",
+                column: "country");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_player_ratings_ruleset_rating",
+                table: "player_ratings",
+                columns: columns,
+                descending: new[] { false, true });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_player_osu_ruleset_data_player_id_ruleset_global_rank",
+                table: "player_osu_ruleset_data",
+                columns: new[] { "player_id", "ruleset", "global_rank" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_players_country",
+                table: "players");
+
+            migrationBuilder.DropIndex(
+                name: "ix_player_ratings_ruleset_rating",
+                table: "player_ratings");
+
+            migrationBuilder.DropIndex(
+                name: "ix_player_osu_ruleset_data_player_id_ruleset_global_rank",
+                table: "player_osu_ruleset_data");
+
+            migrationBuilder.DropColumn(
+                name: "match_win_rate",
+                table: "player_tournament_stats");
+        }
+    }
+}

--- a/Database/OtrContext.cs
+++ b/Database/OtrContext.cs
@@ -642,7 +642,8 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .HasForeignKey(rd => rd.PlayerId)
                 .OnDelete(DeleteBehavior.Cascade);
 
-            entity.HasIndex(rd => new { rd.PlayerId, rd.Ruleset }).IsUnique(); entity.HasIndex(rd => new { rd.PlayerId, rd.Ruleset }).IsUnique();
+            entity.HasIndex(rd => new { rd.PlayerId, rd.Ruleset }).IsUnique();
+            entity.HasIndex(rd => new { rd.PlayerId, rd.Ruleset }).IsUnique();
             entity.HasIndex(rd => new { rd.PlayerId, rd.Ruleset, rd.GlobalRank }).IsUnique();
         });
 

--- a/Database/OtrContext.cs
+++ b/Database/OtrContext.cs
@@ -601,6 +601,7 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .OnDelete(DeleteBehavior.Cascade);
 
             entity.HasIndex(x => x.OsuId).IsUnique();
+            entity.HasIndex(p => p.Country);
         });
 
         modelBuilder.Entity<PlayerMatchStats>(entity =>
@@ -641,7 +642,8 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .HasForeignKey(rd => rd.PlayerId)
                 .OnDelete(DeleteBehavior.Cascade);
 
-            entity.HasIndex(rd => new { rd.PlayerId, rd.Ruleset }).IsUnique();
+            entity.HasIndex(rd => new { rd.PlayerId, rd.Ruleset }).IsUnique(); entity.HasIndex(rd => new { rd.PlayerId, rd.Ruleset }).IsUnique();
+            entity.HasIndex(rd => new { rd.PlayerId, rd.Ruleset, rd.GlobalRank }).IsUnique();
         });
 
         modelBuilder.Entity<PlayerTournamentStats>(entity =>
@@ -719,7 +721,8 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
 
             entity.HasIndex(pr => pr.Ruleset);
             entity.HasIndex(pr => pr.PlayerId);
-            entity.HasIndex(pr => pr.Rating).IsDescending(true);
+            entity.HasIndex(pr => pr.Rating).IsDescending(true);         // ruleset, rating
+            entity.HasIndex(pr => new { pr.Ruleset, pr.Rating }).IsDescending(false, true);
             entity.HasIndex(pr => new { pr.PlayerId, pr.Ruleset }).IsUnique();
         });
 

--- a/Database/OtrContext.cs
+++ b/Database/OtrContext.cs
@@ -643,7 +643,6 @@ public class OtrContext(DbContextOptions<OtrContext> options) : DbContext(option
                 .OnDelete(DeleteBehavior.Cascade);
 
             entity.HasIndex(rd => new { rd.PlayerId, rd.Ruleset }).IsUnique();
-            entity.HasIndex(rd => new { rd.PlayerId, rd.Ruleset }).IsUnique();
             entity.HasIndex(rd => new { rd.PlayerId, rd.Ruleset, rd.GlobalRank }).IsUnique();
         });
 

--- a/Database/Repositories/Implementations/PlayerRatingsRepository.cs
+++ b/Database/Repositories/Implementations/PlayerRatingsRepository.cs
@@ -43,6 +43,7 @@ public class PlayerRatingsRepository(OtrContext context)
                 minMatches, maxMatches, minWinRate, maxWinRate, bronze, silver, gold, platinum, emerald, diamond,
                 master,
                 grandmaster, eliteGrandmaster)
+            .OrderByDescending(pr => pr.Rating)
             .Page(page, pageSize)
             .ToListAsync();
     }
@@ -107,7 +108,9 @@ public class PlayerRatingsRepository(OtrContext context)
     )
     {
         IQueryable<PlayerRating> baseQuery = _context.PlayerRatings
+            .AsNoTracking()
             .Include(pr => pr.Player)
+            .AsSplitQuery()
             .WhereRuleset(ruleset)
             // Filter out players who only have the initial adjustment
             .Where(pr => pr.Adjustments.Count > 1);
@@ -119,9 +122,6 @@ public class PlayerRatingsRepository(OtrContext context)
         baseQuery = FilterByWinRate(baseQuery, ruleset, minWinRate, maxWinRate);
         baseQuery = FilterByTier(baseQuery, bronze, silver, gold, platinum, emerald, diamond, master, grandmaster,
             eliteGrandmaster);
-
-        baseQuery = baseQuery
-            .OrderByDescending(pr => pr.Rating);
 
         return baseQuery;
     }
@@ -157,16 +157,14 @@ public class PlayerRatingsRepository(OtrContext context)
         if (minRank.HasValue)
         {
             query = query.Where(x =>
-                x.Player.RulesetData.Any(rd => rd.Ruleset == ruleset)
-                && x.Player.RulesetData.FirstOrDefault(rd => rd.Ruleset == ruleset)!.GlobalRank >= minRank
+                x.Player.RulesetData.FirstOrDefault(rd => rd.Ruleset == ruleset)!.GlobalRank >= minRank
             );
         }
 
         if (maxRank.HasValue)
         {
             query = query.Where(x =>
-                x.Player.RulesetData.Any(rd => rd.Ruleset == ruleset)
-                && x.Player.RulesetData.FirstOrDefault(rd => rd.Ruleset == ruleset)!.GlobalRank <= maxRank
+                x.Player.RulesetData.FirstOrDefault(rd => rd.Ruleset == ruleset)!.GlobalRank <= maxRank
             );
         }
 

--- a/Database/Repositories/Interfaces/IPlayerTournamentStatsRepository.cs
+++ b/Database/Repositories/Interfaces/IPlayerTournamentStatsRepository.cs
@@ -10,8 +10,8 @@ public interface IPlayerTournamentStatsRepository : IRepository<PlayerTournament
     /// </summary>
     /// <param name="playerIds">The ids of the players to fetch stats for</param>
     /// <param name="ruleset">The ruleset to filter the tournament statistics by</param>
-    /// <returns>A Dictionary of <see cref="PlayerTournamentStats"/> with the key equal to the player's id</returns>
-    Task<IDictionary<int, IList<PlayerTournamentStats>>> GetAsync(IEnumerable<int> playerIds, Ruleset ruleset);
+    /// <returns>A dictionary mapping player IDs to their tournament statistics (sum of tournaments, sum of matches, and average match win rate).</returns>
+    Task<IDictionary<int, (int sumTournaments, int sumMatches, double averageMatchWinRate)>> GetLeaderboardStatsAsync(IEnumerable<int> playerIds, Ruleset ruleset);
 
     /// <summary>
     /// Retrieves all tournament statistics for a specific player based on the provided criteria.


### PR DESCRIPTION
- Adds a few indexes to improve the speed of leaderboard-related lookups
- Converts `PlayerTournamentStats.MatchWinRate` from being a computed property to a static one (now handled by the DataWorkerService)
- Slightly improves efficiency of `TournamentStatsProcessor.UpdatePlayerTournamentStats`
- Improves efficiency of `PlayerTournamentStatsRepository.GetAsync` (now named `GetLeaderboardStatsAsync`). Reduces data fetching by projecting necessary fields instead of fetching the entire `PlayerTournamentStats` entity. Adds `.AsNoTracking` to this query as well.
- Improves efficiency of `PlayerRatingsRepository.PageCountAsync` by moving an `OrderBy` operator outside of the query that it's calling.
- Significantly improves the efficiency of `PlayerRatingsRepository.LeaderboardQuery` by removing tracking, splitting the query, and removing unnecessary queries inside of `PlayerRatingsRepository.FilterByRank`

This will require a re-run of stats for all tournaments due to the change in `PlayerTournamentStats`.