### PR TITLE
Minor bug fixes with mania earliest global rank & country leaderboards

### DIFF
--- a/Database/Repositories/Implementations/PlayerRatingsRepository.cs
+++ b/Database/Repositories/Implementations/PlayerRatingsRepository.cs
@@ -156,6 +156,10 @@ public class PlayerRatingsRepository(OtrContext context)
         {
             baseQuery = baseQuery.Where(x => x.Player.Country == mappedCountry);
         }
+        else
+        {
+            baseQuery = baseQuery.Where(x => x.Player.Country == country);
+        }
 
         return baseQuery;
     }

--- a/Database/Repositories/Implementations/PlayersRepository.cs
+++ b/Database/Repositories/Implementations/PlayersRepository.cs
@@ -122,7 +122,7 @@ public class PlayersRepository(OtrContext context) : RepositoryBase<Player>(cont
             .Include(p => p.User)
             .ThenInclude(u => u!.Settings)
             .Where(p => DateTime.UtcNow - p.OsuLastFetch > outdatedAfter)
-            .OrderBy(p => p.Id)
+            .OrderBy(p => p.OsuLastFetch)
             .Take(limit)
             .ToListAsync();
 
@@ -140,7 +140,7 @@ public class PlayersRepository(OtrContext context) : RepositoryBase<Player>(cont
             .Include(p => p.MatchStats)
             .ThenInclude(pms => pms.Match)
             .Where(p => DateTime.UtcNow - p.OsuTrackLastFetch > outdatedAfter)
-            .OrderBy(p => p.Id)
+            .OrderBy(p => p.OsuTrackLastFetch)
             .Take(limit)
             .ToListAsync();
 }

--- a/OsuApiClient/OsuClient.cs
+++ b/OsuApiClient/OsuClient.cs
@@ -420,7 +420,6 @@ public sealed class OsuClient(
     )
     {
         CheckDisposed();
-        await UpdateCredentialsAsync(cancellationToken);
 
         var queryParams = new Dictionary<string, string>
         {


### PR DESCRIPTION
When mode=3 is fetched from osu!track, that earliest global rank info is now saved on the mania4k and 7k player_osu_ruleset_data entries for each player. This will automatically populate over time and will result in more accurate initial ratings for players without complex logic updates in the otr-processor.