### PR TITLE
Fix data protection & HTTPS redirects

### DIFF
--- a/API/Configurations/AuthConfiguration.cs
+++ b/API/Configurations/AuthConfiguration.cs
@@ -1,8 +1,5 @@
-using JetBrains.Annotations;
-
 namespace API.Configurations;
 
-[UsedImplicitly(ImplicitUseTargetFlags.Members)]
 public class AuthConfiguration
 {
     public const string Position = "Auth";
@@ -21,4 +18,9 @@ public class AuthConfiguration
     /// If Data Protection keys should be persisted to Redis
     /// </summary>
     public bool PersistDataProtectionKeys { get; init; } = true;
+
+    /// <summary>
+    /// The expiration time for cookies
+    /// </summary>
+    public TimeSpan CookieExpiration { get; init; } = TimeSpan.FromDays(30);
 }

--- a/API/HealthChecks/DataProtectionHealthCheck.cs
+++ b/API/HealthChecks/DataProtectionHealthCheck.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace API.HealthChecks;
+
+public class DataProtectionHealthCheck(IDataProtectionProvider dataProtectionProvider) : IHealthCheck
+{
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (dataProtectionProvider == null)
+            {
+                return Task.FromResult(HealthCheckResult.Unhealthy("Data Protection Provider not available (not resolved from DI)."));
+            }
+
+            var protector = dataProtectionProvider.CreateProtector("health-check-test");
+            string testData = "test";
+            string protectedData = protector.Protect(testData);
+            string unprotectedData = protector.Unprotect(protectedData);
+
+            bool isHealthy = testData == unprotectedData;
+
+            return Task.FromResult(isHealthy
+                ? HealthCheckResult.Healthy("Data Protection keys accessible")
+                : HealthCheckResult.Unhealthy("Data Protection key validation failed"));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy("Data Protection health check failed", ex));
+        }
+    }
+}

--- a/API/HealthChecks/DatabaseHealthCheck.cs
+++ b/API/HealthChecks/DatabaseHealthCheck.cs
@@ -1,0 +1,44 @@
+using Database;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace API.HealthChecks;
+
+/// <summary>
+/// Performs a health check on the database
+/// </summary>
+/// <param name="context">The database context</param>
+public class DatabaseHealthCheck(OtrContext context) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext healthCheckContext,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (context == null)
+            {
+                return HealthCheckResult.Unhealthy("Database context not available (not resolved from DI).");
+            }
+
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+            bool canConnect = await context.Database.CanConnectAsync(cancellationToken);
+
+            if (!canConnect)
+            {
+                return HealthCheckResult.Unhealthy("Cannot connect to database.");
+            }
+
+            await context.Database.ExecuteSqlRawAsync("SELECT 1", cancellationToken);
+
+            stopwatch.Stop();
+
+            return HealthCheckResult.Healthy($"Database connection healthy - {stopwatch.ElapsedMilliseconds}ms");
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy("Database health check failed", ex);
+        }
+    }
+}

