### PR TITLE
Score update bug fix

### DIFF
--- a/API/Configurations/MapperProfile.cs
+++ b/API/Configurations/MapperProfile.cs
@@ -19,6 +19,18 @@ public class MapperProfile : Profile
 
         CreateMap<Game, GameDTO>()
             .ForMember(x => x.Players, opt => opt.Ignore());
+
+        CreateMap<GameDTO, Game>(MemberList.Source)
+            .ForMember(x => x.Beatmap, opt => opt.Ignore())
+            .ForMember(x => x.Rosters, opt => opt.Ignore())
+            .ForMember(x => x.Match, opt => opt.Ignore())
+            .ForMember(x => x.AdminNotes, opt => opt.Ignore())
+            .ForMember(x => x.IsFreeMod, opt => opt.UseDestinationValue())
+            .ForSourceMember(x => x.Rosters, opt => opt.DoNotValidate())
+            .ForSourceMember(x => x.AdminNotes, opt => opt.DoNotValidate())
+            .ForSourceMember(x => x.IsFreeMod, opt => opt.DoNotValidate())
+            .ForSourceMember(x => x.Players, opt => opt.DoNotValidate());
+
         CreateMap<GameRoster, GameRosterDTO>();
 
         // Two-way mapping between entity and DTO,
@@ -26,11 +38,9 @@ public class MapperProfile : Profile
         // from the DTO to the entity.
         CreateMap<GameScore, GameScoreDTO>();
         CreateMap<GameScoreDTO, GameScore>(MemberList.Source)
-            .ForSourceMember(x => x.Accuracy, opt => opt.DoNotValidate())
-            .ForMember(x => x.Id, opt => opt.UseDestinationValue())
-            .ForMember(x => x.PlayerId, opt => opt.UseDestinationValue())
             .ForMember(x => x.Accuracy, opt => opt.UseDestinationValue())
             .ForMember(x => x.AdminNotes, opt => opt.Ignore())
+            .ForSourceMember(x => x.Accuracy, opt => opt.DoNotValidate())
             .ForSourceMember(x => x.AdminNotes, opt => opt.DoNotValidate());
 
         CreateMap<Match, MatchCompactDTO>()

--- a/API/Configurations/MapperProfile.cs
+++ b/API/Configurations/MapperProfile.cs
@@ -73,6 +73,10 @@ public class MapperProfile : Profile
         CreateMap<PlayerTournamentStats, PlayerTournamentStatsDTO>();
 
         CreateMap<Tournament, TournamentCompactDTO>();
+        CreateMap<TournamentCompactDTO, Tournament>(MemberList.Source)
+            .ForMember(x => x.SubmittedByUser, opt => opt.Ignore())
+            .ForMember(x => x.VerifiedByUser, opt => opt.Ignore());
+
         CreateMap<Tournament, TournamentDTO>();
         CreateMap<Tournament, TournamentCreatedResultDTO>()
             .MapAsCreatedResult()

--- a/API/Configurations/MapperProfile.cs
+++ b/API/Configurations/MapperProfile.cs
@@ -20,7 +20,18 @@ public class MapperProfile : Profile
         CreateMap<Game, GameDTO>()
             .ForMember(x => x.Players, opt => opt.Ignore());
         CreateMap<GameRoster, GameRosterDTO>();
+
+        // Two-way mapping between entity and DTO,
+        // ignores fields which should not be mapped
+        // from the DTO to the entity.
         CreateMap<GameScore, GameScoreDTO>();
+        CreateMap<GameScoreDTO, GameScore>(MemberList.Source)
+            .ForSourceMember(x => x.Accuracy, opt => opt.DoNotValidate())
+            .ForMember(x => x.Id, opt => opt.UseDestinationValue())
+            .ForMember(x => x.PlayerId, opt => opt.UseDestinationValue())
+            .ForMember(x => x.Accuracy, opt => opt.UseDestinationValue())
+            .ForMember(x => x.AdminNotes, opt => opt.Ignore())
+            .ForSourceMember(x => x.AdminNotes, opt => opt.DoNotValidate());
 
         CreateMap<Match, MatchCompactDTO>()
             .ForMember(x => x.Ruleset, opt => opt.MapFrom(x => x.Tournament.Ruleset));

