### PR TITLE
Platform stats endpoint, some overall tournaments stats

### DIFF
--- a/API/Controllers/PlatformStatsController.cs
+++ b/API/Controllers/PlatformStatsController.cs
@@ -1,0 +1,25 @@
+﻿using API.DTOs;
+using API.Services.Interfaces;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
+
+namespace API.Controllers;
+
+[ApiController]
+[ApiVersion(1)]
+[Route("api/v{version:apiVersion}/stats")]
+public class PlatformStatsController(IPlatformStatsService statsService) : Controller
+{
+    private const int StatsCacheDurationSeconds = 60 * 10;
+
+    /// <summary>
+    /// Get various platform-wide stats
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    [ProducesResponseType<PlatformStatsDTO>(StatusCodes.Status200OK)]
+    [OutputCache(Duration = StatsCacheDurationSeconds)]
+    public async Task<IActionResult> GetAsync() => Ok(await statsService.GetAsync());
+}

--- a/API/DTOs/PlatformStatsDTO.cs
+++ b/API/DTOs/PlatformStatsDTO.cs
@@ -1,0 +1,12 @@
+﻿namespace API.DTOs;
+
+/// <summary>
+/// Represents platform-wide statistics
+/// </summary>
+public class PlatformStatsDTO
+{
+    /// <summary>
+    /// Statistics on all <see cref="Database.Entities.Tournament"/>s existing in the system
+    /// </summary>
+    public TournamentPlatformStatsDTO TournamentsStats { get; init; } = null!;
+}

--- a/API/DTOs/TournamentPlatformStatsDTO.cs
+++ b/API/DTOs/TournamentPlatformStatsDTO.cs
@@ -1,0 +1,19 @@
+﻿using Common.Enums.Verification;
+
+namespace API.DTOs;
+
+/// <summary>
+/// Represents statistics on all <see cref="Database.Entities.Tournament"/>s existing in a system
+/// </summary>
+public class TournamentPlatformStatsDTO
+{
+    /// <summary>
+    /// Total number of all <see cref="Database.Entities.Tournament"/>s in the system
+    /// </summary>
+    public int TotalCount { get; init; }
+
+    /// <summary>
+    /// Mapping of <see cref="Common.Enums.Verification.VerificationStatus"/>es to number of <see cref="Database.Entities.Tournament"/>s having corresponding status
+    /// </summary>
+    public Dictionary<VerificationStatus, int> CountsByVerificationStatuses { get; init; } = new();
+}

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -92,6 +92,7 @@ builder
 
 #region Controller Configuration
 
