### PR TITLE
Fix time series data issues

### DIFF
--- a/API/DTOs/AggregatePlayerMatchStatsDTO.cs
+++ b/API/DTOs/AggregatePlayerMatchStatsDTO.cs
@@ -98,10 +98,10 @@ public class AggregatePlayerMatchStatsDTO
     /// <summary>
     /// The beginning of the period for which the statistics are calculated.
     /// </summary>
-    public DateTime PeriodStart { get; set; }
+    public DateTime? PeriodStart { get; set; }
 
     /// <summary>
     /// The end of the period for which the statistics are calculated.
     /// </summary>
-    public DateTime PeriodEnd { get; set; }
+    public DateTime? PeriodEnd { get; set; }
 }

--- a/API/DTOs/PlayerRatingDTO.cs
+++ b/API/DTOs/PlayerRatingDTO.cs
@@ -41,9 +41,4 @@ public class PlayerRatingDTO
     /// The player
     /// </summary>
     public PlayerCompactDTO Player { get; set; } = null!;
-
-    /// <summary>
-    /// A collection of adjustments that describe the changes resulting in the final rating
-    /// </summary>
-    public ICollection<RatingAdjustmentDTO> Adjustments { get; set; } = [];
 }

--- a/API/DTOs/PlayerRatingStatsDTO.cs
+++ b/API/DTOs/PlayerRatingStatsDTO.cs
@@ -6,6 +6,7 @@ namespace API.DTOs;
 /// <summary>
 /// Describes tournament rating based information for a player in a ruleset with additional statistics
 /// </summary>