--- a/API/HealthChecks/RedisHealthCheck.cs
+++ b/API/HealthChecks/RedisHealthCheck.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using StackExchange.Redis;
+
+namespace API.HealthChecks;
+
+public class RedisHealthCheck(IConnectionMultiplexer redis) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (redis == null)
+            {
+                return HealthCheckResult.Degraded("No Redis connection configured or resolved.");
+            }
+
+            var database = redis.GetDatabase();
+            TimeSpan pong = await database.PingAsync();
+
+            return HealthCheckResult.Healthy($"Redis connection healthy - {pong.TotalMilliseconds}ms");
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy("Redis connection failed", ex);
+        }
+    }
+}

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -209,9 +209,8 @@ builder.Services.AddRateLimiter(options =>
     options.OnRejected = async (context, token) =>
     {
         context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
-        const string readMore =
-            // TODO: Link to the API Terms of Service Document
-            "Currently, detailed information about API rate limits is unavailable.";
+        const string readMore = "https://docs.otr.stagec.xyz/About/Terms-of-Use";
+
         if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out TimeSpan retryAfter))
         {
             await context.HttpContext.Response.WriteAsync(

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -35,6 +35,7 @@ using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
@@ -997,6 +998,12 @@ WebApplication app = builder.Build();
 
 // Set switch for Npgsql
 AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+
+// Configure forwarded headers for proper HTTPS detection behind proxies
+app.UseForwardedHeaders(new ForwardedHeadersOptions
+{
+    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedPrefix
+});
 
 app.UseOpenTelemetryPrometheusScrapingEndpoint();
 

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -430,11 +430,7 @@ builder.Services.AddSerilog(configuration =>
         )
         .DefaultConnection;
 
-#if DEBUG
-    configuration.MinimumLevel.Debug();
-#else
-    configuration.MinimumLevel.Information();
-#endif
+    configuration.MinimumLevel.Verbose();
 
     configuration
         .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
@@ -444,13 +440,12 @@ builder.Services.AddSerilog(configuration =>
         )
         .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Information)
         .MinimumLevel.Override("API", LogEventLevel.Debug)
-        .MinimumLevel.Override("OsuApiClient", LogEventLevel.Information)
+        .MinimumLevel.Override("OsuApiClient", LogEventLevel.Debug)
         .MinimumLevel.Override("System", LogEventLevel.Warning)
         .Enrich.FromLogContext()
         .Enrich.WithSpan()
         .WriteTo.Logger(lc => lc
-            .MinimumLevel.Debug()
-            .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+            .MinimumLevel.Verbose()
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore.Database.Command", LogEventLevel.Warning)
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Information)
             .Filter.ByExcluding(e => e.MessageTemplate.Text.Contains("Microsoft.EntityFrameworkCore.Database.Command"))
@@ -460,17 +455,11 @@ builder.Services.AddSerilog(configuration =>
                     new() { Key = "app", Value = serviceName },
                     new() { Key = "environment", Value = builder.Environment.EnvironmentName }
                 },
-                ["app", "environment"],
-                restrictedToMinimumLevel: LogEventLevel.Debug))
+                ["app", "environment"]))
         .WriteTo.Logger(lc => lc
             .Filter
             .ByExcluding(e => e.MessageTemplate.Text.Contains("Microsoft.EntityFrameworkCore.Database.Command"))
             .WriteTo.Console(outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff} {Level:u3}] [trace_id: {TraceId} span_id: {SpanId}] {Message:lj}{NewLine}"))
-        .WriteTo.File(
-            Path.Join("logs", "log.log"),
-            rollingInterval: RollingInterval.Day,
-            restrictedToMinimumLevel: LogEventLevel.Information
-        )
         .WriteTo.PostgreSQL(
             connString,
             "Logs",

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -1002,7 +1002,13 @@ AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
 // Configure forwarded headers for proper HTTPS detection behind proxies
 app.UseForwardedHeaders(new ForwardedHeadersOptions
 {
-    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedPrefix
+    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedPrefix,
+    // By clearing KnownProxies and KnownNetworks, we are telling the middleware to trust
+    // the X-Forwarded-* headers from any immediate upstream proxy. This is necessary
+    // when the app is containerized and the reverse proxy (Caddy) is on the host,
+    // as the container won't see the request as coming from a loopback address.
+    KnownProxies = { },
+    KnownNetworks = { }
 });
 
 app.UseOpenTelemetryPrometheusScrapingEndpoint();

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -1002,11 +1002,8 @@ AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
 // Configure forwarded headers for proper HTTPS detection behind proxies
 app.UseForwardedHeaders(new ForwardedHeadersOptions
 {
-    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedPrefix,
-    // By clearing KnownProxies and KnownNetworks, we are telling the middleware to trust
-    // the X-Forwarded-* headers from any immediate upstream proxy. This is necessary
-    // when the app is containerized and the reverse proxy (Caddy) is on the host,
-    // as the container won't see the request as coming from a loopback address.
+    RequireHeaderSymmetry = false,
+    ForwardedHeaders = ForwardedHeaders.XForwardedProto,
     KnownProxies = { },
     KnownNetworks = { }
 });


### PR DESCRIPTION
- Continues an attempt at fixing #694, adds more thorough logging to help diagnose any issues. This implementation seemed to work, I didn't have to logout or login once even after restarting all services (including redis). On staging, I executed `docker compose -f docker-compose-staging.yml up -d --force-recreate` and was not required to login a second time.
- Fixes an issue where https redirects were not being passed through. (closes https://github.com/osu-tournament-rating/otr-web/issues/352)
- Adds health checks for redis, database, and data protection.
- Refactors some Program.cs logic out into separate classes for better readability and maintainability
- Ensures all logs (unless overridden manually) are logged to grafana, this includes verbose logs.
- Adds terms of use to 429 response