+builder.Services.AddOutputCache(); // makes available but not enables
 builder.Services
     .AddControllers(o =>
     {
@@ -640,6 +641,8 @@ builder.Services.AddScoped<ITournamentsService, TournamentsService>();
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IUrlHelperService, UrlHelperService>();
 builder.Services.AddScoped<IUserSettingsService, UserSettingsService>();
+builder.Services.AddScoped<IPlatformStatsService, PlatformStatsService>();
+builder.Services.AddScoped<ITournamentPlatformStatsService, TournamentPlatformStatsService>();
 
 #endregion
 
@@ -666,6 +669,9 @@ app.UseSerilogRequestLogging();
 app.UseRouting();
 // Placed after UseRouting and before UseAuthentication and UseAuthorization
 app.UseCors();
+
+// After UseCors
+app.UseOutputCache();
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/API/Services/Implementations/PlatformStatsService.cs
+++ b/API/Services/Implementations/PlatformStatsService.cs
@@ -1,0 +1,13 @@
+﻿using API.DTOs;
+using API.Services.Interfaces;
+
+namespace API.Services.Implementations;
+
+public class PlatformStatsService(ITournamentPlatformStatsService tournamentsStatsService) : IPlatformStatsService
+{
+    public async Task<PlatformStatsDTO> GetAsync() => new()
+    {
+        TournamentsStats = await tournamentsStatsService.GetAsync(),
+    };
+}
+

--- a/API/Services/Implementations/TournamentPlatformStatsService.cs
+++ b/API/Services/Implementations/TournamentPlatformStatsService.cs
@@ -1,0 +1,21 @@
+﻿using API.DTOs;
+using API.Services.Interfaces;
+using Common.Enums.Verification;
+using Database.Repositories.Interfaces;
+
+namespace API.Services.Implementations;
+
+public class TournamentPlatformStatsService(ITournamentsRepository tournamentsRepository) : ITournamentPlatformStatsService
+{
+    public async Task<TournamentPlatformStatsDTO> GetAsync()
+    {
+        Dictionary<VerificationStatus, int> countsByStatuses = await tournamentsRepository.GetVerificationStatusesStatsAsync();
+        var totalCount = countsByStatuses.Sum(x => x.Value);
+
+        return new TournamentPlatformStatsDTO()
+        {
+            TotalCount = totalCount,
+            CountsByVerificationStatuses = countsByStatuses,
+        };
+    }
+}

--- a/API/Services/Interfaces/IPlatformStatsService.cs
+++ b/API/Services/Interfaces/IPlatformStatsService.cs
@@ -1,0 +1,11 @@
+﻿using API.DTOs;
+
+namespace API.Services.Interfaces;
+
+public interface IPlatformStatsService
+{
+    /// <summary>
+    /// Gets various platform-wide stats
+    /// </summary>
+    Task<PlatformStatsDTO> GetAsync();
+}

--- a/API/Services/Interfaces/ITournamentPlatformStatsService.cs
+++ b/API/Services/Interfaces/ITournamentPlatformStatsService.cs
@@ -1,0 +1,11 @@
+﻿using API.DTOs;
+
+namespace API.Services.Interfaces;
+
+public interface ITournamentPlatformStatsService
+{
+    /// <summary>
+    /// Gets various platform-wide stats related to tournaments
+    /// </summary>
+    public Task<TournamentPlatformStatsDTO> GetAsync();
+}

--- a/Database/Repositories/Implementations/TournamentsRepository.cs
+++ b/Database/Repositories/Implementations/TournamentsRepository.cs
@@ -9,7 +9,8 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Database.Repositories.Implementations;
 
-[SuppressMessage("Performance", "CA1862:Use the \'StringComparison\' method overloads to perform case-insensitive string comparisons")]
+[SuppressMessage("Performance",
+    "CA1862:Use the \'StringComparison\' method overloads to perform case-insensitive string comparisons")]
 [SuppressMessage("ReSharper", "SpecifyStringComparison")]
 public class TournamentsRepository(OtrContext context, IBeatmapsRepository beatmapsRepository)
     : RepositoryBase<Tournament>(context), ITournamentsRepository
@@ -293,6 +294,17 @@ public class TournamentsRepository(OtrContext context, IBeatmapsRepository beatm
 
         await UpdateAsync(tournament);
     }
+
+    public async Task<Dictionary<VerificationStatus, int>> GetVerificationStatusesStatsAsync() =>
+        await _context.Tournaments
+            .GroupBy(
+                x => x.VerificationStatus,
+                (x, y) => new
+                {
+                    Status = x,
+                    Count = y.Count()
+                })
+            .ToDictionaryAsync(x => x.Status, x => x.Count);
 
     /// <summary>
     /// Returns a queryable containing tournaments for <see cref="ruleset"/>

--- a/Database/Repositories/Implementations/TournamentsRepository.cs
+++ b/Database/Repositories/Implementations/TournamentsRepository.cs
@@ -9,8 +9,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Database.Repositories.Implementations;
 
-[SuppressMessage("Performance",
-    "CA1862:Use the \'StringComparison\' method overloads to perform case-insensitive string comparisons")]
+[SuppressMessage("Performance", "CA1862:Use the \'StringComparison\' method overloads to perform case-insensitive string comparisons")]
 [SuppressMessage("ReSharper", "SpecifyStringComparison")]
 public class TournamentsRepository(OtrContext context, IBeatmapsRepository beatmapsRepository)
     : RepositoryBase<Tournament>(context), ITournamentsRepository

--- a/Database/Repositories/Interfaces/ITournamentsRepository.cs
+++ b/Database/Repositories/Interfaces/ITournamentsRepository.cs
@@ -189,4 +189,9 @@ public interface ITournamentsRepository : IRepository<Tournament>
     /// <param name="id">Tournament id</param>
     /// <param name="beatmapIds">Collection of beatmap ids to remove from the tournament's collection of pooled beatmaps</param>
     Task DeletePooledBeatmapsAsync(int id, ICollection<int> beatmapIds);
+
+    /// <summary>
+    /// Retrieves a mapping of <see cref="VerificationStatus"/>es to the number of <see cref="Tournament"/>s having corresponding status
+    /// </summary>
+    Task<Dictionary<VerificationStatus, int>> GetVerificationStatusesStatsAsync();
 }


### PR DESCRIPTION
Closes #653, #654

- added cached endpoint
- added DTO and service for composing all stats
- added initial tournament stats generation (from #654)