### PR TITLE
Fix tier logic in player stats output

### DIFF
--- a/API.Tests/Utilities/RatingUtilsTests.cs
+++ b/API.Tests/Utilities/RatingUtilsTests.cs
@@ -6,37 +6,37 @@ namespace APITests.Utilities;
 public class RatingUtilsTests
 {
     [Theory]
-    [InlineData(RatingConstants.RatingBronzeIII, "Bronze III")]
-    [InlineData(RatingConstants.RatingBronzeII, "Bronze II")]
-    [InlineData(RatingConstants.RatingBronzeI, "Bronze I")]
-    [InlineData(RatingConstants.RatingSilverIII, "Silver III")]
-    [InlineData(RatingConstants.RatingSilverII, "Silver II")]
-    [InlineData(RatingConstants.RatingSilverI, "Silver I")]
-    [InlineData(RatingConstants.RatingGoldIII, "Gold III")]
-    [InlineData(RatingConstants.RatingGoldII, "Gold II")]
-    [InlineData(RatingConstants.RatingGoldI, "Gold I")]
-    [InlineData(RatingConstants.RatingPlatinumIII, "Platinum III")]
-    [InlineData(RatingConstants.RatingPlatinumII, "Platinum II")]
-    [InlineData(RatingConstants.RatingPlatinumI, "Platinum I")]
-    [InlineData(RatingConstants.RatingEmeraldIII, "Emerald III")]
-    [InlineData(RatingConstants.RatingEmeraldII, "Emerald II")]
-    [InlineData(RatingConstants.RatingEmeraldI, "Emerald I")]
-    [InlineData(RatingConstants.RatingDiamondIII, "Diamond III")]
-    [InlineData(RatingConstants.RatingDiamondII, "Diamond II")]
-    [InlineData(RatingConstants.RatingDiamondI, "Diamond I")]
-    [InlineData(RatingConstants.RatingMasterIII, "Master III")]
-    [InlineData(RatingConstants.RatingMasterII, "Master II")]
-    [InlineData(RatingConstants.RatingMasterI, "Master I")]
-    [InlineData(RatingConstants.RatingGrandmasterIII, "Grandmaster III")]
-    [InlineData(RatingConstants.RatingGrandmasterII, "Grandmaster II")]
-    [InlineData(RatingConstants.RatingGrandmasterI, "Grandmaster I")]
+    [InlineData(RatingConstants.RatingBronzeIII, "Bronze")]
+    [InlineData(RatingConstants.RatingBronzeII, "Bronze")]
+    [InlineData(RatingConstants.RatingBronzeI, "Bronze")]
+    [InlineData(RatingConstants.RatingSilverIII, "Silver")]
+    [InlineData(RatingConstants.RatingSilverII, "Silver")]
+    [InlineData(RatingConstants.RatingSilverI, "Silver")]
+    [InlineData(RatingConstants.RatingGoldIII, "Gold")]
+    [InlineData(RatingConstants.RatingGoldII, "Gold")]
+    [InlineData(RatingConstants.RatingGoldI, "Gold")]
+    [InlineData(RatingConstants.RatingPlatinumIII, "Platinum")]
+    [InlineData(RatingConstants.RatingPlatinumII, "Platinum")]
+    [InlineData(RatingConstants.RatingPlatinumI, "Platinum")]
+    [InlineData(RatingConstants.RatingEmeraldIII, "Emerald")]
+    [InlineData(RatingConstants.RatingEmeraldII, "Emerald")]
+    [InlineData(RatingConstants.RatingEmeraldI, "Emerald")]
+    [InlineData(RatingConstants.RatingDiamondIII, "Diamond")]
+    [InlineData(RatingConstants.RatingDiamondII, "Diamond")]
+    [InlineData(RatingConstants.RatingDiamondI, "Diamond")]
+    [InlineData(RatingConstants.RatingMasterIII, "Master")]
+    [InlineData(RatingConstants.RatingMasterII, "Master")]
+    [InlineData(RatingConstants.RatingMasterI, "Master")]
+    [InlineData(RatingConstants.RatingGrandmasterIII, "Grandmaster")]
+    [InlineData(RatingConstants.RatingGrandmasterII, "Grandmaster")]
+    [InlineData(RatingConstants.RatingGrandmasterI, "Grandmaster")]
     [InlineData(RatingConstants.RatingEliteGrandmaster, "Elite Grandmaster")]
     public void GetTier_ReturnsCorrectTier(double rating, string expectedTier)
     {
         // Arrange
 
         // Act
-        var actualTier = RatingUtils.GetTier(rating);
+        var actualTier = RatingUtils.GetMajorTier(rating);
 
         // Assert
         Assert.Equal(expectedTier, actualTier);
@@ -92,41 +92,37 @@ public class RatingUtilsTests
     }
 
     [Theory]
-    [InlineData(RatingConstants.RatingBronzeII)]
-    [InlineData(RatingConstants.RatingBronzeI)]
-    [InlineData(RatingConstants.RatingSilverIII)]
-    [InlineData(RatingConstants.RatingSilverII)]
-    [InlineData(RatingConstants.RatingSilverI)]
-    [InlineData(RatingConstants.RatingGoldIII)]
-    [InlineData(RatingConstants.RatingGoldII)]
-    [InlineData(RatingConstants.RatingGoldI)]
-    [InlineData(RatingConstants.RatingPlatinumIII)]
-    [InlineData(RatingConstants.RatingPlatinumII)]
-    [InlineData(RatingConstants.RatingPlatinumI)]
-    [InlineData(RatingConstants.RatingEmeraldIII)]
-    [InlineData(RatingConstants.RatingEmeraldII)]
-    [InlineData(RatingConstants.RatingEmeraldI)]
-    [InlineData(RatingConstants.RatingDiamondIII)]
-    [InlineData(RatingConstants.RatingDiamondII)]
-    [InlineData(RatingConstants.RatingDiamondI)]
-    [InlineData(RatingConstants.RatingMasterIII)]
-    [InlineData(RatingConstants.RatingMasterII)]
-    [InlineData(RatingConstants.RatingMasterI)]
-    [InlineData(RatingConstants.RatingGrandmasterIII)]
-    [InlineData(RatingConstants.RatingGrandmasterII)]
-    [InlineData(RatingConstants.RatingGrandmasterI)]
-    [InlineData(RatingConstants.RatingEliteGrandmaster)]
-    public void GetNextTier_ReturnsCorrectNextTier(double rating)
+    [InlineData(RatingConstants.RatingBronzeII, 1)]
+    [InlineData(RatingConstants.RatingBronzeI, 3)]
+    [InlineData(RatingConstants.RatingSilverIII, 2)]
+    [InlineData(RatingConstants.RatingSilverII, 1)]
+    [InlineData(RatingConstants.RatingSilverI, 3)]
+    [InlineData(RatingConstants.RatingGoldIII, 2)]
+    [InlineData(RatingConstants.RatingGoldII, 1)]
+    [InlineData(RatingConstants.RatingGoldI, 3)]
+    [InlineData(RatingConstants.RatingPlatinumIII, 2)]
+    [InlineData(RatingConstants.RatingPlatinumII, 1)]
+    [InlineData(RatingConstants.RatingPlatinumI, 3)]
+    [InlineData(RatingConstants.RatingEmeraldIII, 2)]
+    [InlineData(RatingConstants.RatingEmeraldII, 1)]
+    [InlineData(RatingConstants.RatingEmeraldI, 3)]
+    [InlineData(RatingConstants.RatingDiamondIII, 2)]
+    [InlineData(RatingConstants.RatingDiamondII, 1)]
+    [InlineData(RatingConstants.RatingDiamondI, 3)]
+    [InlineData(RatingConstants.RatingMasterIII, 2)]
+    [InlineData(RatingConstants.RatingMasterII, 1)]
+    [InlineData(RatingConstants.RatingMasterI, 3)]
+    [InlineData(RatingConstants.RatingGrandmasterIII, 2)]
+    [InlineData(RatingConstants.RatingGrandmasterII, 1)]
+    [InlineData(RatingConstants.RatingGrandmasterI, null)]
+    [InlineData(RatingConstants.RatingEliteGrandmaster, null)]
+    public void GetNextSubTier_ReturnsCorrectNextSubTier(double rating, int? expectedSubTier)
     {
-        // Arrange
-        var belowRating = rating - 1;
-        var expectedTier = RatingUtils.GetTier(rating);
-
         // Act
-        var actualNextTier = RatingUtils.GetNextTier(belowRating);
+        var actualNextSubTier = RatingUtils.GetNextSubTier(rating);
 
         // Assert
-        Assert.Equal(actualNextTier, expectedTier);
+        Assert.Equal(expectedSubTier, actualNextSubTier);
     }
 
     [Fact]
@@ -136,7 +132,7 @@ public class RatingUtilsTests
         const double aboveEliteGrandmaster = RatingConstants.RatingEliteGrandmaster + 1;
 
         // Act
-        var nextTier = RatingUtils.GetNextTier(aboveEliteGrandmaster);
+        var nextTier = RatingUtils.GetNextMajorTier(aboveEliteGrandmaster);
 
         // Assert
         Assert.Null(nextTier);
@@ -295,7 +291,7 @@ public class RatingUtilsTests
     {
         // Arrange
         var belowRating = rating - 1;
-        var expectedMajorTier = RatingUtils.GetTier(rating);
+        var expectedMajorTier = RatingUtils.GetMajorTier(rating);
 
         // Act
         var nextMajorTier = RatingUtils.GetNextMajorTier(belowRating);
@@ -550,156 +546,5 @@ public class RatingUtilsTests
 
         // Assert
         Assert.False(isProvisional);
-    }
-
-    [Theory]
-    [InlineData("Bronze III", true)]
-    [InlineData("Bronze II", true)]
-    [InlineData("Bronze I", true)]
-    [InlineData("Garbage", false)]
-    [InlineData("Silver III", false)]
-    public void IsBronze_ReturnsCorrectBool(string tier, bool expected)
-    {
-        // Arrange
-
-        // Act
-        var actual = RatingUtils.IsBronze(tier);
-
-        // Assert
-        Assert.Equal(expected, actual);
-    }
-
-    [Theory]
-    [InlineData("Silver III", true)]
-    [InlineData("Silver II", true)]
-    [InlineData("Silver I", true)]
-    [InlineData("Garbage", false)]
-    [InlineData("Gold III", false)]
-    public void IsSilver_ReturnsCorrectBool(string tier, bool expected)
-    {
-        // Arrange
-
-        // Act
-        var actual = RatingUtils.IsSilver(tier);
-
-        // Assert
-        Assert.Equal(expected, actual);
-    }
-
-    [Theory]
-    [InlineData("Gold III", true)]
-    [InlineData("Gold II", true)]
-    [InlineData("Gold I", true)]
-    [InlineData("Garbage", false)]
-    [InlineData("Platinum III", false)]
-    public void IsGold_ReturnsCorrectBool(string tier, bool expected)
-    {
-        // Arrange
-
-        // Act
-        var actual = RatingUtils.IsGold(tier);
-
-        // Assert
-        Assert.Equal(expected, actual);
-    }
-
-    [Theory]
-    [InlineData("Platinum III", true)]
-    [InlineData("Platinum II", true)]
-    [InlineData("Platinum I", true)]
-    [InlineData("Garbage", false)]
-    [InlineData("Emerald III", false)]
-    public void IsPlatinum_ReturnsCorrectBool(string tier, bool expected)
-    {
-        // Arrange
-
-        // Act
-        var actual = RatingUtils.IsPlatinum(tier);
-
-        // Assert
-        Assert.Equal(expected, actual);
-    }
-
-    [Theory]
-    [InlineData("Emerald III", true)]
-    [InlineData("Emerald II", true)]
-    [InlineData("Emerald I", true)]
-    [InlineData("Garbage", false)]
-    [InlineData("Diamond III", false)]
-    public void IsEmerald_ReturnsCorrectBool(string tier, bool expected)
-    {
-        // Arrange
-
-        // Act
-        var actual = RatingUtils.IsEmerald(tier);
-
-        // Assert
-        Assert.Equal(expected, actual);
-    }
-
-    [Theory]
-    [InlineData("Diamond III", true)]
-    [InlineData("Diamond II", true)]
-    [InlineData("Diamond I", true)]
-    [InlineData("Garbage", false)]
-    [InlineData("Master III", false)]
-    public void IsDiamond_ReturnsCorrectBool(string tier, bool expected)
-    {
-        // Arrange
-
-        // Act
-        var actual = RatingUtils.IsDiamond(tier);
-
-        // Assert
-        Assert.Equal(expected, actual);
-    }
-
-    [Theory]
-    [InlineData("Master III", true)]
-    [InlineData("Master II", true)]
-    [InlineData("Master I", true)]
-    [InlineData("Garbage", false)]
-    [InlineData("Grandmaster III", false)]
-    public void IsMaster_ReturnsCorrectBool(string tier, bool expected)
-    {
-        // Arrange
-
-        // Act
-        var actual = RatingUtils.IsMaster(tier);
-
-        // Assert
-        Assert.Equal(expected, actual);
-    }
-
-    [Theory]
-    [InlineData("Grandmaster III", true)]
-    [InlineData("Grandmaster II", true)]
-    [InlineData("Grandmaster I", true)]
-    [InlineData("Garbage", false)]
-    [InlineData("Elite Grandmaster", false)]
-    public void IsGrandmaster_ReturnsCorrectBool(string tier, bool expected)
-    {
-        // Arrange
-
-        // Act
-        var actual = RatingUtils.IsGrandmaster(tier);
-
-        // Assert
-        Assert.Equal(expected, actual);
-    }
-
-    [Theory]
-    [InlineData("Elite Grandmaster", true)]
-    [InlineData("Garbage", false)]
-    [InlineData("Grandmaster III", false)]
-    public void IsEliteGrandmaster_ReturnsCorrectBool(string tier, bool expected)
-    {
-        // Arrange
-
-        // Act
-        var actual = RatingUtils.IsEliteGrandmaster(tier);
-
-        // Assert
-        Assert.Equal(expected, actual);
     }
 }

