### PR TITLE
Fix fatal collection mismatch during roster generation

### DIFF
--- a/DataWorkerService/Utilities/RostersHelper.cs
+++ b/DataWorkerService/Utilities/RostersHelper.cs
@@ -86,7 +86,7 @@ public static class RostersHelper
             }
         }
 
-        MatchRoster[] rosters = [.. eGames
+        List<MatchRoster> rosters = [.. eGames
             .SelectMany(g => g.Rosters)
             .GroupBy(
                 gr => gr.Team,


### PR DESCRIPTION
- `GenerateRosters` now returns a `List<MatchRoster>` instead of `MatchRoster[]`

Apparently you cannot assign a fixed-size collection, such as an array, to a `ICollection<T>`. Assigning variable-sized collections, such as `List<T>`, is required. This change was made due to a production issue in the `DataWorkerService`:

```
[2025-03-24 03:30:04.168 ERR] (Microsoft.EntityFrameworkCore.Update) An exception occurred in the database while saving changes for context type 'Database.OtrContext'.
System.NotSupportedException: Collection was of a fixed size.
at System.SZArrayHelper.Remove[T](T _)
at Microsoft.EntityFrameworkCore.Metadata.Internal.ClrICollectionAccessor`3.RemoveStandalone(Object collection, Object value)
at Microsoft.EntityFrameworkCore.Metadata.Internal.ClrICollectionAccessor`3.Remove(Object entity, Object value)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.RemoveFromCollection(INavigationBase navigationBase, Object value)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.NavigationFixer.RemoveFromCollection(InternalEntityEntry entry, INavigationBase navigation, InternalEntityEntry value)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.NavigationFixer.ResetReferenceOrRemoveCollection(InternalEntityEntry entry, INavigationBase navigation, InternalEntityEntry value, Boolean fromQuery)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.NavigationFixer.DeleteFixup(InternalEntityEntry entry)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.NavigationFixer.StateChanged(InternalEntityEntry entry, EntityState oldState, Boolean fromQuery)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.SetEntityState(EntityState oldState, EntityState newState, Boolean acceptChanges, Boolean modifyProperties)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.SetEntityState(EntityState entityState, Boolean acceptChanges, Boolean modifyProperties, Nullable`1 forceStateWhenUnknownKey, Nullable`1 fallbackState)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.AcceptChanges()
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.AcceptAllChanges(IReadOnlyList`1 changedEntries)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChangesAsync(StateManager stateManager, Boolean acceptAllChangesOnSuccess, CancellationToken cancellationToken)
at Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.NpgsqlExecutionStrategy.ExecuteAsync[TState,TResult](TState state, Func`4 operation, Func`4 verifySucceeded, CancellationToken cancellationToken)
at Microsoft.EntityFrameworkCore.DbContext.SaveChangesAsync(Boolean acceptAllChangesOnSuccess, CancellationToken cancellationToken)
System.NotSupportedException: Collection was of a fixed size.
at System.SZArrayHelper.Remove[T](T _)
at Microsoft.EntityFrameworkCore.Metadata.Internal.ClrICollectionAccessor`3.RemoveStandalone(Object collection, Object value)
at Microsoft.EntityFrameworkCore.Metadata.Internal.ClrICollectionAccessor`3.Remove(Object entity, Object value)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.RemoveFromCollection(INavigationBase navigationBase, Object value)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.NavigationFixer.RemoveFromCollection(InternalEntityEntry entry, INavigationBase navigation, InternalEntityEntry value)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.NavigationFixer.ResetReferenceOrRemoveCollection(InternalEntityEntry entry, INavigationBase navigation, InternalEntityEntry value, Boolean fromQuery)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.NavigationFixer.DeleteFixup(InternalEntityEntry entry)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.NavigationFixer.StateChanged(InternalEntityEntry entry, EntityState oldState, Boolean fromQuery)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.SetEntityState(EntityState oldState, EntityState newState, Boolean acceptChanges, Boolean modifyProperties)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.SetEntityState(EntityState entityState, Boolean acceptChanges, Boolean modifyProperties, Nullable`1 forceStateWhenUnknownKey, Nullable`1 fallbackState)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.AcceptChanges()
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.AcceptAllChanges(IReadOnlyList`1 changedEntries)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChangesAsync(StateManager stateManager, Boolean acceptAllChangesOnSuccess, CancellationToken cancellationToken)
at Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.NpgsqlExecutionStrategy.ExecuteAsync[TState,TResult](TState state, Func`4 operation, Func`4 verifySucceeded, CancellationToken cancellationToken)
at Microsoft.EntityFrameworkCore.DbContext.SaveChangesAsync(Boolean acceptAllChangesOnSuccess, CancellationToken cancellationToken)
[2025-03-24 03:30:04.171 ERR] (Microsoft.Extensions.Hosting.Internal.Host) BackgroundService failed
System.NotSupportedException: Collection was of a fixed size.
at System.SZArrayHelper.Remove[T](T _)
at Microsoft.EntityFrameworkCore.Metadata.Internal.ClrICollectionAccessor`3.RemoveStandalone(Object collection, Object value)
at Microsoft.EntityFrameworkCore.Metadata.Internal.ClrICollectionAccessor`3.Remove(Object entity, Object value)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.RemoveFromCollection(INavigationBase navigationBase, Object value)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.NavigationFixer.RemoveFromCollection(InternalEntityEntry entry, INavigationBase navigation, InternalEntityEntry value)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.NavigationFixer.ResetReferenceOrRemoveCollection(InternalEntityEntry entry, INavigationBase navigation, InternalEntityEntry value, Boolean fromQuery)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.NavigationFixer.DeleteFixup(InternalEntityEntry entry)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.NavigationFixer.StateChanged(InternalEntityEntry entry, EntityState oldState, Boolean fromQuery)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.SetEntityState(EntityState oldState, EntityState newState, Boolean acceptChanges, Boolean modifyProperties)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.SetEntityState(EntityState entityState, Boolean acceptChanges, Boolean modifyProperties, Nullable`1 forceStateWhenUnknownKey, Nullable`1 fallbackState)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.AcceptChanges()
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.AcceptAllChanges(IReadOnlyList`1 changedEntries)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChangesAsync(StateManager stateManager, Boolean acceptAllChangesOnSuccess, CancellationToken cancellationToken)
at Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.NpgsqlExecutionStrategy.ExecuteAsync[TState,TResult](TState state, Func`4 operation, Func`4 verifySucceeded, CancellationToken cancellationToken)
at Microsoft.EntityFrameworkCore.DbContext.SaveChangesAsync(Boolean acceptAllChangesOnSuccess, CancellationToken cancellationToken)
at Microsoft.EntityFrameworkCore.DbContext.SaveChangesAsync(Boolean acceptAllChangesOnSuccess, CancellationToken cancellationToken)
at Database.OtrContext.SaveChangesAsync(CancellationToken cancellationToken) in /src/Database/OtrContext.cs:line 985
at DataWorkerService.BackgroundServices.TournamentProcessorService.DoWork(IServiceScope scope, CancellationToken stoppingToken) in /src/DataWorkerService/BackgroundServices/TournamentProcessorService.cs:line 78
at DataWorkerService.BackgroundServices.ScopeConsumingBackgroundService.OnExecutingAsync(CancellationToken stoppingToken) in /src/DataWorkerService/BackgroundServices/ScopeConsumingBackgroundService.cs:line 44
at DataWorkerService.BackgroundServices.ScopeConsumingBackgroundService.ExecuteAsync(CancellationToken stoppingToken) in /src/DataWorkerService/BackgroundServices/ScopeConsumingBackgroundService.cs:line 28
at DataWorkerService.BackgroundServices.TournamentProcessorService.ExecuteAsync(CancellationToken stoppingToken) in /src/DataWorkerService/BackgroundServices/TournamentProcessorService.cs:line 33
at Microsoft.Extensions.Hosting.Internal.Host.TryExecuteBackgroundServiceAsync(BackgroundService backgroundService)
[2025-03-24 03:30:04.210 INF] (DataWorkerService.Services.Implementations.PlayersService) Updated players with outdated osu!track API data [Count: 0]
[2025-03-24 03:30:04.211 FTL] (Microsoft.Extensions.Hosting.Internal.Host) The HostOptions.BackgroundServiceExceptionBehavior is configured to StopHost. A BackgroundService has thrown an unhandled exception, and the IHost instance is stopping. To avoid this behavior, configure this to Ignore; however the BackgroundService will not be restarted.
System.NotSupportedException: Collection was of a fixed size.
at System.SZArrayHelper.Remove[T](T _)
at Microsoft.EntityFrameworkCore.Metadata.Internal.ClrICollectionAccessor`3.RemoveStandalone(Object collection, Object value)
at Microsoft.EntityFrameworkCore.Metadata.Internal.ClrICollectionAccessor`3.Remove(Object entity, Object value)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.RemoveFromCollection(INavigationBase navigationBase, Object value)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.NavigationFixer.RemoveFromCollection(InternalEntityEntry entry, INavigationBase navigation, InternalEntityEntry value)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.NavigationFixer.ResetReferenceOrRemoveCollection(InternalEntityEntry entry, INavigationBase navigation, InternalEntityEntry value, Boolean fromQuery)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.NavigationFixer.DeleteFixup(InternalEntityEntry entry)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.NavigationFixer.StateChanged(InternalEntityEntry entry, EntityState oldState, Boolean fromQuery)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.SetEntityState(EntityState oldState, EntityState newState, Boolean acceptChanges, Boolean modifyProperties)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.SetEntityState(EntityState entityState, Boolean acceptChanges, Boolean modifyProperties, Nullable`1 forceStateWhenUnknownKey, Nullable`1 fallbackState)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.AcceptChanges()
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.AcceptAllChanges(IReadOnlyList`1 changedEntries)
at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChangesAsync(StateManager stateManager, Boolean acceptAllChangesOnSuccess, CancellationToken cancellationToken)
at Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.NpgsqlExecutionStrategy.ExecuteAsync[TState,TResult](TState state, Func`4 operation, Func`4 verifySucceeded, CancellationToken cancellationToken)
at Microsoft.EntityFrameworkCore.DbContext.SaveChangesAsync(Boolean acceptAllChangesOnSuccess, CancellationToken cancellationToken)
at Microsoft.EntityFrameworkCore.DbContext.SaveChangesAsync(Boolean acceptAllChangesOnSuccess, CancellationToken cancellationToken)
at Database.OtrContext.SaveChangesAsync(CancellationToken cancellationToken) in /src/Database/OtrContext.cs:line 985
at DataWorkerService.BackgroundServices.TournamentProcessorService.DoWork(IServiceScope scope, CancellationToken stoppingToken) in /src/DataWorkerService/BackgroundServices/TournamentProcessorService.cs:line 78
at DataWorkerService.BackgroundServices.ScopeConsumingBackgroundService.OnExecutingAsync(CancellationToken stoppingToken) in /src/DataWorkerService/BackgroundServices/ScopeConsumingBackgroundService.cs:line 44
at DataWorkerService.BackgroundServices.ScopeConsumingBackgroundService.ExecuteAsync(CancellationToken stoppingToken) in /src/DataWorkerService/BackgroundServices/ScopeConsumingBackgroundService.cs:line 28
at DataWorkerService.BackgroundServices.TournamentProcessorService.ExecuteAsync(CancellationToken stoppingToken) in /src/DataWorkerService/BackgroundServices/TournamentProcessorService.cs:line 33
at Microsoft.Extensions.Hosting.Internal.Host.TryExecuteBackgroundServiceAsync(BackgroundService backgroundService)
```

