### PR TITLE
Serialize enum dictionary keys as integers instead of strings

### DIFF
--- a/API.Tests/GlobalSuppressions.cs
+++ b/API.Tests/GlobalSuppressions.cs
@@ -1,0 +1,7 @@
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+

--- a/API.Tests/Integration/PlatformStatsIntegrationTests.cs
+++ b/API.Tests/Integration/PlatformStatsIntegrationTests.cs
@@ -1,0 +1,151 @@
+using API.DTOs;
+using API.Utilities;
+using Common.Enums;
+using Common.Enums.Verification;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace API.Tests.Integration;
+
+public class PlatformStatsIntegrationTests
+{
+    [Fact]
+    public void Complete_PlatformStats_Serialization_Should_Use_Numeric_Enum_Keys()
+    {
+        // Arrange - Use the same JsonSerializerSettings as the API
+        var settings = new JsonSerializerSettings
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            Converters = { new NewtonsoftEnumDictionaryKeyConverter() }
+        };
+
+        // Create comprehensive platform stats data with all enum dictionary keys
+        var platformStats = new PlatformStatsDTO
+        {
+            RatingStats = new RatingPlatformStatsDTO
+            {
+                RatingsByRuleset = new Dictionary<Ruleset, Dictionary<int, int>>
+                {
+                    [Ruleset.Osu] = new() { [100] = 50, [200] = 30 },
+                    [Ruleset.Taiko] = new() { [150] = 20 },
+                    [Ruleset.Catch] = new() { [175] = 15 },
+                    [Ruleset.Mania4k] = new() { [125] = 25 },
+                    [Ruleset.Mania7k] = new() { [180] = 10 }
+                }
+            },
+            TournamentStats = new TournamentPlatformStatsDTO
+            {
+                TotalCount = 500,
+                CountByVerificationStatus = new Dictionary<VerificationStatus, int>
+                {
+                    [VerificationStatus.None] = 10,
+                    [VerificationStatus.PreRejected] = 20,
+                    [VerificationStatus.PreVerified] = 100,
+                    [VerificationStatus.Rejected] = 50,
+                    [VerificationStatus.Verified] = 320
+                },
+                VerifiedByRuleset = new Dictionary<Ruleset, int>
+                {
+                    [Ruleset.Osu] = 200,
+                    [Ruleset.Taiko] = 50,
+                    [Ruleset.Catch] = 40,
+                    [Ruleset.Mania4k] = 20,
+                    [Ruleset.Mania7k] = 10
+                }
+            },
+            UserStats = new UserPlatformStatsDTO()
+        };
+
+        // Act
+        string json = JsonConvert.SerializeObject(platformStats, settings);
+
+        // Assert - All enum keys should be numeric
+
+        // Ruleset enum values (0, 1, 2, 4, 5)
+        Assert.Contains("\"0\":", json); // Ruleset.Osu = 0
+        Assert.Contains("\"1\":", json); // Ruleset.Taiko = 1  
+        Assert.Contains("\"2\":", json); // Ruleset.Catch = 2
+        Assert.Contains("\"4\":", json); // Ruleset.Mania4k = 4
+        Assert.Contains("\"5\":", json); // Ruleset.Mania7k = 5
+
+        // VerificationStatus enum values (0, 1, 2, 3, 4)
+        Assert.Contains("\"3\":", json); // VerificationStatus.Rejected = 3 (unique value)
+
+        // Should NOT contain string enum representations
+        Assert.DoesNotContain("\"osu\":", json);
+        Assert.DoesNotContain("\"taiko\":", json);
+        Assert.DoesNotContain("\"fruits\":", json);
+        Assert.DoesNotContain("\"mania\":", json);
+        Assert.DoesNotContain("\"none\":", json);
+        Assert.DoesNotContain("\"preRejected\":", json);
+        Assert.DoesNotContain("\"preVerified\":", json);
+        Assert.DoesNotContain("\"rejected\":", json);
+        Assert.DoesNotContain("\"verified\":", json);
+    }
+
+    [Fact]
+    public void Complete_Deserialization_Should_Handle_Numeric_Enum_Keys()
+    {
+        // Arrange
+        var settings = new JsonSerializerSettings
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            Converters = { new NewtonsoftEnumDictionaryKeyConverter() }
+        };
+
+        string json = """
+        {
+            "tournamentStats": {
+                "totalCount": 100,
+                "countByVerificationStatus": {
+                    "0": 5,
+                    "1": 10,
+                    "2": 30,
+                    "3": 15,
+                    "4": 40
+                },
+                "verifiedByYear": {},
+                "verifiedByRuleset": {
+                    "0": 25,
+                    "1": 10,
+                    "2": 5
+                },
+                "verifiedByLobbySize": {}
+            },
+            "ratingStats": {
+                "ratingsByRuleset": {
+                    "0": { "100": 20, "200": 30 },
+                    "2": { "150": 15 }
+                }
+            },
+            "userStats": {
+                "sumByDate": {}
+            }
+        }
+        """;
+
+        // Act
+        var result = JsonConvert.DeserializeObject<PlatformStatsDTO>(json, settings);
+
+        // Assert
+        Assert.NotNull(result);
+
+        // Check RatingStats
+        Assert.NotNull(result.RatingStats);
+        Assert.Equal(2, result.RatingStats.RatingsByRuleset.Count);
+        Assert.True(result.RatingStats.RatingsByRuleset.ContainsKey(Ruleset.Osu));
+        Assert.True(result.RatingStats.RatingsByRuleset.ContainsKey(Ruleset.Catch));
+        Assert.Equal(20, result.RatingStats.RatingsByRuleset[Ruleset.Osu][100]);
+        Assert.Equal(15, result.RatingStats.RatingsByRuleset[Ruleset.Catch][150]);
+
+        // Check TournamentStats
+        Assert.NotNull(result.TournamentStats);
+        Assert.Equal(5, result.TournamentStats.CountByVerificationStatus.Count);
+        Assert.Equal(5, result.TournamentStats.CountByVerificationStatus[VerificationStatus.None]);
+        Assert.Equal(40, result.TournamentStats.CountByVerificationStatus[VerificationStatus.Verified]);
+
+        Assert.Equal(3, result.TournamentStats.VerifiedByRuleset.Count);
+        Assert.Equal(25, result.TournamentStats.VerifiedByRuleset[Ruleset.Osu]);
+        Assert.Equal(5, result.TournamentStats.VerifiedByRuleset[Ruleset.Catch]);
+    }
+}

