### PR TITLE
Fix unsafe `_playerCache` insertion causing crash

### DIFF
--- a/DataWorkerService/Services/Implementations/OsuApiDataParserService.cs
+++ b/DataWorkerService/Services/Implementations/OsuApiDataParserService.cs
@@ -213,7 +213,7 @@ public class OsuApiDataParserService(
             _beatmapSetCache.TryAdd(beatmapSet.OsuId, beatmapSet);
             if (beatmapSet.Creator is not null)
             {
-                _playerCache.Add(beatmapSet.Creator.OsuId, beatmapSet.Creator);
+                _playerCache.TryAdd(beatmapSet.Creator.OsuId, beatmapSet.Creator);
             }
 
             beatmapSet.Beatmaps.ToList().ForEach(b =>


### PR DESCRIPTION
- Fixes a bug in the DataWorkerService where it would crash if a beatmapset creator was already cached.