### PR TITLE
TournamentDTO & TournamentSearchResultDTO improvements

### DIFF
--- a/API/Configurations/MapperProfile.cs
+++ b/API/Configurations/MapperProfile.cs
@@ -71,7 +71,10 @@ public class MapperProfile : Profile
         CreateMap<Player, PlayerCompactDTO>()
             .ForMember(x => x.UserId, opt => opt.MapFrom(y => y.User!.Id));
         CreateMap<PlayerOsuRulesetData, PlayerOsuRulesetDataDTO>();
-        CreateMap<PlayerTournamentStats, PlayerTournamentStatsDTO>();
+
+        CreateMap<PlayerTournamentStats, PlayerTournamentStatsBaseDTO>();
+        CreateMap<PlayerTournamentStats, PlayerTournamentStatsDTO>()
+            .IncludeBase<PlayerTournamentStats, PlayerTournamentStatsBaseDTO>();
 
         CreateMap<Tournament, TournamentCompactDTO>();
         CreateMap<TournamentCompactDTO, Tournament>(MemberList.Source)

--- a/API/Configurations/MapperProfile.cs
+++ b/API/Configurations/MapperProfile.cs
@@ -85,8 +85,8 @@ public class MapperProfile : Profile
         CreateMap<Tournament, TournamentCreatedResultDTO>()
             .MapAsCreatedResult()
             .AfterMap<GenerateLocationUriAction>();
-        CreateMap<Tournament, TournamentSearchResultDTO>()
-            .ForMember(x => x.Ruleset, opt => opt.MapFrom(y => y.Ruleset));
+
+        CreateMap<Tournament, TournamentSearchResultDTO>();
 
         CreateMap<User, UserCompactDTO>();
         CreateMap<User, UserDTO>();

--- a/API/DTOs/PlayerTournamentStatsBaseDTO.cs
+++ b/API/DTOs/PlayerTournamentStatsBaseDTO.cs
@@ -1,0 +1,64 @@
+namespace API.DTOs;
+
+public class PlayerTournamentStatsBaseDTO
+{
+    /// <summary>
+    /// Average change in rating
+    /// </summary>
+    public double AverageRatingDelta { get; init; }
+
+    /// <summary>
+    /// Average match cost
+    /// </summary>
+    public double AverageMatchCost { get; init; }
+
+    /// <summary>
+    /// Average score
+    /// </summary>
+    public int AverageScore { get; init; }
+
+    /// <summary>
+    /// Average placement
+    /// </summary>
+    public double AveragePlacement { get; init; }
+
+    /// <summary>
+    /// Average accuracy
+    /// </summary>
+    public double AverageAccuracy { get; init; }
+
+    /// <summary>
+    /// Total number of <see cref="Match"/>es played
+    /// </summary>
+    public int MatchesPlayed { get; init; }
+
+    /// <summary>
+    /// Total number of <see cref="Match"/>es won
+    /// </summary>
+    public int MatchesWon { get; init; }
+
+    /// <summary>
+    /// Total number of <see cref="Match"/>es lost
+    /// </summary>
+    public int MatchesLost { get; init; }
+
+    /// <summary>
+    /// Total number of <see cref="Game"/>s played
+    /// </summary>
+    public int GamesPlayed { get; init; }
+
+    /// <summary>
+    /// Total number of <see cref="Game"/>s won
+    /// </summary>
+    public int GamesWon { get; init; }
+
+    /// <summary>
+    /// Total number of <see cref="Game"/>s lost
+    /// </summary>
+    public int GamesLost { get; init; }
+
+    /// <summary>
+    /// The player who owns these stats
+    /// </summary>
+    public PlayerCompactDTO Player { get; init; } = null!;
+}

--- a/API/DTOs/PlayerTournamentStatsDTO.cs
+++ b/API/DTOs/PlayerTournamentStatsDTO.cs
@@ -1,69 +1,9 @@
 namespace API.DTOs;
 
