### PR TITLE
Add logic for `TierProgress.NextTier` and `TierProgress.NextSubTier`

### DIFF
--- a/API/DTOs/TierProgressDTO.cs
+++ b/API/DTOs/TierProgressDTO.cs
@@ -30,9 +30,24 @@ public class TierProgressDTO(double rating)
     public double RatingForNextMajorTier { get; set; } = RatingUtils.GetNextMajorTierRatingDelta(rating);
 
     /// <summary>
-    /// Next major tier following current tier
+    /// Major tier name of the next tier
+    /// </summary>
+    /// <remarks>
+    /// This will only be different from the current tier if the
+    /// next tier is a major tier change. Useful to avoid having to calculate this manually based on
+    /// the current tier.
+    /// </remarks>
+    public string? NextTier { get; set; } = RatingUtils.GetNextTierRating(rating).HasValue ? RatingUtils.GetMajorTier(RatingUtils.GetNextTierRating(rating)!.Value) : null;
+
+    /// <summary>
+    /// Major tier following current major tier
     /// </summary>
     public string? NextMajorTier { get; set; } = RatingUtils.GetNextMajorTier(rating);
+
+    /// <summary>
+    /// Sub tier following current sub tier
+    /// </summary>
+    public int? NextSubTier { get; set; } = RatingUtils.GetNextSubTier(rating);
 
     /// <summary>
     /// Progress to the next sub tier as a percentage

--- a/API/DTOs/TierProgressDTO.cs
+++ b/API/DTOs/TierProgressDTO.cs
@@ -20,6 +20,19 @@ public class TierProgressDTO(double rating)
     public int? CurrentSubTier { get; set; } = RatingUtils.GetSubTier(rating);
 
     /// <summary>
+    /// Name of the next major tier
+    /// </summary>
+    /// <remarks>
+    /// Null if there is no next major tier, e.g. when the rating value is within the maximum tier
+    /// </remarks>
+    public string? NextTier { get; set; } = RatingUtils.GetNextTierRating(rating).HasValue ? RatingUtils.GetMajorTier(RatingUtils.GetNextTierRating(rating)!.Value) : null;
+
+    /// <summary>
+    /// Next sub tier
+    /// </summary>
+    public int? NextSubTier { get; set; } = RatingUtils.GetNextSubTier(rating);
+
+    /// <summary>
     /// Rating required to reach next sub tier
     /// </summary>
     public double RatingForNextTier { get; set; } = RatingUtils.GetNextTierRatingDelta(rating);
@@ -30,24 +43,9 @@ public class TierProgressDTO(double rating)
     public double RatingForNextMajorTier { get; set; } = RatingUtils.GetNextMajorTierRatingDelta(rating);
 
     /// <summary>
-    /// Major tier name of the next tier
-    /// </summary>
-    /// <remarks>
-    /// This will only be different from the current tier if the
-    /// next tier is a major tier change. Useful to avoid having to calculate this manually based on
-    /// the current tier.
-    /// </remarks>
-    public string? NextTier { get; set; } = RatingUtils.GetNextTierRating(rating).HasValue ? RatingUtils.GetMajorTier(RatingUtils.GetNextTierRating(rating)!.Value) : null;
-
-    /// <summary>
     /// Major tier following current major tier
     /// </summary>
     public string? NextMajorTier { get; set; } = RatingUtils.GetNextMajorTier(rating);
-
-    /// <summary>
-    /// Sub tier following current sub tier
-    /// </summary>
-    public int? NextSubTier { get; set; } = RatingUtils.GetNextSubTier(rating);
 
     /// <summary>
     /// Progress to the next sub tier as a percentage


### PR DESCRIPTION
Adds two fields to `TierProgressDTO`, useful for seeing what the very next tier is without having to do any other calculation.

```json
"tierProgress": {
      "currentTier": "Emerald",
      "currentSubTier": 2,
      "ratingForNextTier": 55.28578044889173,
      "ratingForNextMajorTier": 155.28578044889173,
      "nextTier": "Emerald", // new
      "nextMajorTier": "Diamond",
      "nextSubTier": 1, // new
      "subTierFillPercentage": 0.4471421955110827,
      "majorTierFillPercentage": 0.48238073183702757
    },
```