### PR TITLE
Use date-based versioning for production deployments

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "v*"
+      - "[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]*"
 
 jobs:
   build_test:


### PR DESCRIPTION
Part of our agenda to migrate to date-based versioning instead of semantic versioning.

Format: `YYYY.MM.DD.PP` where `P` is "patch" for that day.

e.g. `2025.06.07` or `2025.06.07.2`