--- a/API/Configurations/MapperProfile.cs
+++ b/API/Configurations/MapperProfile.cs
@@ -46,6 +46,9 @@ public class MapperProfile : Profile
         CreateMap<Match, MatchCompactDTO>()
             .ForMember(x => x.Ruleset, opt => opt.MapFrom(x => x.Tournament.Ruleset));
 
+        CreateMap<MatchCompactDTO, Match>(MemberList.Source)
+            .ForSourceMember(x => x.Ruleset, opt => opt.DoNotValidate());
+
         CreateMap<Match, MatchDTO>()
             .IncludeBase<Match, MatchCompactDTO>()
             .ForMember(x => x.Players, opt => opt.Ignore());

--- a/API/Services/Implementations/GameScoresService.cs
+++ b/API/Services/Implementations/GameScoresService.cs
@@ -19,13 +19,7 @@ public class GameScoresService(IGameScoresRepository gameScoresRepository, IMapp
             return null;
         }
 
-        existing.Team = score.Team;
-        existing.Score = score.Score;
-        existing.Mods = score.Mods;
-        existing.CountMiss = score.CountMiss;
-        existing.VerificationStatus = score.VerificationStatus;
-        existing.ProcessingStatus = score.ProcessingStatus;
-        existing.RejectionReason = score.RejectionReason;
+        mapper.Map(score, existing);
 
         await gameScoresRepository.UpdateAsync(existing);
         return mapper.Map<GameScoreDTO>(existing);

--- a/API/Services/Implementations/GamesService.cs
+++ b/API/Services/Implementations/GamesService.cs
@@ -29,15 +29,7 @@ public class GamesService(IGamesRepository gamesRepository, IPlayersRepository p
             return null;
         }
 
-        existing.Ruleset = game.Ruleset;
-        existing.ScoringType = game.ScoringType;
-        existing.TeamType = game.TeamType;
-        existing.Mods = game.Mods;
-        existing.VerificationStatus = game.VerificationStatus;
-        existing.ProcessingStatus = game.ProcessingStatus;
-        existing.RejectionReason = game.RejectionReason;
-        existing.StartTime = game.StartTime;
-        existing.EndTime = game.EndTime ?? existing.EndTime;
+        mapper.Map(game, existing);
 
         await gamesRepository.UpdateAsync(existing);
         return mapper.Map<GameDTO>(existing);

--- a/API/Services/Implementations/MatchesService.cs
+++ b/API/Services/Implementations/MatchesService.cs
@@ -78,12 +78,7 @@ public class MatchesService(
             return null;
         }
 
-        existing.Name = match.Name;
-        existing.StartTime = match.StartTime ?? existing.StartTime;
-        existing.EndTime = match.EndTime ?? existing.EndTime;
-        existing.VerificationStatus = match.VerificationStatus;
-        existing.RejectionReason = match.RejectionReason;
-        existing.ProcessingStatus = match.ProcessingStatus;
+        mapper.Map(match, existing);
 
         await matchesRepository.UpdateAsync(existing);
         return mapper.Map<MatchDTO>(existing);

--- a/API/Services/Implementations/TournamentsService.cs
+++ b/API/Services/Implementations/TournamentsService.cs
@@ -138,15 +138,7 @@ public class TournamentsService(
             return null;
         }
 
-        existing.Name = wrapper.Name;
-        existing.Abbreviation = wrapper.Abbreviation;
-        existing.ForumUrl = wrapper.ForumUrl;
-        existing.Ruleset = wrapper.Ruleset;
-        existing.RankRangeLowerBound = wrapper.RankRangeLowerBound;
-        existing.LobbySize = wrapper.LobbySize;
-        existing.ProcessingStatus = wrapper.ProcessingStatus;
-        existing.VerificationStatus = wrapper.VerificationStatus;
-        existing.RejectionReason = wrapper.RejectionReason;
+        mapper.Map(wrapper, existing);
 
         await tournamentsRepository.UpdateAsync(existing);
         return mapper.Map<TournamentCompactDTO>(existing);


### PR DESCRIPTION
Not all fields were being mapped from GameScoreDTO to the score entity in our update method.

This PR adds support for two-way mapping between GameScoreDTO and GameScore whilst ignoring navigation fields (in this case, just admin notes).