### PR TITLE
Fix dataworker crash part 2

### DIFF
--- a/DataWorkerService/Processors/Matches/MatchStatsProcessor.cs
+++ b/DataWorkerService/Processors/Matches/MatchStatsProcessor.cs
@@ -62,8 +62,9 @@ public class MatchStatsProcessor(
 
         if (verifiedGames.Count == 0)
         {
-            logger.LogDebug(
-                "No verified and processed games found for match, skipping stat generation. [Id: {Id}]",
+            logger.LogError(
+                "No verified and processed games found for match, skipping stat generation. " +
+                "Verification and processing statuses may be out of sync. [Id: {Id}]",
                 entity.Id
             );
             return;

--- a/DataWorkerService/Processors/Matches/MatchStatsProcessor.cs
+++ b/DataWorkerService/Processors/Matches/MatchStatsProcessor.cs
@@ -60,6 +60,15 @@ public class MatchStatsProcessor(
 
         List<Game> verifiedGames = [.. entity.Games.Where(g => g is { VerificationStatus: VerificationStatus.Verified, ProcessingStatus: GameProcessingStatus.Done })];
 
+        if (verifiedGames.Count == 0)
+        {
+            logger.LogDebug(
+                "No verified and processed games found for match, skipping stat generation. [Id: {Id}]",
+                entity.Id
+            );
+            return;
+        }
+
         // Sanity check
         foreach (Game game in verifiedGames)
         {


### PR DESCRIPTION
Log an error instead of crashing if a match has no games when stat processing occurs.