--- a/API/DTOs/PlayerRatingStatsDTO.cs
+++ b/API/DTOs/PlayerRatingStatsDTO.cs
@@ -32,7 +32,7 @@ public class PlayerRatingStatsDTO : PlayerRatingDTO
     /// <summary>
     /// Rating tier progress information
     /// </summary>
-    public RankProgressDTO RankProgress { get; set; } = new();
+    public required RankProgressDTO RankProgress { get; set; }
 
     /// <summary>
     /// Denotes the current rating as being provisional

--- a/API/DTOs/PlayerRatingStatsDTO.cs
+++ b/API/DTOs/PlayerRatingStatsDTO.cs
@@ -25,11 +25,6 @@ public class PlayerRatingStatsDTO : PlayerRatingDTO
     public double WinRate { get; set; }
 
     /// <summary>
-    /// Current tier
-    /// </summary>
-    public string CurrentTier => RatingUtils.GetMajorTier(Rating);
-
-    /// <summary>
     /// Rating tier progress information
     /// </summary>
     public required RankProgressDTO RankProgress { get; set; }

--- a/API/DTOs/PlayerRatingStatsDTO.cs
+++ b/API/DTOs/PlayerRatingStatsDTO.cs
@@ -27,7 +27,7 @@ public class PlayerRatingStatsDTO : PlayerRatingDTO
     /// <summary>
     /// Current tier
     /// </summary>