+/// <remarks>If filtered by time, all fields in this class will change.</remarks>
 [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 public class PlayerRatingStatsDTO : PlayerRatingDTO
 {
@@ -28,6 +29,11 @@ public class PlayerRatingStatsDTO : PlayerRatingDTO
     /// Rating tier progress information
     /// </summary>
     public required TierProgressDTO TierProgress { get; set; }
+
+    /// <summary>
+    /// A collection of adjustments that describe the changes resulting in the final rating
+    /// </summary>
+    public ICollection<RatingAdjustmentDTO> Adjustments { get; set; } = [];
 
     /// <summary>
     /// Denotes the current rating as being provisional

--- a/API/Services/Implementations/FilteringService.cs
+++ b/API/Services/Implementations/FilteringService.cs
@@ -74,7 +74,7 @@ public class FilteringService(
         }
 
         PlayerRatingStatsDTO? ratingStats =
-            await playerRatingsService.GetAsync(playerInfo.Id, filteringRequest.Ruleset, false);
+            await playerRatingsService.GetAsync(playerInfo.Id, filteringRequest.Ruleset, includeAdjustments: false);
 
         if (ratingStats == null)
         {

--- a/API/Services/Implementations/PlayerRatingsService.cs
+++ b/API/Services/Implementations/PlayerRatingsService.cs
@@ -15,18 +15,19 @@ public class PlayerRatingsService(
     IMapper mapper
 ) : IPlayerRatingsService
 {
-    public async Task<PlayerRatingStatsDTO?> GetAsync(int playerId, Ruleset ruleset, bool includeAdjustments)
+    public async Task<PlayerRatingStatsDTO?> GetAsync(int playerId, Ruleset ruleset, DateTime? dateMin = null, DateTime? dateMax = null, bool includeAdjustments = false)
     {
-        PlayerRating? currentStats = await playerRatingsRepository.GetAsync(playerId, ruleset, includeAdjustments);
+        // Note: Adjustments are the only property filtered by time
+        PlayerRating? currentStats = await playerRatingsRepository.GetAsync(playerId, ruleset, dateMin, dateMax, includeAdjustments);
 
         if (currentStats is null)
         {
             return null;
         }
 
-        var matchesPlayed = await matchStatsRepository.CountMatchesPlayedAsync(playerId, ruleset);
-        var winRate = await matchStatsRepository.GlobalWinrateAsync(playerId, ruleset);
-        var tournamentsPlayed = await tournamentsService.CountPlayedAsync(playerId, ruleset);
+        var matchesPlayed = await matchStatsRepository.CountMatchesPlayedAsync(playerId, ruleset, dateMin, dateMax);
+        var winRate = await matchStatsRepository.GlobalWinrateAsync(playerId, ruleset, dateMin, dateMax);
+        var tournamentsPlayed = await tournamentsService.CountPlayedAsync(playerId, ruleset, dateMin, dateMax);
         var tierProgress = new TierProgressDTO(currentStats.Rating);
 
         return new PlayerRatingStatsDTO

--- a/API/Services/Implementations/PlayerStatsService.cs
+++ b/API/Services/Implementations/PlayerStatsService.cs
@@ -86,9 +86,6 @@ public class PlayerStatsService(
         DateTime? dateMax = null
     )
     {
-        dateMin ??= DateTime.MinValue;
-        dateMax ??= DateTime.MaxValue;
-
         Player? player = await playersRepository.GetVersatileAsync(key, true);
 
         if (player is null)
@@ -99,22 +96,16 @@ public class PlayerStatsService(
         ruleset ??= player.User?.Settings.DefaultRuleset ?? player.DefaultRuleset;
 
         PlayerCompactDTO playerInfo = mapper.Map<PlayerCompactDTO>(player);
-
-        PlayerRatingStatsDTO? ratingStats = await GetCurrentAsync(player.Id, ruleset.Value);
+        PlayerRatingStatsDTO? ratingStats = await GetRatingStatsAsync(player.Id, ruleset.Value, dateMin, dateMax);
 
         if (ratingStats is null)
         {
             return new PlayerDashboardStatsDTO { PlayerInfo = playerInfo, Ruleset = ruleset.Value };
         }
 
-        AggregatePlayerMatchStatsDTO? matchStats =
-            await GetMatchStatsAsync(player.Id, ruleset.Value, dateMin.Value, dateMax.Value);
-
-        IEnumerable<PlayerModStatsDTO> modStats = await GetModStatsAsync(player.Id, ruleset.Value, dateMin.Value, dateMax.Value);
-
-        PlayerTournamentPerformanceDTO tournamentPerformance =
-            await GetTournamentStatsAsync(player.Id, ruleset.Value, dateMin.Value, dateMax.Value);
-
+        AggregatePlayerMatchStatsDTO? matchStats = await GetMatchStatsAsync(player.Id, ruleset.Value, dateMin, dateMax);
+        IEnumerable<PlayerModStatsDTO> modStats = await GetModStatsAsync(player.Id, ruleset.Value, dateMin, dateMax);
+        PlayerTournamentPerformanceDTO tournamentPerformance = await GetTournamentStatsAsync(player.Id, ruleset.Value, dateMin, dateMax);
         Dictionary<bool, List<PlayerFrequencyDTO>> frequentTeammatesOpponents = await GetFrequentMatchupsAsync(player.Id, ruleset.Value, dateMin, dateMax);
 
         return new PlayerDashboardStatsDTO
@@ -225,18 +216,17 @@ public class PlayerStatsService(
         ];
     }
 
-
-    private async Task<PlayerRatingStatsDTO?> GetCurrentAsync(int playerId, Ruleset ruleset)
+    private async Task<PlayerRatingStatsDTO?> GetRatingStatsAsync(int playerId, Ruleset ruleset, DateTime? dateMin = null, DateTime? dateMax = null)
     {
-        PlayerRatingStatsDTO? ratingStats = await playerRatingsService.GetAsync(playerId, ruleset, true);
+        PlayerRatingStatsDTO? ratingStats = await playerRatingsService.GetAsync(playerId, ruleset, dateMin, dateMax, true);
 
         if (ratingStats == null)
         {
             return null;
         }
 
-        var matchesPlayed = await playerMatchStatsRepository.CountMatchesPlayedAsync(playerId, ruleset);
-        var winRate = await playerMatchStatsRepository.GlobalWinrateAsync(playerId, ruleset);
+        var matchesPlayed = await playerMatchStatsRepository.CountMatchesPlayedAsync(playerId, ruleset, dateMin, dateMax);
+        var winRate = await playerMatchStatsRepository.GlobalWinrateAsync(playerId, ruleset, dateMin, dateMax);
 
         ratingStats.MatchesPlayed = matchesPlayed;
         ratingStats.WinRate = winRate;
@@ -249,8 +239,8 @@ public class PlayerStatsService(
     private async Task<IEnumerable<PlayerModStatsDTO>> GetModStatsAsync(
         int playerId,
         Ruleset ruleset,
-        DateTime dateMin,
-        DateTime dateMax
+        DateTime? dateMin,
+        DateTime? dateMax
     )
     {
         Dictionary<Mods, int> modScores = await gameScoresRepository.GetAverageModScoresAsync(playerId, ruleset, dateMin, dateMax);
@@ -261,8 +251,8 @@ public class PlayerStatsService(
     private async Task<PlayerTournamentPerformanceDTO> GetTournamentStatsAsync(
         int playerId,
         Ruleset ruleset,
-        DateTime dateMin,
-        DateTime dateMax
+        DateTime? dateMin,
+        DateTime? dateMax
     )
     {
         const int count = 5;
@@ -309,8 +299,8 @@ public class PlayerStatsService(
     private async Task<AggregatePlayerMatchStatsDTO?> GetMatchStatsAsync(
         int id,
         Ruleset ruleset,
-        DateTime dateMin,
-        DateTime dateMax
+        DateTime? dateMin,
+        DateTime? dateMax
     )
     {
         var matchStats = (await playerMatchStatsRepository.GetForPlayerAsync(id, ruleset, dateMin, dateMax)).ToList();

--- a/API/Services/Interfaces/IPlayerRatingsService.cs
+++ b/API/Services/Interfaces/IPlayerRatingsService.cs
@@ -5,7 +5,7 @@ namespace API.Services.Interfaces;
 
 public interface IPlayerRatingsService
 {
-    Task<PlayerRatingStatsDTO?> GetAsync(int playerId, Ruleset ruleset, bool includeAdjustments);
+    Task<PlayerRatingStatsDTO?> GetAsync(int playerId, Ruleset ruleset, DateTime? dateMin = null, DateTime? dateMax = null, bool includeAdjustments = false);
 
     /// <summary>
     /// See <see cref="IApiPlayerRatingsRepository.GetHistogramAsync"/>

--- a/Database/Repositories/Implementations/MatchesRepository.cs
+++ b/Database/Repositories/Implementations/MatchesRepository.cs
@@ -93,6 +93,7 @@ public class MatchesRepository(OtrContext context) : RepositoryBase<Match>(conte
     public async Task<Match?> GetFullAsync(int id, bool verified)
     {
         IQueryable<Match> query = _context.Matches
+            .AsSplitQuery()
             .AsNoTracking()
             .IncludeChildren(verified)
             .IncludeTournament()

--- a/Database/Repositories/Implementations/PlayerRatingsRepository.cs
+++ b/Database/Repositories/Implementations/PlayerRatingsRepository.cs
@@ -14,13 +14,13 @@ public class PlayerRatingsRepository(OtrContext context)
 {
     private readonly OtrContext _context = context;
 
-    public async Task<PlayerRating?> GetAsync(int playerId, Ruleset ruleset, bool includeAdjustments)
+    public async Task<PlayerRating?> GetAsync(int playerId, Ruleset ruleset, DateTime? dateMin = null, DateTime? dateMax = null, bool includeAdjustments = false)
     {
         if (includeAdjustments)
         {
             return await _context.PlayerRatings
                 .Include(pr => pr.Player.User)
-                .Include(pr => pr.Adjustments)
+                .Include(pr => pr.Adjustments.Where(ra => ra.Timestamp >= dateMin && ra.Timestamp <= dateMax))
                 .ThenInclude(a => a.Match)
                 .Where(pr => pr.PlayerId == playerId && pr.Ruleset == ruleset)
                 .FirstOrDefaultAsync();

--- a/Database/Repositories/Implementations/TournamentsRepository.cs
+++ b/Database/Repositories/Implementations/TournamentsRepository.cs
@@ -79,8 +79,8 @@ public class TournamentsRepository(OtrContext context, IBeatmapsRepository beatm
     public async Task<int> CountPlayedAsync(
         int playerId,
         Ruleset ruleset,
-        DateTime dateMin,
-        DateTime dateMax
+        DateTime? dateMin,
+        DateTime? dateMax
     ) => await QueryForParticipation(playerId, ruleset, dateMin, dateMax).Select(x => x.Id).Distinct().CountAsync();
 
     public async Task<ICollection<Tournament>> GetAsync(
@@ -173,8 +173,8 @@ public class TournamentsRepository(OtrContext context, IBeatmapsRepository beatm
     public async Task<Dictionary<int, int>> GetLobbySizeStatsAsync(
         int playerId,
         Ruleset ruleset,
-        DateTime dateMin,
-        DateTime dateMax
+        DateTime? dateMin,
+        DateTime? dateMax
     )
     {
         var participatedTournaments =

--- a/Database/Repositories/Interfaces/IPlayerRatingsRepository.cs
+++ b/Database/Repositories/Interfaces/IPlayerRatingsRepository.cs
@@ -10,11 +10,14 @@ public interface IPlayerRatingsRepository : IRepository<PlayerRating>
     /// </summary>
     /// <param name="playerId">Player id</param>
     /// <param name="ruleset">Ruleset</param>
+    /// <param name="dateMin">Date lower bound</param>
+    /// <param name="dateMax">Date upper bound</param>
+    /// <remarks>dateMin and dateMax are only used for filtering the rating adjustments. Other data is always current</remarks>
     /// <returns>
     /// A <see cref="PlayerRating" /> for the given playerId and <see cref="Ruleset" />,
     /// or null if not found
     /// </returns>
-    Task<PlayerRating?> GetAsync(int playerId, Ruleset ruleset, bool includeAdjustments = false);
+    Task<PlayerRating?> GetAsync(int playerId, Ruleset ruleset, DateTime? dateMin = null, DateTime? dateMax = null, bool includeAdjustments = false);
 
     /// <summary>
     /// Get a collection of ratings

--- a/Database/Repositories/Interfaces/ITournamentsRepository.cs
+++ b/Database/Repositories/Interfaces/ITournamentsRepository.cs
@@ -46,7 +46,7 @@ public interface ITournamentsRepository : IRepository<Tournament>
     /// <param name="ruleset">Ruleset</param>
     /// <param name="dateMin">Date lower bound</param>
     /// <param name="dateMax">Date upper bound</param>
-    Task<int> CountPlayedAsync(int playerId, Ruleset ruleset, DateTime dateMin, DateTime dateMax);
+    Task<int> CountPlayedAsync(int playerId, Ruleset ruleset, DateTime? dateMin, DateTime? dateMax);
 
     /// <summary>
     /// Gets all tournaments with pagination
@@ -155,8 +155,8 @@ public interface ITournamentsRepository : IRepository<Tournament>
     Task<Dictionary<int, int>> GetLobbySizeStatsAsync(
         int playerId,
         Ruleset ruleset,
-        DateTime dateMin,
-        DateTime dateMax
+        DateTime? dateMin,
+        DateTime? dateMax
     );
 
     /// <summary>


### PR DESCRIPTION
# Overview

Updates the stats layer functionality and design to correctly handle date range specification.

# Changelog

- Fixes multiple bugs where data would not be correctly filtered by `dateMin` and `dateMax` if specified.
- Move `TierProgress` to `PlayerRatingDTO` because this is not something that changes if the user selects a time period
- Replaces `DateTime` with `DateTime?` in several places
- Moved some fields between `PlayerRatingDTO` and `PlayerRatingStatsDTO` to enforce the constraint that `PlayerRatingDTO` fields are never updated if the requester specifies a time window.