### PR TITLE
Fix bug in player teammate / opponent fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ postgres_exporter.env
 *.csproj.user
 .vscode/
 
+.aider*

--- a/API/DTOs/LeaderboardRequestQueryDTO.cs
+++ b/API/DTOs/LeaderboardRequestQueryDTO.cs
@@ -1,9 +1,9 @@
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using API.DTOs.Interfaces;
-using Common.Enums;
 using API.Utilities;
 using API.Utilities.DataAnnotations;
+using Common.Enums;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Mvc;
 

--- a/API/Services/Implementations/PlayerStatsService.cs
+++ b/API/Services/Implementations/PlayerStatsService.cs
@@ -169,9 +169,14 @@ public class PlayerStatsService(
             [false] = frequencyOpponents.Count > 0 ? CreatePlayerFrequencyList(frequencyOpponents, players) : []
         };
 
-        if (result[true].Count + result[false].Count != uniquePlayerIds.Count)
+        // Log a warning if some players couldn't be fetched, but don't throw an exception.
+        // The CreatePlayerFrequencyList helper already filters out missing players.
+        var foundPlayerIds = players.Keys.ToHashSet();
+        var missingPlayerIds = uniquePlayerIds.Where(id => !foundPlayerIds.Contains(id)).ToList();
+        if (missingPlayerIds.Count > 0)
         {
-            throw new InvalidOperationException("Mismatch between frequency counts and player data. Some players could not be fetched from the database.");
+            logger.LogWarning("Could not fetch player data for the following IDs involved in frequent matchups for player {PlayerId}: {MissingPlayerIds}",
+                playerId, string.Join(", ", missingPlayerIds));
         }
 
         return result;


### PR DESCRIPTION
Prevents the player stats endpoint from crashing if historical frequent teammate/opponent data includes players who are no longer fetchable. Removed the exception thrown when player counts mismatched. Now logs a warning for any missing players and continues processing with the available data.