-    public string CurrentTier => RatingUtils.GetTier(Rating);
+    public string CurrentTier => RatingUtils.GetMajorTier(Rating);
 
     /// <summary>
     /// Rating tier progress information

--- a/API/DTOs/PlayerRatingStatsDTO.cs
+++ b/API/DTOs/PlayerRatingStatsDTO.cs
@@ -27,7 +27,7 @@ public class PlayerRatingStatsDTO : PlayerRatingDTO
     /// <summary>
     /// Rating tier progress information
     /// </summary>
-    public required RankProgressDTO RankProgress { get; set; }
+    public required TierProgressDTO TierProgress { get; set; }
 
     /// <summary>
     /// Denotes the current rating as being provisional

--- a/API/DTOs/PlayerSearchResultDTO.cs
+++ b/API/DTOs/PlayerSearchResultDTO.cs
@@ -30,7 +30,7 @@ public class PlayerSearchResultDTO
     /// <summary>
     /// Current rating tier of the player for the given ruleset
     /// </summary>
-    public string? RatingTier => Rating.HasValue ? RatingUtils.GetTier(Rating.Value) : null;
+    public string? RatingTier => Rating.HasValue ? RatingUtils.GetMajorTier(Rating.Value) : null;
 
     /// <summary>
     /// osu! username of the player

