### PR TITLE
Remove default rate limit config values and anonymous limit partition

### DIFF
--- a/API/Configurations/RateLimitConfiguration.cs
+++ b/API/Configurations/RateLimitConfiguration.cs
@@ -7,13 +7,14 @@ public class RateLimitConfiguration
     public const string Position = "RateLimit";
 
     /// <summary>
-    /// The total amount of tokens available per <see cref="Window"/>
+    /// The total amount of tokens available per <see cref="Window"/>, per user/client
     /// </summary>
     [Range(1, int.MaxValue, ErrorMessage = "PermitLimit must be an integer greater than 1!")]
-    public int PermitLimit { get; init; } = 30;
+    public int PermitLimit { get; init; }
+
     /// <summary>
     /// The amount of time (in seconds) before the <see cref="PermitLimit"/> is refreshed
     /// </summary>
     [Range(1, int.MaxValue, ErrorMessage = "Window must be an integer greater than 1!")]
-    public int Window { get; init; } = 60;
+    public int Window { get; init; }
 }

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -187,15 +187,6 @@ builder.Services.AddRateLimiter(options =>
     // Configure the rate limit partitioning rules
     options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
     {
-        // Shared partition for anonymous requests
-        if (context.User.Identity is { IsAuthenticated: false })
-        {
-            return RateLimitPartition.GetFixedWindowLimiter(
-                "anonymous",
-                _ => GetRateLimiterOptions()
-            );
-        }
-
         // Partition for each unique user / client
         return RateLimitPartition.GetFixedWindowLimiter(
             $"{context.User.GetSubjectType()}_{context.User.GetSubjectId()}",


### PR DESCRIPTION
- Removes default rate limit configuration values. These values should always be explicitly set in the configuration.
- Removes anonymous shared rate limit bucket. Cloudflare will handle spammers at the network level. This also is a bad idea to have because if we have a high user count, the service will be unbearably rate limited by innocent users.