### PR TITLE
fix: clear warning flags prior to processing

### DIFF
--- a/DWS/AutomationChecks/GameAutomationChecks.cs
+++ b/DWS/AutomationChecks/GameAutomationChecks.cs
@@ -13,6 +13,9 @@ public class GameAutomationChecks(ILogger<GameAutomationChecks> logger)
     {
         logger.LogTrace("Processing game {GameId}", game.Id);
 
+        // Clear warning flags prior to processing
+        game.WarningFlags = GameWarningFlags.None;
+
         GameRejectionReason result = GameBeatmapUsageCheck(game, tournament) |
                                      GameEndTimeCheck(game) |
                                      GameModCheck(game) |

--- a/DWS/AutomationChecks/MatchAutomationChecks.cs
+++ b/DWS/AutomationChecks/MatchAutomationChecks.cs
@@ -21,6 +21,9 @@ public class MatchAutomationChecks(ILogger<MatchAutomationChecks> logger)
     {
         logger.LogTrace("Processing match {MatchId}", match.Id);
 
+        // Clear warning flags prior to processing
+        match.WarningFlags = MatchWarningFlags.None;
+
         MatchBeatmapCheck(match);
         MatchNameFormatCheck(match);
         MatchTeamsIntegrityCheck(match);


### PR DESCRIPTION
- Fixes a bug where warning flags would not be cleared prior to automation check processing, resulting in warning flags basically never going away.

Closes #780