--- a/API/Controllers/LeaderboardsController.cs
+++ b/API/Controllers/LeaderboardsController.cs
@@ -1,8 +1,6 @@
-using API.Authorization;
 using API.DTOs;
 using API.Services.Interfaces;
 using Asp.Versioning;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace API.Controllers;

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -130,11 +130,6 @@ builder.Services
             new NewtonsoftJsonValidationMetadataProvider(new CamelCaseNamingStrategy()));
         o.Filters.Add(new AuthorizeFilter(AuthorizationPolicies.Whitelist));
     })
-    .AddJsonOptions(o =>
-    {
-        o.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-        o.JsonSerializerOptions.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
-    })
     .AddNewtonsoftJson(o =>
     {
         o.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -1,7 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Reflection;
 using System.Security.Claims;
-
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.RateLimiting;
 using API.Authorization;
@@ -129,6 +129,11 @@ builder.Services
         o.ModelMetadataDetailsProviders.Add(
             new NewtonsoftJsonValidationMetadataProvider(new CamelCaseNamingStrategy()));
         o.Filters.Add(new AuthorizeFilter(AuthorizationPolicies.Whitelist));
+    })
+    .AddJsonOptions(o =>
+    {
+        o.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        o.JsonSerializerOptions.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
     })
     .AddNewtonsoftJson(o =>
     {

--- a/API/Utilities/NewtonsoftEnumDictionaryKeyConverter.cs
+++ b/API/Utilities/NewtonsoftEnumDictionaryKeyConverter.cs
@@ -1,0 +1,114 @@
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace API.Utilities;
+
+/// <summary>
+/// Custom Newtonsoft.Json converter that ensures enum dictionary keys are serialized as numeric values
+/// instead of description strings.
+/// </summary>
+public class NewtonsoftEnumDictionaryKeyConverter : JsonConverter
+{
+    public override bool CanConvert(Type objectType)
+    {
+        // This converter handles dictionaries where the key is an enum
+        if (!objectType.IsGenericType)
+        {
+            return false;
+        }
+
+        Type genericDefinition = objectType.GetGenericTypeDefinition();
+        if (genericDefinition != typeof(Dictionary<,>) &&
+            genericDefinition != typeof(IDictionary<,>) &&
+            !objectType.GetInterfaces().Any(i =>
+                i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>)))
+        {
+            return false;
+        }
+
+        Type keyType = objectType.GetGenericArguments()[0];
+        return keyType.IsEnum;
+    }
+
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+    {
+        if (reader.TokenType != JsonToken.StartObject)
+        {
+            throw new JsonException("Expected StartObject token");
+        }
+
+        Type keyType = objectType.GetGenericArguments()[0];
+        Type valueType = objectType.GetGenericArguments()[1];
+
+        // Create the dictionary instance
+        Type dictionaryType = typeof(Dictionary<,>).MakeGenericType(keyType, valueType);
+        object dictionary = Activator.CreateInstance(dictionaryType)!;
+        MethodInfo addMethod = dictionaryType.GetMethod("Add")!;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonToken.EndObject)
+            {
+                break;
+            }
+
+            if (reader.TokenType != JsonToken.PropertyName)
+            {
+                throw new JsonException("Expected PropertyName token");
+            }
+
+            string? keyString = (reader.Value?.ToString()) ?? throw new JsonException("Property name cannot be null");
+
+            // Try to parse as integer first, then fall back to string parsing
+            object key;
+            if (int.TryParse(keyString, out int intValue) && Enum.IsDefined(keyType, intValue))
+            {
+                key = Enum.ToObject(keyType, intValue);
+            }
+            else if (Enum.TryParse(keyType, keyString, true, out object? enumValue))
+            {
+                key = enumValue!;
+            }
+            else
+            {
+                throw new JsonException($"Unable to convert '{keyString}' to {keyType.Name}");
+            }
+
+            reader.Read();
+            object? value = serializer.Deserialize(reader, valueType);
+            addMethod.Invoke(dictionary, [key, value]);
+        }
+
+        return dictionary;
+    }
+
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        if (value == null)
+        {
+            writer.WriteNull();
+            return;
+        }
+
+        writer.WriteStartObject();
+
+        Type dictionaryType = value.GetType();
+
+        // Get the dictionary entries
+        PropertyInfo keysProperty = dictionaryType.GetProperty("Keys")!;
+        PropertyInfo indexer = dictionaryType.GetProperty("Item")!;
+        System.Collections.IEnumerable keys = (System.Collections.IEnumerable)keysProperty.GetValue(value)!;
+
+        foreach (object? key in keys)
+        {
+            // Write enum key as its numeric value converted to string
+            string numericKey = Convert.ToInt32(key).ToString();
+            writer.WritePropertyName(numericKey);
+
+            object? val = indexer.GetValue(value, [key]);
+            serializer.Serialize(writer, val);
+        }
+
+        writer.WriteEndObject();
+    }
+}


### PR DESCRIPTION
Currently, enums which are the key of a Dictionary are serialized into their string representation. i.e. "fruits" for Ruleset.Catch. This change forces enums to serialize as an integer when they are the key of a dictionary.

We want enums to serialize into integers because that's how the frontend client lib knows how to parse them. The client lib doesn't know that "osu" as a dictionary key is equal to `Ruleset.Osu`.