-public class PlayerTournamentStatsDTO
+public class PlayerTournamentStatsDTO : PlayerTournamentStatsBaseDTO
 {
     /// <summary>
-    /// Average change in rating
+    /// The tournament that these stats are for
     /// </summary>
-    public double AverageRatingDelta { get; init; }
-
-    /// <summary>
-    /// Average match cost
-    /// </summary>
-    public double AverageMatchCost { get; init; }
-
-    /// <summary>
-    /// Average score
-    /// </summary>
-    public int AverageScore { get; init; }
-
-    /// <summary>
-    /// Average placement
-    /// </summary>
-    public double AveragePlacement { get; init; }
-
-    /// <summary>
-    /// Average accuracy
-    /// </summary>
-    public double AverageAccuracy { get; init; }
-
-    /// <summary>
-    /// Total number of <see cref="Match"/>es played
-    /// </summary>
-    public int MatchesPlayed { get; init; }
-
-    /// <summary>
-    /// Total number of <see cref="Match"/>es won
-    /// </summary>
-    public int MatchesWon { get; init; }
-
-    /// <summary>
-    /// Total number of <see cref="Match"/>es lost
-    /// </summary>
-    public int MatchesLost { get; init; }
-
-    /// <summary>
-    /// Total number of <see cref="Game"/>s played
-    /// </summary>
-    public int GamesPlayed { get; init; }
-
-    /// <summary>
-    /// Total number of <see cref="Game"/>s won
-    /// </summary>
-    public int GamesWon { get; init; }
-
-    /// <summary>
-    /// Total number of <see cref="Game"/>s lost
-    /// </summary>
-    public int GamesLost { get; init; }
-
-    /// <summary>
-    /// The player who owns these stats
-    /// </summary>
-    public PlayerCompactDTO Player { get; init; } = null!;
-
-    /// <summary>
-    /// Tournament
-    /// </summary>
-    public TournamentCompactDTO Tournament { get; init; } = null!;
+    public TournamentCompactDTO Tournament { get; set; } = null!;
 }

--- a/API/DTOs/TournamentDTO.cs
+++ b/API/DTOs/TournamentDTO.cs
@@ -15,4 +15,9 @@ public class TournamentDTO : TournamentCompactDTO
     /// All admin notes associated with the tournament
     /// </summary>
     public ICollection<AdminNoteDTO> AdminNotes { get; init; } = [];
+
+    /// <summary>
+    /// All player tournament stats associated with the tournament
+    /// </summary>
+    public ICollection<PlayerTournamentStatsBaseDTO> PlayerTournamentStats { get; init; } = [];
 }

--- a/API/DTOs/TournamentSearchResultDTO.cs
+++ b/API/DTOs/TournamentSearchResultDTO.cs
@@ -1,4 +1,5 @@
 using Common.Enums;
+using Common.Enums.Verification;
 
 namespace API.DTOs;
 
@@ -16,6 +17,21 @@ public class TournamentSearchResultDTO
     /// Ruleset of the tournament
     /// </summary>
     public Ruleset Ruleset { get; set; }
+
+    /// <summary>
+    /// Verification status of the tournament
+    /// </summary>
+    public VerificationStatus VerificationStatus { get; set; }
+
+    /// <summary>
+    /// Rejection reason of the tournament
+    /// </summary>
+    public string? RejectionReason { get; set; }
+
+    /// <summary>
+    /// Abbreviation of the tournament
+    /// </summary>
+    public string? Abbreviation { get; set; }
 
     /// <summary>
     /// Expected in-match team size

--- a/API/DTOs/TournamentSearchResultDTO.cs
+++ b/API/DTOs/TournamentSearchResultDTO.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Common.Enums;
 using Common.Enums.Verification;
 
@@ -26,7 +27,7 @@ public class TournamentSearchResultDTO
     /// <summary>
     /// Rejection reason of the tournament
     /// </summary>
-    public string? RejectionReason { get; set; }
+    public TournamentRejectionReason RejectionReason { get; set; }
 
     /// <summary>
     /// Abbreviation of the tournament

