### PR TITLE
Anonymize more routes, remove /me redirect

### DIFF
--- a/API/Controllers/AdminNotesController.cs
+++ b/API/Controllers/AdminNotesController.cs
@@ -93,7 +93,7 @@ public class AdminNotesController(IAdminNoteService adminNoteService, OtrContext
     /// <response code="404">An entity matching the given id does not exist</response>
     /// <response code="200">Returns all admin notes for the entity</response>
     [HttpGet("{entityId:int}/notes")]
-    [Authorize(Roles = $"{OtrClaims.Roles.User}, {OtrClaims.Roles.Client}")]
+    [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType<IEnumerable<AdminNoteDTO>>(StatusCodes.Status200OK)]
     public async Task<IActionResult> ListNotesAsync(int entityId)

--- a/API/Controllers/MatchesController.cs
+++ b/API/Controllers/MatchesController.cs
@@ -32,7 +32,7 @@ public class MatchesController(IMatchesService matchesService) : Controller
     /// <response code="404">A match matching the given id does not exist</response>
     /// <response code="200">Returns a match</response>
     [HttpGet("{id:int}")]
-    [Authorize(Roles = $"{OtrClaims.Roles.User}, {OtrClaims.Roles.Client}")]
+    [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType<MatchDTO>(StatusCodes.Status200OK)]
     public async Task<IActionResult> GetAsync(int id)

--- a/API/Controllers/MeController.cs
+++ b/API/Controllers/MeController.cs
@@ -18,14 +18,20 @@ public class MeController(IUsersService usersService) : Controller
     /// <summary>
     /// Get the currently logged in user
     /// </summary>
-    /// <response code="302">Redirects to `GET` `/users/{id}`</response>
     /// <response code="200">Returns the currently logged in user</response>
+    /// <response code="404">User not found</response>
     [HttpGet]
     [Authorize(Roles = OtrClaims.Roles.User)]
-    [ProducesResponseType(StatusCodes.Status302Found)]
     [ProducesResponseType<UserDTO>(StatusCodes.Status200OK)]
-    public IActionResult Get() =>
-        RedirectToAction("Get", "Users", new { id = User.GetSubjectId() });
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetAsync()
+    {
+        UserDTO? user = await usersService.GetAsync(User.GetSubjectId());
+
+        return user is null
+            ? NotFound()
+            : Ok(user);
+    }
 
     /// <summary>
     /// Get player stats for the currently logged in user

--- a/API/Controllers/PlatformStatsController.cs
+++ b/API/Controllers/PlatformStatsController.cs
@@ -1,5 +1,4 @@
-﻿using API.Authorization;
-using API.DTOs;
+﻿using API.DTOs;
 using API.Services.Interfaces;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;

--- a/API/Controllers/PlatformStatsController.cs
+++ b/API/Controllers/PlatformStatsController.cs
@@ -13,14 +13,14 @@ namespace API.Controllers;
 [Route("api/v{version:apiVersion}/stats")]
 public class PlatformStatsController(IPlatformStatsService statsService) : Controller
 {
-    private const int StatsCacheDurationSeconds = 600;
+    private const int StatsCacheDurationSeconds = 10;
 
     /// <summary>
     /// Get various platform-wide stats
     /// </summary>
     /// <response code="200">Returns various platform-wide stats</response>
     [HttpGet]
-    [Authorize(Roles = OtrClaims.Roles.User)] // TODO: allow anonymous with anti-csrf protection
+    [AllowAnonymous]
     [ProducesResponseType<PlatformStatsDTO>(StatusCodes.Status200OK)]
     [OutputCache(Duration = StatsCacheDurationSeconds)]
     public async Task<IActionResult> GetAsync() => Ok(await statsService.GetAsync());

--- a/API/Controllers/PlayersController.cs
+++ b/API/Controllers/PlayersController.cs
@@ -21,7 +21,7 @@ public class PlayersController(IPlayerService playerService, IPlayerStatsService
     /// <response code="404">A player matching the given key does not exist</response>
     /// <response code="200">Returns a player</response>
     [HttpGet]
-    [Authorize(Roles = $"{OtrClaims.Roles.User}, {OtrClaims.Roles.Client}")]
+    [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType<PlayerCompactDTO>(StatusCodes.Status200OK)]
     public async Task<IActionResult> GetAsync(string key)
@@ -50,7 +50,7 @@ public class PlayersController(IPlayerService playerService, IPlayerStatsService
     /// <response code="404">A player matching the given search key does not exist</response>
     /// <response code="200">Returns a player's stats</response>
     [HttpGet("stats")]
-    [Authorize(Roles = $"{OtrClaims.Roles.User}, {OtrClaims.Roles.Client}")]
+    [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType<PlayerDashboardStatsDTO>(StatusCodes.Status200OK)]
     public async Task<IActionResult> GetStatsAsync(

--- a/API/Controllers/TournamentsController.cs
+++ b/API/Controllers/TournamentsController.cs
@@ -120,7 +120,7 @@ public partial class TournamentsController(ITournamentsService tournamentsServic
     /// <response code="404">A tournament matching the given id does not exist</response>
     /// <response code="200">Returns a tournament</response>
     [HttpGet("{id:int}")]
-    [Authorize(Roles = $"{OtrClaims.Roles.User}, {OtrClaims.Roles.Client}")]
+    [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType<TournamentDTO>(StatusCodes.Status200OK)]
     public async Task<IActionResult> GetAsync(int id)
@@ -207,7 +207,7 @@ public partial class TournamentsController(ITournamentsService tournamentsServic
     /// <response code="404">A tournament matching the given id does not exist</response>
     /// <response code="200">Returns a collection of pooled beatmaps</response>
     [HttpGet("{id:int}/beatmaps")]
-    [Authorize(Roles = $"{OtrClaims.Roles.User}, {OtrClaims.Roles.Client}")]
+    [AllowAnonymous]
     [ProducesResponseType<IEnumerable<BeatmapDTO>>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetBeatmapsAsync(int id)


### PR DESCRIPTION
- Enables anonymous requests for `/players/:id`, `/players/:id/stats`, `/tournaments/:id`, `/tournaments/:id/beatmaps`, and `/adminnotes`.
- Removes redirect call in `/me` (cuts number of HTTP requests in half to fetch the same data).