### PR TITLE
Hotfix mania search and default ruleset assignment logic

### DIFF
--- a/API/Services/Implementations/SearchService.cs
+++ b/API/Services/Implementations/SearchService.cs
@@ -84,6 +84,10 @@ public class SearchService(
             {
                 PlayerRating? stats = player.Ratings
                     .FirstOrDefault(r => r.Ruleset == (player.User?.Settings.DefaultRuleset ?? player.DefaultRuleset));
+
+                // If a player has no rating for their default ruleset, use the highest rated ruleset available
+                stats ??= player.Ratings.OrderByDescending(r => r.Rating).FirstOrDefault();
+
                 return new PlayerSearchResultDTO
                 {
                     Id = player.Id,

--- a/DataWorkerService/Services/Implementations/PlayersService.cs
+++ b/DataWorkerService/Services/Implementations/PlayersService.cs
@@ -123,8 +123,11 @@ public class PlayersService(
             }
 
             rulesetData.Pp = result.Statistics.Pp;
-            // Safe when IsRanked is true
-            rulesetData.GlobalRank = result.Statistics.GlobalRank!.Value;
+
+            if (result.Statistics.GlobalRank is not null)
+            {
+                rulesetData.GlobalRank = result.Statistics.GlobalRank.Value;
+            }
 
             // Update any ruleset variant data
             foreach (UserStatisticsVariant variant in result.Statistics.Variants.Where(v => v.IsRanked))
@@ -144,7 +147,7 @@ public class PlayersService(
             }
         }
 
-        if (!defaultRulesetIsControlled && player.User is not null)
+        if (!defaultRulesetIsControlled && player.User?.Settings is not null && lowestRank != int.MaxValue)
         {
             player.User.Settings.DefaultRuleset = defaultRuleset;
         }


### PR DESCRIPTION
Fixes a bug where ManiaOther was being assigned as the default ruleset for mania players. Also adds logic to search such that a fallback ruleset is used if none is configured (falls back to the PlayerRating with the highest rating value).