--- a/API/Services/Implementations/SearchService.cs
+++ b/API/Services/Implementations/SearchService.cs
@@ -27,17 +27,24 @@ public class SearchService(
 
     private async Task<IEnumerable<TournamentSearchResultDTO>> SearchTournamentsByNameAsync(string tournamentName)
     {
-        IList<TournamentSearchResultDTO>? result =
-            await cacheHandler.Cache.GetObjectAsync<IList<TournamentSearchResultDTO>>(
+        IList<TournamentSearchResultDTO>? result;
+
+        try
+        {
+            result = await cacheHandler.Cache.GetObjectAsync<IList<TournamentSearchResultDTO>>(
                 CacheUtils.TournamentSearchKey(tournamentName));
 
-        if (result is not null)
+            if (result is not null)
+            {
+                return result;
+            }
+        }
+        catch (Exception)
         {
-            return result;
+            // Item failed to resolve from cache, continue with search
         }
 
         IList<Tournament> searchResult = await tournamentsRepository.SearchAsync(tournamentName);
-
         result = [.. searchResult.Select(t => mapper.Map<TournamentSearchResultDTO>(t))];
 
         await cacheHandler.SetTournamentSearchResultAsync(result, tournamentName);

--- a/API/Services/Implementations/SearchService.cs
+++ b/API/Services/Implementations/SearchService.cs
@@ -2,6 +2,7 @@ using API.DTOs;
 using API.Handlers.Interfaces;
 using API.Services.Interfaces;
 using API.Utilities;
+using AutoMapper;
 using Database.Entities;
 using Database.Entities.Processor;
 using Database.Repositories.Interfaces;
@@ -12,7 +13,8 @@ public class SearchService(
     ITournamentsRepository tournamentsRepository,
     IMatchesService matchesService,
     IPlayersRepository playerRepository,
-    ICacheHandler cacheHandler
+    ICacheHandler cacheHandler,
+    IMapper mapper
 ) : ISearchService
 {
     public async Task<SearchResponseCollectionDTO> SearchByNameAsync(string searchKey) =>
@@ -36,13 +38,7 @@ public class SearchService(
 
         IList<Tournament> searchResult = await tournamentsRepository.SearchAsync(tournamentName);
 
-        result = [.. searchResult.Select(t => new TournamentSearchResultDTO
-        {
-            Id = t.Id,
-            Ruleset = t.Ruleset,
-            LobbySize = t.LobbySize,
-            Name = t.Name
-        })];
+        result = [.. searchResult.Select(t => mapper.Map<TournamentSearchResultDTO>(t))];
 
         await cacheHandler.SetTournamentSearchResultAsync(result, tournamentName);
         return result;

--- a/Database/Repositories/Interfaces/ITournamentsRepository.cs
+++ b/Database/Repositories/Interfaces/ITournamentsRepository.cs
@@ -14,6 +14,10 @@ public interface ITournamentsRepository : IRepository<Tournament>
     /// Whether to eagerly load navigational properties.
     /// If true, all returned entities will not be tracked by the context
     /// </param>
+    /// <remarks>
+    /// <see cref="Entities.PlayerTournamentStats"/> will be included for this tournament,
+    /// the <see cref="Entities.PlayerMatchStats"/> will be included for matches played in this tournament.
+    /// </remarks>
     Task<Tournament?> GetAsync(int id, bool eagerLoad = false);
 
     /// <summary>


### PR DESCRIPTION
- Moves all but the `Tournament` property from `PlayerTournamentStatsDTO` to a new type: `PlayerTournamentStatsBaseDTO`
- Adds `PlayerTournamentStatsBaseDTO` to `TournamentDTO`
- Adds more fields to the `TournamentSearchResultDTO` type
- Fixes a bug where cache misses on `TournamentSearchResultDTO` could produce an unhandled exception.
- `PlayerTournamentStatsDTO` is now included on `TournamentDTO` (one entry per player in the tournament).