### PR TITLE
Fix authentication for public endpoints

### DIFF
--- a/API/Controllers/LeaderboardsController.cs
+++ b/API/Controllers/LeaderboardsController.cs
@@ -1,6 +1,7 @@
 using API.DTOs;
 using API.Services.Interfaces;
 using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace API.Controllers;
@@ -15,6 +16,7 @@ public class LeaderboardsController(IPlayerStatsService playerStatsService) : Co
     /// </summary>
     /// <response code="200">Returns the leaderboard</response>
     [HttpGet]
+    [AllowAnonymous]
     [ProducesResponseType<LeaderboardDTO>(StatusCodes.Status200OK)]
     public async Task<ActionResult<LeaderboardDTO>> GetAsync(
        [FromQuery] LeaderboardRequestQueryDTO requestQuery

--- a/API/Controllers/TournamentsController.cs
+++ b/API/Controllers/TournamentsController.cs
@@ -21,6 +21,7 @@ public partial class TournamentsController(ITournamentsService tournamentsServic
     /// <remarks>Results will not include match data</remarks>
     /// <response code="200">Returns all tournaments which fit the request query</response>
     [HttpGet]
+    [AllowAnonymous]
     [ProducesResponseType<IEnumerable<TournamentDTO>>(StatusCodes.Status200OK)]
     public async Task<IActionResult> ListAsync([FromQuery] TournamentRequestQueryDTO requestQuery) =>
         Ok(await tournamentsService.GetAsync(requestQuery));


### PR DESCRIPTION
Added explicit [AllowAnonymous] attribute to endpoints that were recently made public by removing [Authorize] attributes. This fixes authentication scheme selection issues causing 401 errors on /leaderboards and /tournaments endpoints. The authentication middleware now properly handles both authenticated and anonymous users on these endpoints.