--- a/API/DTOs/RankProgressDTO.cs
+++ b/API/DTOs/RankProgressDTO.cs
@@ -10,6 +10,11 @@ namespace API.DTOs;
 public class RankProgressDTO(double rating)
 {
     /// <summary>
+    /// Current tier
+    /// </summary>
+    public string CurrentTier { get; set; } = RatingUtils.GetMajorTier(rating);
+
+    /// <summary>
     /// Current sub tier
     /// </summary>
     public int? CurrentSubTier { get; set; } = RatingUtils.GetSubTier(rating);

--- a/API/DTOs/RankProgressDTO.cs
+++ b/API/DTOs/RankProgressDTO.cs
@@ -1,37 +1,41 @@
+using API.Utilities;
+using JetBrains.Annotations;
+
 namespace API.DTOs;
 
 /// <summary>
 /// Represents rating tier progress data
 /// </summary>
-public class RankProgressDTO
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+public class RankProgressDTO(double rating)
 {
     /// <summary>
     /// Current sub tier
     /// </summary>
-    public int? CurrentSubTier { get; set; }
+    public int? CurrentSubTier { get; set; } = RatingUtils.GetSubTier(rating);
 
     /// <summary>
     /// Rating required to reach next sub tier
     /// </summary>
-    public double RatingForNextTier { get; set; }
+    public double RatingForNextTier { get; set; } = RatingUtils.GetNextTierRatingDelta(rating);
 
     /// <summary>
     /// Rating required to reach next major tier
     /// </summary>
-    public double RatingForNextMajorTier { get; set; }
+    public double RatingForNextMajorTier { get; set; } = RatingUtils.GetNextMajorTierRatingDelta(rating);
 
     /// <summary>
     /// Next major tier following current tier
     /// </summary>
-    public string? NextMajorTier { get; set; }
+    public string? NextMajorTier { get; set; } = RatingUtils.GetNextMajorTier(rating);
 
     /// <summary>
     /// Progress to the next sub tier as a percentage
     /// </summary>
-    public double? SubTierFillPercentage { get; set; }
+    public double? SubTierFillPercentage { get; set; } = RatingUtils.GetNextTierFillPercentage(rating);
 
     /// <summary>
     /// Progress to the next major tier as a percentage
     /// </summary>
-    public double? MajorTierFillPercentage { get; set; }
+    public double? MajorTierFillPercentage { get; set; } = RatingUtils.GetNextMajorTierFillPercentage(rating);
 }

--- a/API/DTOs/RankProgressDTO.cs
+++ b/API/DTOs/RankProgressDTO.cs
@@ -6,11 +6,6 @@ namespace API.DTOs;
 public class RankProgressDTO
 {
     /// <summary>
-    /// Current tier
-    /// </summary>
-    public string CurrentTier { get; set; } = null!;
-
-    /// <summary>
     /// Current sub tier
     /// </summary>
     public int? CurrentSubTier { get; set; }

--- a/API/DTOs/TierProgressDTO.cs
+++ b/API/DTOs/TierProgressDTO.cs
@@ -7,7 +7,7 @@ namespace API.DTOs;
 /// Represents rating tier progress data
 /// </summary>
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public class RankProgressDTO(double rating)
+public class TierProgressDTO(double rating)
 {
     /// <summary>
     /// Current tier

--- a/API/Services/Implementations/PlayerRatingsService.cs
+++ b/API/Services/Implementations/PlayerRatingsService.cs
@@ -29,7 +29,6 @@ public class PlayerRatingsService(
         var tournamentsPlayed = await tournamentsService.CountPlayedAsync(playerId, ruleset);
         var rankProgress = new RankProgressDTO
         {
-            CurrentTier = RatingUtils.GetTier(currentStats.Rating),
             CurrentSubTier = RatingUtils.GetSubTier(currentStats.Rating),
             RatingForNextTier = RatingUtils.GetNextTierRatingDelta(currentStats.Rating),
             RatingForNextMajorTier = RatingUtils.GetNextMajorTierRatingDelta(currentStats.Rating),

--- a/API/Services/Implementations/PlayerRatingsService.cs
+++ b/API/Services/Implementations/PlayerRatingsService.cs
@@ -27,7 +27,7 @@ public class PlayerRatingsService(
         var matchesPlayed = await matchStatsRepository.CountMatchesPlayedAsync(playerId, ruleset);
         var winRate = await matchStatsRepository.GlobalWinrateAsync(playerId, ruleset);
         var tournamentsPlayed = await tournamentsService.CountPlayedAsync(playerId, ruleset);
-        var rankProgress = new RankProgressDTO(currentStats.Rating);
+        var tierProgress = new TierProgressDTO(currentStats.Rating);
 
         return new PlayerRatingStatsDTO
         {
@@ -41,7 +41,7 @@ public class PlayerRatingsService(
             Volatility = currentStats.Volatility,
             WinRate = winRate,
             TournamentsPlayed = tournamentsPlayed,
-            RankProgress = rankProgress,
+            TierProgress = tierProgress,
             Adjustments = mapper.Map<ICollection<RatingAdjustmentDTO>>(currentStats.Adjustments.OrderBy(a => a.Timestamp))
         };
     }

--- a/API/Services/Implementations/PlayerRatingsService.cs
+++ b/API/Services/Implementations/PlayerRatingsService.cs
@@ -27,15 +27,7 @@ public class PlayerRatingsService(
         var matchesPlayed = await matchStatsRepository.CountMatchesPlayedAsync(playerId, ruleset);
         var winRate = await matchStatsRepository.GlobalWinrateAsync(playerId, ruleset);
         var tournamentsPlayed = await tournamentsService.CountPlayedAsync(playerId, ruleset);
-        var rankProgress = new RankProgressDTO
-        {
-            CurrentSubTier = RatingUtils.GetSubTier(currentStats.Rating),
-            RatingForNextTier = RatingUtils.GetNextTierRatingDelta(currentStats.Rating),
-            RatingForNextMajorTier = RatingUtils.GetNextMajorTierRatingDelta(currentStats.Rating),
-            NextMajorTier = RatingUtils.GetNextMajorTier(currentStats.Rating),
-            SubTierFillPercentage = RatingUtils.GetNextTierFillPercentage(currentStats.Rating),
-            MajorTierFillPercentage = RatingUtils.GetNextMajorTierFillPercentage(currentStats.Rating)
-        };
+        var rankProgress = new RankProgressDTO(currentStats.Rating);
 
         return new PlayerRatingStatsDTO
         {

--- a/API/Services/Implementations/PlayerStatsService.cs
+++ b/API/Services/Implementations/PlayerStatsService.cs
@@ -66,7 +66,8 @@ public class PlayerStatsService(
                 Adjustments = [], // We don't need adjustments for leaderboards
                 TournamentsPlayed = pts.sumTournaments,
                 MatchesPlayed = pts.sumMatches,
-                WinRate = pts.averageMatchWinRate
+                WinRate = pts.averageMatchWinRate,
+                RankProgress = new RankProgressDTO(pr.Rating)
             });
         }
 
@@ -240,15 +241,7 @@ public class PlayerStatsService(
         ratingStats.MatchesPlayed = matchesPlayed;
         ratingStats.WinRate = winRate;
 
-        ratingStats.RankProgress = new RankProgressDTO
-        {
-            CurrentSubTier = RatingUtils.GetSubTier(ratingStats.Rating),
-            RatingForNextTier = RatingUtils.GetNextTierRatingDelta(ratingStats.Rating),
-            RatingForNextMajorTier = RatingUtils.GetNextMajorTierRatingDelta(ratingStats.Rating),
-            NextMajorTier = RatingUtils.GetNextMajorTier(ratingStats.Rating),
-            SubTierFillPercentage = RatingUtils.GetNextTierFillPercentage(ratingStats.Rating),
-            MajorTierFillPercentage = RatingUtils.GetNextMajorTierFillPercentage(ratingStats.Rating)
-        };
+        ratingStats.RankProgress = new RankProgressDTO(ratingStats.Rating);
 
         return ratingStats;
     }

--- a/API/Services/Implementations/PlayerStatsService.cs
+++ b/API/Services/Implementations/PlayerStatsService.cs
@@ -242,7 +242,6 @@ public class PlayerStatsService(
 
         ratingStats.RankProgress = new RankProgressDTO
         {
-            CurrentTier = RatingUtils.GetTier(ratingStats.Rating),
             CurrentSubTier = RatingUtils.GetSubTier(ratingStats.Rating),
             RatingForNextTier = RatingUtils.GetNextTierRatingDelta(ratingStats.Rating),
             RatingForNextMajorTier = RatingUtils.GetNextMajorTierRatingDelta(ratingStats.Rating),

--- a/API/Services/Implementations/PlayerStatsService.cs
+++ b/API/Services/Implementations/PlayerStatsService.cs
@@ -67,7 +67,7 @@ public class PlayerStatsService(
                 TournamentsPlayed = pts.sumTournaments,
                 MatchesPlayed = pts.sumMatches,
                 WinRate = pts.averageMatchWinRate,
-                RankProgress = new RankProgressDTO(pr.Rating)
+                TierProgress = new TierProgressDTO(pr.Rating)
             });
         }
 
@@ -241,7 +241,7 @@ public class PlayerStatsService(
         ratingStats.MatchesPlayed = matchesPlayed;
         ratingStats.WinRate = winRate;
 
-        ratingStats.RankProgress = new RankProgressDTO(ratingStats.Rating);
+        ratingStats.TierProgress = new TierProgressDTO(ratingStats.Rating);
 
         return ratingStats;
     }

--- a/API/Utilities/RatingUtils.cs
+++ b/API/Utilities/RatingUtils.cs
@@ -308,24 +308,38 @@ public static class RatingUtils
     /// <remarks>Will return null for given ratings at or above <see cref="RatingGrandmasterI"/></remarks>
     public static int? GetNextSubTier(double rating)
     {
+        // First get the current sub-tier (1, 2, or 3) for the given rating
+        // This will be null for Elite Grandmaster
         var currentSubTier = GetSubTier(rating);
 
         switch (currentSubTier)
         {
+            // If current sub-tier is null (Elite Grandmaster), there is no next tier
             case null:
                 return null;
+
+            // If current sub-tier is 2 or 3, the next sub-tier is simply one less
+            // (Sub-tiers count down: 3 → 2 → 1 within each major tier)
+            // Example: Bronze III (3) → Bronze II (2) → Bronze I (1)
             case > 1:
                 return currentSubTier - 1;
+
+            // If current sub-tier is 1, we need to move to the next major tier
             default:
                 {
-                    // Check if there's a next major tier
+                    // Check if there's a next major tier available
                     var nextMajorTier = GetNextMajorTier(rating);
 
+                    // Elite Grandmaster is the highest tier, so there's no next tier after it.
+                    // Therefore, there is no sub tier and we return null.
                     if (nextMajorTier == "Elite Grandmaster")
                     {
                         return null;
                     }
 
+                    // If there is a next major tier, return 3 (the highest sub-tier of that major tier)
+                    // Example: Bronze I (1) → Silver III (3)
+                    // If there's no next major tier, return null
                     return nextMajorTier != null ? 3 : null;
                 }
         }

--- a/API/Utilities/RatingUtils.cs
+++ b/API/Utilities/RatingUtils.cs
@@ -24,37 +24,23 @@ public static class RatingUtils
     public const int RatingMinimum = 100;
 
     /// <summary>
-    /// Gets the string representation of the given rating
+    /// Gets the major tier representation of the specified rating
     /// </summary>
-    public static string GetTier(double rating) =>
-        rating switch
+    public static string GetMajorTier(double rating)
+    {
+        return rating switch
         {
-            <= RatingConstants.RatingBronzeIII => "Bronze III",
-            < RatingConstants.RatingBronzeI => "Bronze II",
-            < RatingConstants.RatingSilverIII => "Bronze I",
-            < RatingConstants.RatingSilverII => "Silver III",
-            < RatingConstants.RatingSilverI => "Silver II",
-            < RatingConstants.RatingGoldIII => "Silver I",
-            < RatingConstants.RatingGoldII => "Gold III",
-            < RatingConstants.RatingGoldI => "Gold II",
-            < RatingConstants.RatingPlatinumIII => "Gold I",
-            < RatingConstants.RatingPlatinumII => "Platinum III",
-            < RatingConstants.RatingPlatinumI => "Platinum II",
-            < RatingConstants.RatingEmeraldIII => "Platinum I",
-            < RatingConstants.RatingEmeraldII => "Emerald III",
-            < RatingConstants.RatingEmeraldI => "Emerald II",
-            < RatingConstants.RatingDiamondIII => "Emerald I",
-            < RatingConstants.RatingDiamondII => "Diamond III",
-            < RatingConstants.RatingDiamondI => "Diamond II",
-            < RatingConstants.RatingMasterIII => "Diamond I",
-            < RatingConstants.RatingMasterII => "Master III",
-            < RatingConstants.RatingMasterI => "Master II",
-            < RatingConstants.RatingGrandmasterIII => "Master I",
-            < RatingConstants.RatingGrandmasterII => "Grandmaster III",
-            < RatingConstants.RatingGrandmasterI => "Grandmaster II",
-            < RatingConstants.RatingEliteGrandmaster => "Grandmaster I",
+            < RatingConstants.RatingSilverIII => "Bronze",
+            < RatingConstants.RatingGoldIII => "Silver",
+            < RatingConstants.RatingPlatinumIII => "Gold",
+            < RatingConstants.RatingEmeraldIII => "Platinum",
+            < RatingConstants.RatingDiamondIII => "Emerald",
+            < RatingConstants.RatingMasterIII => "Diamond",
+            < RatingConstants.RatingGrandmasterIII => "Master",
+            < RatingConstants.RatingEliteGrandmaster => "Grandmaster",
             _ => "Elite Grandmaster"
         };
+    }
 
     /// <summary>
     /// Gets the integer representation of the sub-tier for the given rating
@@ -87,40 +73,6 @@ public static class RatingUtils
             < RatingConstants.RatingGrandmasterII => 3,
             < RatingConstants.RatingGrandmasterI => 2,
             < RatingConstants.RatingEliteGrandmaster => 1,
-            _ => null
-        };
-
-    /// <summary>
-    /// Gets the string representation of the next tier for the given rating
-    /// </summary>
-    /// <remarks>Will return null for given ratings greater than <see cref="RatingEliteGrandmaster"/></remarks>
-    public static string? GetNextTier(double rating) =>
-        rating switch
-        {
-            < RatingConstants.RatingBronzeII => GetTier(RatingConstants.RatingBronzeII),
-            < RatingConstants.RatingBronzeI => GetTier(RatingConstants.RatingBronzeI),
-            < RatingConstants.RatingSilverIII => GetTier(RatingConstants.RatingSilverIII),
-            < RatingConstants.RatingSilverII => GetTier(RatingConstants.RatingSilverII),
-            < RatingConstants.RatingSilverI => GetTier(RatingConstants.RatingSilverI),
-            < RatingConstants.RatingGoldIII => GetTier(RatingConstants.RatingGoldIII),
-            < RatingConstants.RatingGoldII => GetTier(RatingConstants.RatingGoldII),
-            < RatingConstants.RatingGoldI => GetTier(RatingConstants.RatingGoldI),
-            < RatingConstants.RatingPlatinumIII => GetTier(RatingConstants.RatingPlatinumIII),
-            < RatingConstants.RatingPlatinumII => GetTier(RatingConstants.RatingPlatinumII),
-            < RatingConstants.RatingPlatinumI => GetTier(RatingConstants.RatingPlatinumI),
-            < RatingConstants.RatingEmeraldIII => GetTier(RatingConstants.RatingEmeraldIII),
-            < RatingConstants.RatingEmeraldII => GetTier(RatingConstants.RatingEmeraldII),
-            < RatingConstants.RatingEmeraldI => GetTier(RatingConstants.RatingEmeraldI),
-            < RatingConstants.RatingDiamondIII => GetTier(RatingConstants.RatingDiamondIII),
-            < RatingConstants.RatingDiamondII => GetTier(RatingConstants.RatingDiamondII),
-            < RatingConstants.RatingDiamondI => GetTier(RatingConstants.RatingDiamondI),
-            < RatingConstants.RatingMasterIII => GetTier(RatingConstants.RatingMasterIII),
-            < RatingConstants.RatingMasterII => GetTier(RatingConstants.RatingMasterII),
-            < RatingConstants.RatingMasterI => GetTier(RatingConstants.RatingMasterI),
-            < RatingConstants.RatingGrandmasterIII => GetTier(RatingConstants.RatingGrandmasterIII),
-            < RatingConstants.RatingGrandmasterII => GetTier(RatingConstants.RatingGrandmasterII),
-            < RatingConstants.RatingGrandmasterI => GetTier(RatingConstants.RatingGrandmasterI),
-            < RatingConstants.RatingEliteGrandmaster => GetTier(RatingConstants.RatingEliteGrandmaster),
             _ => null
         };
 
@@ -228,18 +180,20 @@ public static class RatingUtils
     /// <summary>
     /// Gets the string representation of the next major tier for the given rating
     /// </summary>
-    /// <remarks>Will return null for given ratings greater than <see cref="RatingEliteGrandmaster"/></remarks>
+    /// <remarks>
+    /// Will return null for given ratings greater than <see cref="RatingEliteGrandmaster"/>
+    /// </remarks>
     public static string? GetNextMajorTier(double rating) =>
         rating switch
         {
-            < RatingConstants.RatingSilverIII => GetTier(RatingConstants.RatingSilverIII),
-            < RatingConstants.RatingGoldIII => GetTier(RatingConstants.RatingGoldIII),
-            < RatingConstants.RatingPlatinumIII => GetTier(RatingConstants.RatingPlatinumIII),
-            < RatingConstants.RatingEmeraldIII => GetTier(RatingConstants.RatingEmeraldIII),
-            < RatingConstants.RatingDiamondIII => GetTier(RatingConstants.RatingDiamondIII),
-            < RatingConstants.RatingMasterIII => GetTier(RatingConstants.RatingMasterIII),
-            < RatingConstants.RatingGrandmasterIII => GetTier(RatingConstants.RatingGrandmasterIII),
-            < RatingConstants.RatingEliteGrandmaster => GetTier(RatingConstants.RatingEliteGrandmaster),
+            < RatingConstants.RatingSilverIII => GetMajorTier(RatingConstants.RatingSilverIII),
+            < RatingConstants.RatingGoldIII => GetMajorTier(RatingConstants.RatingGoldIII),
+            < RatingConstants.RatingPlatinumIII => GetMajorTier(RatingConstants.RatingPlatinumIII),
+            < RatingConstants.RatingEmeraldIII => GetMajorTier(RatingConstants.RatingEmeraldIII),
+            < RatingConstants.RatingDiamondIII => GetMajorTier(RatingConstants.RatingDiamondIII),
+            < RatingConstants.RatingMasterIII => GetMajorTier(RatingConstants.RatingMasterIII),
+            < RatingConstants.RatingGrandmasterIII => GetMajorTier(RatingConstants.RatingGrandmasterIII),
+            < RatingConstants.RatingEliteGrandmaster => GetMajorTier(RatingConstants.RatingEliteGrandmaster),
             _ => null
         };
 
@@ -349,72 +303,31 @@ public static class RatingUtils
         volatility >= 200.0 || matchesPlayed <= 8 || tournamentsPlayed <= 2;
 
     /// <summary>
-    /// Denotes the given tier is Elite Grandmaster
+    /// Gets the integer representation of the next sub-tier for the given rating
     /// </summary>
-    public static bool IsEliteGrandmaster(string tier) =>
-        tier == GetTier(RatingConstants.RatingEliteGrandmaster);
+    /// <remarks>Will return null for given ratings at or above <see cref="RatingGrandmasterI"/></remarks>
+    public static int? GetNextSubTier(double rating)
+    {
+        var currentSubTier = GetSubTier(rating);
 
-    /// <summary>
-    /// Denotes the given tier is any Grandmaster tier
-    /// </summary>
-    public static bool IsGrandmaster(string tier) =>
-        tier == GetTier(RatingConstants.RatingGrandmasterIII) ||
-        tier == GetTier(RatingConstants.RatingGrandmasterII) ||
-        tier == GetTier(RatingConstants.RatingGrandmasterI);
+        switch (currentSubTier)
+        {
+            case null:
+                return null;
+            case > 1:
+                return currentSubTier - 1;
+            default:
+                {
+                    // Check if there's a next major tier
+                    var nextMajorTier = GetNextMajorTier(rating);
 
-    /// <summary>
-    /// Denotes the given tier is any Master tier
-    /// </summary>
-    public static bool IsMaster(string tier) =>
-        tier == GetTier(RatingConstants.RatingMasterIII) ||
-        tier == GetTier(RatingConstants.RatingMasterII) ||
-        tier == GetTier(RatingConstants.RatingMasterI);
+                    if (nextMajorTier == "Elite Grandmaster")
+                    {
+                        return null;
+                    }
 
-    /// <summary>
-    /// Denotes the given tier is any Diamond tier
-    /// </summary>
-    public static bool IsDiamond(string tier) =>
-        tier == GetTier(RatingConstants.RatingDiamondIII) ||
-        tier == GetTier(RatingConstants.RatingDiamondII) ||
-        tier == GetTier(RatingConstants.RatingDiamondI);
-
-    /// <summary>
-    /// Denotes the given tier is any Emerald tier
-    /// </summary>
-    public static bool IsEmerald(string tier) =>
-        tier == GetTier(RatingConstants.RatingEmeraldIII) ||
-        tier == GetTier(RatingConstants.RatingEmeraldII) ||
-        tier == GetTier(RatingConstants.RatingEmeraldI);
-
-    /// <summary>
-    /// Denotes the given tier is any Platinum tier
-    /// </summary>
-    public static bool IsPlatinum(string tier) =>
-        tier == GetTier(RatingConstants.RatingPlatinumIII) ||
-        tier == GetTier(RatingConstants.RatingPlatinumII) ||
-        tier == GetTier(RatingConstants.RatingPlatinumI);
-
-    /// <summary>
-    /// Denotes the given tier is any Gold tier
-    /// </summary>
-    public static bool IsGold(string tier) =>
-        tier == GetTier(RatingConstants.RatingGoldIII) ||
-        tier == GetTier(RatingConstants.RatingGoldII) ||
-        tier == GetTier(RatingConstants.RatingGoldI);
-
-    /// <summary>
-    /// Denotes the given tier is any Silver tier
-    /// </summary>
-    public static bool IsSilver(string tier) =>
-        tier == GetTier(RatingConstants.RatingSilverIII) ||
-        tier == GetTier(RatingConstants.RatingSilverII) ||
-        tier == GetTier(RatingConstants.RatingSilverI);
-
-    /// <summary>
-    /// Denotes the given tier is any Bronze tier
-    /// </summary>
-    public static bool IsBronze(string tier) =>
-        tier == GetTier(RatingConstants.RatingBronzeIII) ||
-        tier == GetTier(RatingConstants.RatingBronzeII) ||
-        tier == GetTier(RatingConstants.RatingBronzeI);
+                    return nextMajorTier != null ? 3 : null;
+                }
+        }
+    }
 }


### PR DESCRIPTION
## Dependencies

- [x] #641 

The previous tier logic didn't make a whole lot of sense. We were displaying strings with roman numerals *and* a "subtier" field. In reality, this display should be handled by the caller.

## Overivew

This change:

- Removes a duplicate field from the stats output (currentTier was present in rating and rankProgress).
- Removes the string display of sub tiers from the stats endpoint object
- Uses display of "major tiers" where we used to display the full tier with roman numerals.

![image](https://github.com/user-attachments/assets/8acc51d8-a8c0-4764-877b-ef67c8d1dca5)
