### PR TITLE
Add endpoint to delete player scores from match

### DIFF
--- a/API/Controllers/MatchesController.cs
+++ b/API/Controllers/MatchesController.cs
@@ -124,4 +124,26 @@ public class MatchesController(IMatchesService matchesService) : Controller
         await matchesService.DeleteAsync(id);
         return NoContent();
     }
+
+    /// <summary>
+    /// Delete all scores belonging to a player for a given match
+    /// </summary>
+    /// <param name="id">Match id</param>
+    /// <param name="playerId">Player id</param>
+    /// <response code="404">A match matching the given id does not exist</response>
+    /// <response code="200">Returns the number of scores deleted</response>
+    [HttpDelete("{id:int}/player/{playerId:int}")]
+    [Authorize(Roles = OtrClaims.Roles.Admin)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<int>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> DeletePlayerScoresAsync(int id, int playerId)
+    {
+        if (!await matchesService.ExistsAsync(id))
+        {
+            return NotFound();
+        }
+
+        int deletedCount = await matchesService.DeletePlayerScoresAsync(id, playerId);
+        return Ok(deletedCount);
+    }
 }

--- a/API/Services/Implementations/MatchesService.cs
+++ b/API/Services/Implementations/MatchesService.cs
@@ -11,6 +11,7 @@ namespace API.Services.Implementations;
 public class MatchesService(
     IMatchesRepository matchesRepository,
     IPlayersRepository playersRepository,
+    IGameScoresRepository gameScoresRepository,
     IMapper mapper
 ) : IMatchesService
 {
@@ -99,6 +100,16 @@ public class MatchesService(
 
     public async Task DeleteAsync(int id) =>
         await matchesRepository.DeleteAsync(id);
+
+    public async Task<int> DeletePlayerScoresAsync(int matchId, int playerId)
+    {
+        if (!await matchesRepository.ExistsAsync(matchId))
+        {
+            return 0;
+        }
+
+        return await gameScoresRepository.DeleteByMatchAndPlayerAsync(matchId, playerId);
+    }
 
     private async Task<ICollection<PlayerCompactDTO>> GetPlayerCompactsAsync(MatchDTO match)
     {

--- a/API/Services/Interfaces/IMatchesService.cs
+++ b/API/Services/Interfaces/IMatchesService.cs
@@ -63,4 +63,12 @@ public interface IMatchesService
     /// </summary>
     /// <param name="id">Match id</param>
     Task DeleteAsync(int id);
+
+    /// <summary>
+    /// Deletes all scores belonging to a player for a given match
+    /// </summary>
+    /// <param name="matchId">Match id</param>
+    /// <param name="playerId">Player id</param>
+    /// <returns>The number of scores deleted</returns>
+    Task<int> DeletePlayerScoresAsync(int matchId, int playerId);
 }

--- a/Database/Repositories/Implementations/GameScoresRepository.cs
+++ b/Database/Repositories/Implementations/GameScoresRepository.cs
@@ -61,4 +61,11 @@ public class GameScoresRepository(OtrContext context) : RepositoryBase<GameScore
             .WherePlayerId(playerId)
             .CountAsync();
     }
+
+    public async Task<int> DeleteByMatchAndPlayerAsync(int matchId, int playerId)
+    {
+        return await _context.GameScores
+            .Where(gs => gs.Game.MatchId == matchId && gs.PlayerId == playerId)
+            .ExecuteDeleteAsync();
+    }
 }

--- a/Database/Repositories/Interfaces/IGameScoresRepository.cs
+++ b/Database/Repositories/Interfaces/IGameScoresRepository.cs
@@ -14,4 +14,12 @@ public interface IGameScoresRepository : IRepository<GameScore>
 
     Task<Dictionary<Mods, int>> GetModFrequenciesAsync(int playerId, Ruleset ruleset, DateTime? dateMin, DateTime? dateMax);
     Task<Dictionary<Mods, int>> GetAverageModScoresAsync(int playerId, Ruleset ruleset, DateTime? dateMin, DateTime? dateMax);
+
+    /// <summary>
+    /// Deletes all scores belonging to a player across all games in a specific match
+    /// </summary>
+    /// <param name="matchId">Match id</param>
+    /// <param name="playerId">Player id</param>
+    /// <returns>The number of scores deleted</returns>
+    Task<int> DeleteByMatchAndPlayerAsync(int matchId, int playerId);
 }


### PR DESCRIPTION
Adds a new admin-only endpoint `DELETE /api/v1/matches/:matchId/player/:playerId`. When executed, deletes all scores a player made during that match. Use case is for verification of 1v1 matches where a ref played in the lobby (the UI display is very ugly when there are "no team" scores present alongside TeamVS scores).

Closes #718