### PR TITLE
fix: remove signout call on rejected query

### DIFF
--- a/API/Program.cs
+++ b/API/Program.cs
@@ -618,7 +618,6 @@ builder.Services
                 {
                     authLogger.Warning("Cookie validation failed - user not authenticated. UserId: {UserId}", userId ?? "Unknown");
                     context.RejectPrincipal();
-                    await context.HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
                     return;
                 }
 
@@ -632,7 +631,6 @@ builder.Services
                 {
                     authLogger.Debug("Cookie authentication rejected - X-Api-Key header not provided. UserId: {UserId}", userId);
                     context.RejectPrincipal();
-                    await context.HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
                     return;
                 }
 
@@ -640,7 +638,6 @@ builder.Services
                 {
                     authLogger.Debug("Cookie authentication rejected - Invalid X-Api-Key header. UserId: {UserId}", userId);
                     context.RejectPrincipal();
-                    await context.HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
                     return;
                 }
 


### PR DESCRIPTION
- Fixes an issue where unauthenticated requests would cause the server to clear the otr-session cookie. This is super annoying in local development because JWT calls are not authorized in this way. No impact in prod.
